### PR TITLE
AADS, on the sdk, when I query projects, I see VIDEO input types are renamed to VIDEO_OLD and FRAME input types are renamed to VIDEO, and I see a deprecation warning for FRAME input type

### DIFF
--- a/kili/cli.py
+++ b/kili/cli.py
@@ -2,6 +2,7 @@
 
 from typing import Optional, Tuple
 import json
+import warnings
 import click
 from tabulate import tabulate
 from typeguard import typechecked
@@ -123,6 +124,8 @@ def create_project(api_key: str,
     To build a Kili project interface, please visit: \n
     https://docs.kili-technology.com/docs/customizing-the-interface-through-json-settings
     """
+    if input_type == 'FRAME':
+        warnings.warn("FRAME input type is deprecated. Please use VIDEO instead")
     with open(interface, encoding='utf-8') as interface_file:
         json_interface = json.load(interface_file)
     kili = Kili(api_key=api_key, api_endpoint=endpoint)
@@ -204,13 +207,13 @@ def import_assets(api_key: str,
         # pylint: disable=raise-missing-from
         raise NotFound(f'project ID: {project_id}')
 
-    if input_type != 'FRAME' and (fps is not None or frames is True):
+    if input_type not in ('FRAME', 'VIDEO') and (fps is not None or frames is True):
         illegal_option = 'fps and frames are'
         if frames is False:
             illegal_option = 'fps is'
         if fps is None:
             illegal_option = 'frames is'
-        raise ValueError(f'{illegal_option} only valid for a FRAME project')
+        raise ValueError(f'{illegal_option} only valid for a VIDEO project')
 
     files_to_upload = get_file_paths_to_upload(files, input_type, exclude)
     if len(files_to_upload) == 0:

--- a/kili/cli.py
+++ b/kili/cli.py
@@ -97,7 +97,8 @@ def list_project(api_key: str,
 @click.option('--title', type=str, required=True,
               help='Project Title.')
 @click.option('--input-type', type=click.Choice(INPUT_TYPE), required=True,
-              help='Project input data type. Please check your license to see which ones you have access to.')
+              help='Project input data type. '
+              'Please check your license to see which ones you have access to.')
 @click.option('--description', type=str, default='',
               help='Project description.')
 @tablefmt_option

--- a/kili/cli.py
+++ b/kili/cli.py
@@ -97,7 +97,7 @@ def list_project(api_key: str,
 @click.option('--title', type=str, required=True,
               help='Project Title.')
 @click.option('--input-type', type=click.Choice(INPUT_TYPE), required=True,
-              help='Project input data type.')
+              help='Project input data type. Please check your license to see which ones you have access to.')
 @click.option('--description', type=str, default='',
               help='Project description.')
 @tablefmt_option

--- a/kili/constants.py
+++ b/kili/constants.py
@@ -6,7 +6,7 @@ This script lists package constants.
 NO_ACCESS_RIGHT = '[noAccessRights] It seems you do not have access to this object.' \
     ' Please double check your credentials.'
 
-INPUT_TYPE = ['AUDIO', 'FRAME', 'IMAGE', 'PDF', 'TEXT', 'TIME_SERIES', 'VIDEO', 'VIDEO_OLD']
+INPUT_TYPE = ['FRAME', 'IMAGE', 'PDF', 'TEXT', 'VIDEO', 'VIDEO_OLD']
 
 mime_extensions = {
   'Audio': 'audio/x-flac,audio/mpeg,video/mp4',

--- a/kili/constants.py
+++ b/kili/constants.py
@@ -6,7 +6,7 @@ This script lists package constants.
 NO_ACCESS_RIGHT = '[noAccessRights] It seems you do not have access to this object.' \
     ' Please double check your credentials.'
 
-INPUT_TYPE = ['AUDIO', 'FRAME', 'IMAGE', 'PDF', 'TEXT', 'TIME_SERIES']
+INPUT_TYPE = ['AUDIO', 'FRAME', 'IMAGE', 'PDF', 'TEXT', 'TIME_SERIES', 'VIDEO', 'VIDEO_OLD']
 
 mime_extensions = {
   'Audio': 'audio/x-flac,audio/mpeg,video/mp4',

--- a/kili/constants.py
+++ b/kili/constants.py
@@ -9,9 +9,9 @@ NO_ACCESS_RIGHT = '[noAccessRights] It seems you do not have access to this obje
 INPUT_TYPE = ['AUDIO', 'FRAME', 'IMAGE', 'PDF', 'TEXT', 'TIME_SERIES']
 
 mime_extensions = {
-    'Audio': 'audio/x-flac,audio/mpeg,video/mp4',
-    'Csv': 'text/csv',
-    'Frame': 'video/mp4,video/x-matroska,video/3gpp,video/x-msvideo,'
+  'Audio': 'audio/x-flac,audio/mpeg,video/mp4',
+  'Csv': 'text/csv',
+  'Video': 'video/mp4,video/x-matroska,video/3gpp,video/x-msvideo,' \
     'video/x-m4v,video/quicktime,video/webm',
     'Image': 'image/jpeg,image/png,image/bmp,image/gif,image/webp,image/x-icon,'
     'image/tiff,image/vnd.microsoft.icon,image/svg+xml,image/avif,image/apng',
@@ -21,15 +21,16 @@ mime_extensions = {
 }
 
 mime_extensions_for_IV2 = {
-    'AUDIO': mime_extensions['Audio'],
-    'FRAME': mime_extensions['Frame'],
-    'IMAGE': mime_extensions['Image'],
-    'NA': '',
-    'PDF': mime_extensions['Pdf'],
-    'TEXT': mime_extensions['Text'],
-    'TIME_SERIES': mime_extensions['Csv'],
-    'URL': '',
-    'VIDEO': mime_extensions['Csv'],
+  'AUDIO': mime_extensions['Audio'],
+  'FRAME': mime_extensions['Video'],
+  'IMAGE': mime_extensions['Image'],
+  'NA': '',
+  'PDF': mime_extensions['Pdf'],
+  'TEXT': mime_extensions['Text'],
+  'TIME_SERIES': mime_extensions['Csv'],
+  'URL': '',
+  'VIDEO': mime_extensions['Video'],
+  'VIDEO_OLD': mime_extensions['Csv'],
 }
 
 MUTATION_BATCH_SIZE = 100

--- a/kili/constants.py
+++ b/kili/constants.py
@@ -6,7 +6,7 @@ This script lists package constants.
 NO_ACCESS_RIGHT = '[noAccessRights] It seems you do not have access to this object.' \
     ' Please double check your credentials.'
 
-INPUT_TYPE = ['FRAME', 'IMAGE', 'PDF', 'TEXT', 'VIDEO', 'VIDEO_OLD']
+INPUT_TYPE = ['AUDIO', 'FRAME', 'IMAGE', 'PDF', 'TEXT', 'TIME_SERIES', 'VIDEO', 'VIDEO_OLD']
 
 mime_extensions = {
   'Audio': 'audio/x-flac,audio/mpeg,video/mp4',

--- a/kili/mutations/asset/__init__.py
+++ b/kili/mutations/asset/__init__.py
@@ -53,16 +53,16 @@ class MutationsAsset:
                 - For a `TEXT` project, the content can be either raw text, or URLs to TEXT assets.
                 - For an `IMAGE` / `PDF` project, the content can be either URLs or paths to existing
                     images/pdf on your computer.
-                - For a `VIDEO`  project, the content must be either URLs or paths to existing
-                    videos on your computer.
+                - For a `VIDEO_OLD`  project, the content must be hosted on a web server,
+                    and you point Kili to your data by giving the URLs.
             external_id_array: List of external ids given to identify the assets.
                 If None, random identifiers are created.
             is_honeypot_array:  Whether to use the asset for honeypot
             status_array: By default, all imported assets are set to `TODO`. Other options:
                 `ONGOING`, `LABELED`, `REVIEWED`.
-            json_content_array: Useful for `FRAME` or `TEXT` projects only.
+            json_content_array: Useful for `VIDEO` or `TEXT` projects only.
 
-                - For `FRAME` projects, each element is a sequence of frames, i.e. a
+                - For `VIDEO` projects, each element is a sequence of frames, i.e. a
                     list of URLs to images or a list of paths to images.
                 - For `TEXT` projects, each element is a json_content dict,
                     formatted according to documentation [on how to import

--- a/kili/mutations/asset/helpers.py
+++ b/kili/mutations/asset/helpers.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 from typing import List, Optional, Tuple, Union
 import glob
 import mimetypes
+import warnings
 
 from ...constants import mime_extensions_for_IV2
 from ...helpers import (convert_to_list_of_none, encode_base64, format_metadata,
@@ -30,7 +31,7 @@ def encode_object_if_not_url(content, input_type):
 
 def process_frame_json_content(json_content):
     """
-    Function to process individual json_content of FRAME projects
+    Function to process individual json_content of VIDEO projects
     """
     if is_url(json_content):
         return json_content
@@ -67,7 +68,9 @@ def process_json_content(input_type: str,
     """
     if json_content_array is None:
         return [''] * len(content_array)
-    if input_type == 'FRAME':
+    if input_type == 'VIDEO' or input_type == 'FRAME':
+        if input_type == 'FRAME': 
+            warnings.warn("FRAME input type is deprecated. Please use VIDEO instead")   
         return list(map(process_frame_json_content, json_content_array))
     return [element if is_url(element) else dumps(element) for element in json_content_array]
 
@@ -79,15 +82,14 @@ def process_content(input_type: str,
     Process the array of contents
     """
     if input_type in ['IMAGE', 'PDF']:
-        return [content if is_url(content)
-                else (content
-                      if (json_content_array is not None and json_content_array[i] is not None)
-                      else (encode_base64(content) if check_file_mime_type(content, input_type)
-                            else None))
-                for i, content in enumerate(content_array)]
-    if input_type == 'FRAME' and json_content_array is None:
-        content_array = [encode_object_if_not_url(
-            content, input_type) for content in content_array]
+        return [content if is_url(content) else (content
+            if (json_content_array is not None and json_content_array[i] is not None)
+            else (encode_base64(content) if check_file_mime_type(content, input_type) else None))
+            for i, content in enumerate(content_array)]
+    if input_type == 'VIDEO' or input_type == 'FRAME' and json_content_array is None:
+        if input_type == 'FRAME':
+            warnings.warn("FRAME input type is deprecated. Please use VIDEO instead")
+        content_array = [encode_object_if_not_url(content, input_type) for content in content_array]
     if input_type == 'TIME_SERIES':
         content_array = list(map(process_time_series, content_array))
     return content_array
@@ -145,6 +147,11 @@ def check_file_mime_type(content: str, input_type: str, verbose: bool = True) ->
     """
     Returns true if the mime type of the file corresponds to the allowed mime types of the project
     """
+    if input_type not in ['IMAGE', 'FRAME', 'PDF', 'TIME_SERIES', 'VIDEO']:
+        return True
+
+    if input_type == 'FRAME':
+        warnings.warn("FRAME input type is deprecated. Please use VIDEO instead")
 
     mime_type = get_data_type(content.lower())
 
@@ -180,7 +187,9 @@ def process_metadata(input_type: str, content_array: Union[List[str], None],
     """
     json_metadata_array = [
         {}] * len(content_array) if json_metadata_array is None else json_metadata_array
-    if input_type == 'FRAME':
+    if input_type == 'FRAME' or input_type == 'VIDEO':
+        if input_type == 'FRAME':
+            warnings.warn("FRAME input type is deprecated. Please use VIDEO instead")
         should_use_native_video = json_content_array is None
         json_metadata_array = [add_video_parameters(
             json_metadata, should_use_native_video) for json_metadata in json_metadata_array]
@@ -198,7 +207,7 @@ def get_request_to_execute(
     """
     if json_content_array is not None:
         return GQL_APPEND_MANY_TO_DATASET, None
-    if input_type != 'FRAME':
+    if input_type != 'FRAME' and input_type != 'VIDEO':
         if input_type == 'IMAGE' and mime_type == 'image/tiff':
             return GQL_APPEND_MANY_FRAMES_TO_DATASET, 'GEO_SATELLITE'
         return GQL_APPEND_MANY_TO_DATASET, None

--- a/kili/mutations/asset/helpers.py
+++ b/kili/mutations/asset/helpers.py
@@ -8,7 +8,6 @@ from uuid import uuid4
 from typing import List, Optional, Tuple, Union
 import glob
 import mimetypes
-import warnings
 
 from ...constants import mime_extensions_for_IV2
 from ...helpers import (convert_to_list_of_none, encode_base64, format_metadata,
@@ -68,9 +67,7 @@ def process_json_content(input_type: str,
     """
     if json_content_array is None:
         return [''] * len(content_array)
-    if input_type == 'VIDEO' or input_type == 'FRAME':
-        if input_type == 'FRAME': 
-            warnings.warn("FRAME input type is deprecated. Please use VIDEO instead")   
+    if input_type in ('VIDEO', 'FRAME'):
         return list(map(process_frame_json_content, json_content_array))
     return [element if is_url(element) else dumps(element) for element in json_content_array]
 
@@ -86,9 +83,7 @@ def process_content(input_type: str,
             if (json_content_array is not None and json_content_array[i] is not None)
             else (encode_base64(content) if check_file_mime_type(content, input_type) else None))
             for i, content in enumerate(content_array)]
-    if input_type == 'VIDEO' or input_type == 'FRAME' and json_content_array is None:
-        if input_type == 'FRAME':
-            warnings.warn("FRAME input type is deprecated. Please use VIDEO instead")
+    if input_type in ('VIDEO', 'FRAME') and json_content_array is None:
         content_array = [encode_object_if_not_url(content, input_type) for content in content_array]
     if input_type == 'TIME_SERIES':
         content_array = list(map(process_time_series, content_array))
@@ -147,11 +142,8 @@ def check_file_mime_type(content: str, input_type: str, verbose: bool = True) ->
     """
     Returns true if the mime type of the file corresponds to the allowed mime types of the project
     """
-    if input_type not in ['IMAGE', 'FRAME', 'PDF', 'TIME_SERIES', 'VIDEO']:
-        return True
 
-    if input_type == 'FRAME':
-        warnings.warn("FRAME input type is deprecated. Please use VIDEO instead")
+
 
     mime_type = get_data_type(content.lower())
 
@@ -187,9 +179,7 @@ def process_metadata(input_type: str, content_array: Union[List[str], None],
     """
     json_metadata_array = [
         {}] * len(content_array) if json_metadata_array is None else json_metadata_array
-    if input_type == 'FRAME' or input_type == 'VIDEO':
-        if input_type == 'FRAME':
-            warnings.warn("FRAME input type is deprecated. Please use VIDEO instead")
+    if input_type in ('FRAME', 'VIDEO'):
         should_use_native_video = json_content_array is None
         json_metadata_array = [add_video_parameters(
             json_metadata, should_use_native_video) for json_metadata in json_metadata_array]
@@ -207,7 +197,7 @@ def get_request_to_execute(
     """
     if json_content_array is not None:
         return GQL_APPEND_MANY_TO_DATASET, None
-    if input_type != 'FRAME' and input_type != 'VIDEO':
+    if input_type not in ('FRAME', 'VIDEO'):
         if input_type == 'IMAGE' and mime_type == 'image/tiff':
             return GQL_APPEND_MANY_FRAMES_TO_DATASET, 'GEO_SATELLITE'
         return GQL_APPEND_MANY_TO_DATASET, None
@@ -349,7 +339,7 @@ def generate_json_metadata_array(as_frames, fps, nb_files, input_type):
     """
 
     json_metadata_array = None
-    if input_type == 'FRAME':
+    if input_type in ('FRAME', 'VIDEO'):
         json_metadata_array = [
             {'processingParameters': {
                 'shouldKeepNativeFrameRate': fps is None,

--- a/kili/mutations/project/__init__.py
+++ b/kili/mutations/project/__init__.py
@@ -1,5 +1,6 @@
 """Project mutations."""
 
+import warnings
 from json import dumps
 from typing import Optional
 
@@ -95,7 +96,8 @@ class MutationsProject:
             honeypot_mark : Should be between 0 and 1
             instructions : Instructions of the project.
             interface_category: Always use 'IV2'.
-            input_type: Currently, one of `AUDIO`, `FRAME`, `IMAGE`, `PDF`, `TEXT`, `VIDEO_OLD`, `VIDEO`, `NA`.
+            input_type: Currently, one of `AUDIO`, `FRAME`, `IMAGE`, `PDF`, `TEXT`,
+                `VIDEO_OLD`, `VIDEO`.
             json_interface: The json parameters of the project, see Edit your interface.
             min_consensus_size: Should be between 1 and 10
                 Number of people that will annotate the same asset, for consensus computation.
@@ -187,6 +189,8 @@ class MutationsProject:
             For more detailed examples on how to create projects,
                 see [the recipe](https://github.com/kili-technology/kili-python-sdk/blob/master/recipes/create_project.ipynb).
         """
+        if input_type == 'FRAME':
+            warnings.warn("FRAME input type is deprecated. Please use VIDEO instead")
         variables = {
             'data': {'description': description,
                      'inputType': input_type,

--- a/kili/mutations/project/__init__.py
+++ b/kili/mutations/project/__init__.py
@@ -95,7 +95,7 @@ class MutationsProject:
             honeypot_mark : Should be between 0 and 1
             instructions : Instructions of the project.
             interface_category: Always use 'IV2'.
-            input_type: Currently, one of `AUDIO`, `FRAME`, `IMAGE`, `PDF`, `TEXT`, `VIDEO`, `NA`.
+            input_type: Currently, one of `AUDIO`, `FRAME`, `IMAGE`, `PDF`, `TEXT`, `VIDEO_OLD`, `VIDEO`, `NA`.
             json_interface: The json parameters of the project, see Edit your interface.
             min_consensus_size: Should be between 1 and 10
                 Number of people that will annotate the same asset, for consensus computation.

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -12,14 +12,14 @@ def mocked__projects(project_id=None, **_):
         return [{'id': 'text_project', 'inputType': 'TEXT'}]
     if project_id == 'image_project':
         return [{'id': 'image_project', 'inputType': 'IMAGE'}]
-    if project_id == 'frame_project':
-        return [{'id': 'frame_project', 'inputType': 'FRAME'}]
+    if project_id == 'video':
+        return [{'id': 'frame_project', 'inputType': 'VIDEO'}]
     if project_id == None:
         return [{'id': 'text_project', 'title': 'text_project', 'description': ' a project with text',
                  'numberOfAssets': 10, 'numberOfRemainingAssets': 10},
                 {'id': 'image_project', 'title': 'image_project', 'description': ' a project with image',
                  'numberOfAssets': 0, 'numberOfRemainingAssets': 0},
-                {'id': 'frame_project', 'title': 'frame_project', 'description': ' a project with frame',
+                {'id': 'frame_project', 'title': 'frame_project', 'description': ' a project with video',
                  'numberOfAssets': 10, 'numberOfRemainingAssets': 0}]
 
 
@@ -111,7 +111,7 @@ def test_import(mocker):
         }
     },
         {
-        'case_name': 'AAU, when I import videos to a frame project, as native by changing the fps, I see a success',
+        'case_name': 'AAU, when I import videos to a video project, as native by changing the fps, I see a success',
         'files': ['test_tree/'],
         'options': {
             'project-id': 'frame_project',
@@ -131,7 +131,7 @@ def test_import(mocker):
         }
     },
         {
-        'case_name': 'AAU, when I import videos to a frame project, as frames with the native frame rate, I see a success',
+        'case_name': 'AAU, when I import videos to a video project, as frames with the native frame rate, I see a success',
         'files': ['test_tree/'],
         'options': {
             'project-id': 'frame_project',

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -12,14 +12,14 @@ def mocked__projects(project_id=None, **_):
         return [{'id': 'text_project', 'inputType': 'TEXT'}]
     if project_id == 'image_project':
         return [{'id': 'image_project', 'inputType': 'IMAGE'}]
-    if project_id == 'video':
-        return [{'id': 'frame_project', 'inputType': 'VIDEO'}]
+    if project_id == 'video_project':
+        return [{'id': 'video_project', 'inputType': 'VIDEO'}]
     if project_id == None:
         return [{'id': 'text_project', 'title': 'text_project', 'description': ' a project with text',
                  'numberOfAssets': 10, 'numberOfRemainingAssets': 10},
                 {'id': 'image_project', 'title': 'image_project', 'description': ' a project with image',
                  'numberOfAssets': 0, 'numberOfRemainingAssets': 0},
-                {'id': 'frame_project', 'title': 'frame_project', 'description': ' a project with video',
+                {'id': 'video_project', 'title': 'video_project', 'description': ' a project with video',
                  'numberOfAssets': 10, 'numberOfRemainingAssets': 0}]
 
 
@@ -114,11 +114,11 @@ def test_import(mocker):
         'case_name': 'AAU, when I import videos to a video project, as native by changing the fps, I see a success',
         'files': ['test_tree/'],
         'options': {
-            'project-id': 'frame_project',
+            'project-id': 'video_project',
             'fps': '10',
         },
         'expected_mutation_payload': {
-            'project_id': 'frame_project',
+            'project_id': 'video_project',
             'content_array': ['test_tree/video1.mp4', 'test_tree/video2.mp4'],
             'external_id_array': ['video1.mp4', 'video2.mp4'],
             'json_metadata_array': [
@@ -134,11 +134,11 @@ def test_import(mocker):
         'case_name': 'AAU, when I import videos to a video project, as frames with the native frame rate, I see a success',
         'files': ['test_tree/'],
         'options': {
-            'project-id': 'frame_project',
+            'project-id': 'video_project',
         },
         'flags': ['frames'],
         'expected_mutation_payload': {
-            'project_id': 'frame_project',
+            'project_id': 'video_project',
             'content_array': ['test_tree/video1.mp4', 'test_tree/video2.mp4'],
             'external_id_array': ['video1.mp4', 'video2.mp4'],
             'json_metadata_array': [


### PR DESCRIPTION
… warning for frame type

- [ ] I opened a merge request on `kili` on a branch with the same name than the branch of the current pull request and forced security tests.
- [ ] I opened a pull request on the Node playground if the changes are breaking.
