### PR TITLE
fix(ML-558): rm project from the fields in proj. version query

### DIFF
--- a/kili/queries/project_version/__init__.py
+++ b/kili/queries/project_version/__init__.py
@@ -38,7 +38,6 @@ class QueriesProjectVersion:
                 'id',
                 'content',
                 'name',
-                'project',
                 'projectId'],
             disable_tqdm: bool = False,
             as_generator: bool = False) -> Union[List[dict], Generator[dict, None, None]]:


### PR DESCRIPTION
- [X] I opened a merge request on `kili` on a branch with the same name than the branch of the current pull request and forced security tests.
- [ ] I opened a pull request on the Node playground if the changes are breaking.

This was happening because the `project` field is no longer allowed.