### PR TITLE
feat: clean the exception strings

### DIFF
--- a/kili/exceptions.py
+++ b/kili/exceptions.py
@@ -1,5 +1,5 @@
 """Exceptions of the package."""
-
+import ast
 
 class NotFound(Exception):
     """Used when a given object is not found in Kili"""
@@ -43,11 +43,11 @@ class GraphQLError(Exception):
     """
     Used when the GraphQL call returns an error
     """
-
-    def __init__(self, mutation, error, batch_number=None):
+    def __init__(self, error: Exception, batch_number=None):
         if batch_number is None:
             super().__init__(
-                f'Mutation "{mutation}" failed with error: "{error}"')
+                f'error: "{ast.literal_eval(str(error))[0]["message"]}"')
         else:
             super().__init__(
-                f'Mutation "{mutation}" failed from index {100*batch_number} with error: "{error}"')
+                f'error at index {100*batch_number}: '
+                f'{ast.literal_eval(str(error))[0]["message"]}"')

--- a/kili/helpers.py
+++ b/kili/helpers.py
@@ -69,7 +69,7 @@ def format_result(name, result, _object=None):
         result: query result to parse
     """
     if 'errors' in result:
-        raise GraphQLError(name, result['errors'])
+        raise GraphQLError(result['errors'])
     formatted_json = format_json(result['data'][name])
     if _object is None:
         return formatted_json

--- a/kili/utils/pagination.py
+++ b/kili/utils/pagination.py
@@ -144,7 +144,7 @@ def _mutate_from_paginated_call(self,
         mutation_time = time.time() - mutation_start
         results.append(result)
         if 'errors' in result:
-            raise GraphQLError('data', result['errors'], batch_number)
+            raise GraphQLError(result['errors'], batch_number)
         if mutation_time < THROTTLING_DELAY:
             time.sleep(THROTTLING_DELAY - mutation_time)
     return results


### PR DESCRIPTION
first step to clean up errors in the SDK: get rid of the stack trace coming from the backend, and only keep the message.