### PR TITLE
AAU, on the CLI, I see a function to list all members of a project

### DIFF
--- a/kili/cli/project/__init__.py
+++ b/kili/cli/project/__init__.py
@@ -9,6 +9,7 @@ from kili.cli.project.describe import describe_project
 from kili.cli.project.import_ import import_assets
 from kili.cli.project.label import import_labels
 from kili.cli.project.list_ import list_projects
+from kili.cli.project.member import member
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)
@@ -21,3 +22,4 @@ project.add_command(describe_project, name="describe")
 project.add_command(import_assets, name="import")
 project.add_command(import_labels, name="label")
 project.add_command(list_projects, name="list")
+project.add_command(member, name="member")

--- a/kili/cli/project/list_.py
+++ b/kili/cli/project/list_.py
@@ -26,7 +26,7 @@ def list_projects(api_key: Optional[str],
     \b
     !!! Examples
         ```
-        kili project list --max 10 --format pretty
+        kili project list --max 10 ----stdout-format pretty
         ```
 
     """

--- a/kili/cli/project/list_.py
+++ b/kili/cli/project/list_.py
@@ -26,7 +26,7 @@ def list_projects(api_key: Optional[str],
     \b
     !!! Examples
         ```
-        kili project list --max 10 ----stdout-format pretty
+        kili project list --max 10 --stdout-format pretty
         ```
 
     """

--- a/kili/cli/project/member/__init__.py
+++ b/kili/cli/project/member/__init__.py
@@ -1,4 +1,4 @@
-
+"""Project member command of Kili CLI"""
 
 import click
 
@@ -8,7 +8,7 @@ from kili.cli.project.member.list_ import list_members
 
 @click.group(context_settings=CONTEXT_SETTINGS)
 def member():
-    """Commands to interact with a Kili project member"""
+    """Commands to interact with Kili project members"""
 
 
 member.add_command(list_members, name="list")

--- a/kili/cli/project/member/__init__.py
+++ b/kili/cli/project/member/__init__.py
@@ -1,0 +1,14 @@
+
+
+import click
+
+from kili.cli.common_args import CONTEXT_SETTINGS
+from kili.cli.project.member.list_ import list_members
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+def member():
+    """Commands to interact with a Kili project member"""
+
+
+member.add_command(list_members, name="list")

--- a/kili/cli/project/member/list_.py
+++ b/kili/cli/project/member/list_.py
@@ -1,4 +1,4 @@
-"""CLI's project list subcommand"""
+"""CLI's project member list subcommand"""
 
 from typing import Dict, List, Optional, cast
 import click
@@ -12,16 +12,6 @@ from kili.cli.common_args import Options
 ROLE_ORDER = {
     v: i for i, v in enumerate(["ADMIN", "TEAM_MANAGER", "REVIEWER", "LABELER"])
 }
-
-
-def role_order(col: pd.Series) -> pd.Series:
-    """ordering pandas series by custom role order"""
-    out = col
-    # apply custom sorting only to column one:
-    if col.name == "ROLE":
-        out = col.map(ROLE_ORDER)
-    # default text sorting is about to be applied
-    return out
 
 
 @click.command()
@@ -40,7 +30,7 @@ def list_members(api_key: Optional[str],
     \b
     !!! Examples
         ```
-        kili project member list --project-id <project_id> ----stdout-format pretty
+        kili project member list --project-id <project_id> --stdout-format pretty
         ```
 
     """
@@ -49,28 +39,28 @@ def list_members(api_key: Optional[str],
         List[Dict], kili.project_users(
             project_id=project_id,
             fields=[
-                'id', 'role', 'activated',
+                'role', 'activated',
                 'user.email', 'user.id',
                 'user.firstname', 'user.lastname',
                 'user.organization.name',
             ],
             disable_tqdm=True))
     users = pd.DataFrame(users)
-    users.rename(columns={'id': 'ROLE_ID', 'role': 'ROLE',
-                 'activated': 'ACTIVATED'}, inplace=True)
     users = pd.concat([users.drop(['user'], axis=1),
                       users['user'].apply(pd.Series)], axis=1)
     users = pd.concat([users.drop(['organization'], axis=1),
                       users['organization'].apply(pd.Series)], axis=1)
-    users['ORGANIZATION'] = users['name']
-    users['NAME'] = users['lastname'].str.title() + ' ' + \
-        users['firstname'].str.title()
-    users.rename(columns={'email': 'EMAIL', 'id': 'ID'}, inplace=True)
-    users = users[['ROLE', 'NAME', 'EMAIL', 'ID',
-                   'ORGANIZATION', 'ROLE_ID', 'ACTIVATED']]
+    users = users.loc[users['activated']]
+    users.rename(columns={'role': 'ROLE', 'email': 'EMAIL',
+                 'id': 'ID', 'name': 'ORGANIZATION'}, inplace=True)
+    users['NAME'] = users['firstname'].str.title() + ' ' + \
+        users['lastname'].str.title()
     users = users.sort_values(
         by=["ROLE", "NAME"],
         ascending=True,
-        key=role_order,
+        key=lambda column: column.map(
+            ROLE_ORDER) if column.name == "ROLE" else column,
     )
+    users = users[['ROLE', 'NAME', 'EMAIL', 'ID',
+                   'ORGANIZATION']]
     print(tabulate(users, headers='keys', tablefmt=tablefmt, showindex=False))

--- a/kili/cli/project/member/list_.py
+++ b/kili/cli/project/member/list_.py
@@ -1,0 +1,75 @@
+"""CLI's project list subcommand"""
+
+from typing import Dict, List, Optional, cast
+import click
+
+import numpy as np
+import pandas as pd
+from tabulate import tabulate
+
+from kili.client import Kili
+from kili.cli.common_args import Options
+
+ROLE_ORDER = {
+    v: i for i, v in enumerate(["ADMIN", "TEAM_MANAGER", "LABELER", "REVIEWER"])
+}
+
+
+def role_order(col: pd.Series) -> pd.Series:
+    out = col
+    # apply custom sorting only to column one:
+    if col.name == "ROLE":
+        out = col.map(ROLE_ORDER)
+    # default text sorting is about to be applied
+    return out
+
+
+@click.command()
+@Options.api_key
+@Options.endpoint
+@click.option('--project-id', type=str, required=True,
+              help='Id of the project to list members of')
+@Options.tablefmt
+def list_members(api_key: Optional[str],
+                 endpoint: Optional[str],
+                 project_id: str,
+                 tablefmt: str):
+    """
+    List the members of the project
+
+    \b
+    !!! Examples
+        ```
+        kili project member list --project-id <project_id> --format pretty
+        ```
+
+    """
+    kili = Kili(api_key=api_key, api_endpoint=endpoint)
+    users = kili.project_users(
+        project_id=project_id,
+        fields=[
+            'id', 'role', 'activated',
+            'user.email', 'user.id',
+            'user.firstname', 'user.lastname',
+            'user.organization.name', 'user.organizationRole'
+        ]
+    )
+    users = pd.DataFrame(users)
+    users.rename(columns={'id': 'ROLE_ID', 'role': 'ROLE',
+                 'activated': 'ACTIVATED'}, inplace=True)
+    users = pd.concat([users.drop(['user'], axis=1),
+                      users['user'].apply(pd.Series)], axis=1)
+    users = pd.concat([users.drop(['organization'], axis=1),
+                      users['organization'].apply(pd.Series)], axis=1)
+    users['ORGANIZATION'] = users['name']
+    users['NAME'] = users['lastname'].str.title() + ' ' + \
+        users['firstname'].str.title()
+    users.rename(columns={'email': 'EMAIL', 'id': 'ID'}, inplace=True)
+    users = users[['ROLE', 'NAME', 'EMAIL', 'ID',
+                   'ORGANIZATION', 'ROLE_ID', 'ACTIVATED']]
+    users = users.sort_values(
+        by=["ROLE", "NAME"],
+        ascending=True,
+        key=role_order,
+    )
+    print(tabulate(users, headers='keys', tablefmt=tablefmt, showindex=False))

--- a/kili/cli/project/member/list_.py
+++ b/kili/cli/project/member/list_.py
@@ -3,7 +3,6 @@
 from typing import Dict, List, Optional, cast
 import click
 
-import numpy as np
 import pandas as pd
 from tabulate import tabulate
 
@@ -11,11 +10,12 @@ from kili.client import Kili
 from kili.cli.common_args import Options
 
 ROLE_ORDER = {
-    v: i for i, v in enumerate(["ADMIN", "TEAM_MANAGER", "LABELER", "REVIEWER"])
+    v: i for i, v in enumerate(["ADMIN", "TEAM_MANAGER", "REVIEWER", "LABELER"])
 }
 
 
 def role_order(col: pd.Series) -> pd.Series:
+    """ordering pandas series by custom role order"""
     out = col
     # apply custom sorting only to column one:
     if col.name == "ROLE":
@@ -40,20 +40,21 @@ def list_members(api_key: Optional[str],
     \b
     !!! Examples
         ```
-        kili project member list --project-id <project_id> --format pretty
+        kili project member list --project-id <project_id> ----stdout-format pretty
         ```
 
     """
     kili = Kili(api_key=api_key, api_endpoint=endpoint)
-    users = kili.project_users(
-        project_id=project_id,
-        fields=[
-            'id', 'role', 'activated',
-            'user.email', 'user.id',
-            'user.firstname', 'user.lastname',
-            'user.organization.name', 'user.organizationRole'
-        ]
-    )
+    users = cast(
+        List[Dict], kili.project_users(
+            project_id=project_id,
+            fields=[
+                'id', 'role', 'activated',
+                'user.email', 'user.id',
+                'user.firstname', 'user.lastname',
+                'user.organization.name',
+            ],
+            disable_tqdm=True))
     users = pd.DataFrame(users)
     users.rename(columns={'id': 'ROLE_ID', 'role': 'ROLE',
                  'activated': 'ACTIVATED'}, inplace=True)

--- a/test/cli/test_project.py
+++ b/test/cli/test_project.py
@@ -23,7 +23,7 @@ def mocked__project_users(**_):
                       'id': 'user_id',
                       'lastname': 'doe',
                       'organization': {'name': 'test'}}},
-            {'activated': False,
+            {'activated': True,
             'id': 'role_id_2',
              'role': 'LABELER',
              'user': {'email': 'jane.doe@test.com',
@@ -291,5 +291,5 @@ class TestCLIProject():
         runner = CliRunner()
         result = runner.invoke(list_members, ['--project-id', "project_id"])
         debug_subprocess_pytest(result)
-        assert ((result.output.count("Doe Jane") == 1) and
+        assert ((result.output.count("Jane Doe") == 1) and
                 (result.output.count("@test.com") == 2))

--- a/test/cli/test_project.py
+++ b/test/cli/test_project.py
@@ -196,8 +196,7 @@ class TestCLIProject():
         assert (result.output.count('40.8%') == 1) and (
             result.output.count('N/A') == 2) and (
             result.output.count('49') == 1) and (
-            result.output.count('project title') == 1
-        )
+            result.output.count('project title') == 1)
 
     def test_import_labels(self, mocker):
         TEST_CASES = [{

--- a/test/cli/test_project.py
+++ b/test/cli/test_project.py
@@ -9,7 +9,28 @@ from kili.cli.project.describe import describe_project
 from kili.cli.project.import_ import import_assets
 from kili.cli.project.label import import_labels
 from kili.cli.project.list_ import list_projects
+from kili.cli.project.member.list_ import list_members
+
 from ..utils import debug_subprocess_pytest
+
+
+def mocked__project_users(**_):
+    return [{'activated': True,
+            'id': 'role_id_1',
+             'role': 'ADMIN',
+             'user': {'email': 'john.doe@test.com',
+                      'firstname': 'john',
+                      'id': 'user_id',
+                      'lastname': 'doe',
+                      'organization': {'name': 'test'}}},
+            {'activated': False,
+            'id': 'role_id_2',
+             'role': 'LABELER',
+             'user': {'email': 'jane.doe@test.com',
+                      'firstname': 'jane',
+                      'id': 'user_id_2',
+                      'lastname': 'doe',
+                      'organization': {'name': 'test'}}}, ]
 
 
 def mocked__projects(project_id=None, **_):
@@ -50,6 +71,8 @@ kili_client.create_predictions = create_predictions_mock = MagicMock()
 kili_client.count_projects = count_projects_mock = MagicMock(return_value=1)
 kili_client.append_many_to_dataset = append_many_to_dataset_mock = MagicMock()
 kili_client.create_project = create_project_mock = MagicMock()
+kili_client.project_users = project_users_mock = MagicMock(
+    side_effect=mocked__project_users)
 
 kili = MagicMock()
 kili.Kili = MagicMock(return_value=kili_client)
@@ -263,3 +286,10 @@ class TestCLIProject():
             else:
                 create_predictions_mock.assert_called_with(
                     **test_case['expected_mutation_payload'])
+
+    def test_list_members(self, mocker):
+        runner = CliRunner()
+        result = runner.invoke(list_members, ['--project-id', "project_id"])
+        debug_subprocess_pytest(result)
+        assert ((result.output.count("Doe Jane") == 1) and
+                (result.output.count("@test.com") == 2))


### PR DESCRIPTION
few remarks: 
- I put the Organization name because I think it is interesting but I did not put organization role (ADMIN or USER), wdyt?
- I kept the role_id (or project_user_id) as we put it in the specs, but actually, I am for removing it: even in the labeling authors, the user_id is used and not the project_user_id (the only use I can find is for the delete_user mutation). wdyt?
