### PR TITLE
AADS, on the sdk, when I query projects, I see VIDEO input types are renamed to VIDEO_OLD and FRAME input types are renamed to VIDEO, and I see a deprecation warning for FRAME input type

### DIFF
--- a/kili/cli/project/import_.py
+++ b/kili/cli/project/import_.py
@@ -69,13 +69,13 @@ def import_assets(api_key: Optional[str],
         # pylint: disable=raise-missing-from
         raise NotFound(f'project ID: {project_id}')
 
-    if input_type != 'FRAME' and (fps is not None or as_frames is True):
+    if input_type not in ('FRAME','VIDEO') and (fps is not None or as_frames is True):
         illegal_option = 'fps and frames are'
         if not as_frames:
             illegal_option = 'fps is'
         if fps is None:
             illegal_option = 'frames is'
-        raise ValueError(f'{illegal_option} only valid for a FRAME project')
+        raise ValueError(f'{illegal_option} only valid for a VIDEO project')
 
     files_to_upload = get_file_paths_to_upload(
         files, input_type, verbose)

--- a/kili/constants.py
+++ b/kili/constants.py
@@ -6,12 +6,12 @@ This script lists package constants.
 NO_ACCESS_RIGHT = '[noAccessRights] It seems you do not have access to this object.' \
     ' Please double check your credentials.'
 
-INPUT_TYPE = ['AUDIO', 'FRAME', 'IMAGE', 'PDF', 'TEXT', 'TIME_SERIES', 'VIDEO']
+INPUT_TYPE = ['AUDIO', 'FRAME', 'IMAGE', 'PDF', 'TEXT', 'TIME_SERIES', 'VIDEO', 'VIDEO_LEGACY']
 
 mime_extensions = {
   'Audio': 'audio/x-flac,audio/mpeg,video/mp4',
   'Csv': 'text/csv',
-  'Frame': 'video/mp4,video/x-matroska,video/3gpp,video/x-msvideo,' \
+  'Video': 'video/mp4,video/x-matroska,video/3gpp,video/x-msvideo,' \
     'video/x-m4v,video/quicktime,video/webm',
   'Image': 'image/jpeg,image/png,image/bmp,image/gif,image/webp,image/x-icon,'
     'image/tiff,image/vnd.microsoft.icon,image/svg+xml,image/avif,image/apng',
@@ -22,14 +22,15 @@ mime_extensions = {
 
 mime_extensions_for_IV2 = {
   'AUDIO': mime_extensions['Audio'],
-  'FRAME': mime_extensions['Frame'],
+  'FRAME': mime_extensions['Video'],
   'IMAGE': mime_extensions['Image'],
   'NA': '',
   'PDF': mime_extensions['Pdf'],
   'TEXT': mime_extensions['Text'],
   'TIME_SERIES': mime_extensions['Csv'],
   'URL': '',
-  'VIDEO': mime_extensions['Csv'],
+  'VIDEO': mime_extensions['Video'],
+  'VIDEO_LEGACY': mime_extensions['Csv'],
 }
 
 MUTATION_BATCH_SIZE = 100

--- a/kili/mutations/asset/helpers.py
+++ b/kili/mutations/asset/helpers.py
@@ -208,7 +208,7 @@ def get_request_to_execute(
         len(json_metadata_array) > 0 and
         not json_metadata_array[0].get(
             'processingParameters', {}).get('shouldUseNativeVideo', True)):
-        return GQL_APPEND_MANY_FRAMES_TO_DATASET, 'VIDEO_LEGACY'
+        return GQL_APPEND_MANY_FRAMES_TO_DATASET, 'VIDEO'
     return GQL_APPEND_MANY_TO_DATASET, None
 
 

--- a/kili/mutations/asset/helpers.py
+++ b/kili/mutations/asset/helpers.py
@@ -30,7 +30,7 @@ def encode_object_if_not_url(content, input_type):
 
 def process_frame_json_content(json_content):
     """
-    Function to process individual json_content of FRAME projects
+    Function to process individual json_content of VIDEO projects
     """
     if is_url(json_content):
         return json_content
@@ -67,7 +67,7 @@ def process_json_content(input_type: str,
     """
     if json_content_array is None:
         return [''] * len(content_array)
-    if input_type == 'FRAME':
+    if input_type in ('FRAME', 'VIDEO'):
         return list(map(process_frame_json_content, json_content_array))
     return [element if is_url(element) else dumps(element) for element in json_content_array]
 
@@ -85,7 +85,7 @@ def process_content(input_type: str,
                       else (encode_base64(content) if check_file_mime_type(content, input_type)
                             else None))
                 for i, content in enumerate(content_array)]
-    if input_type == 'FRAME' and json_content_array is None:
+    if input_type in ('FRAME', 'VIDEO') and json_content_array is None:
         content_array = [encode_object_if_not_url(
             content, input_type) for content in content_array]
     if input_type == 'TIME_SERIES':
@@ -180,7 +180,7 @@ def process_metadata(input_type: str, content_array: Union[List[str], None],
     """
     json_metadata_array = [
         {}] * len(content_array) if json_metadata_array is None else json_metadata_array
-    if input_type == 'FRAME':
+    if input_type in ('FRAME', 'VIDEO'):
         should_use_native_video = json_content_array is None
         json_metadata_array = [add_video_parameters(
             json_metadata, should_use_native_video) for json_metadata in json_metadata_array]
@@ -198,7 +198,7 @@ def get_request_to_execute(
     """
     if json_content_array is not None:
         return GQL_APPEND_MANY_TO_DATASET, None
-    if input_type != 'FRAME':
+    if input_type not in ('FRAME', 'VIDEO'):
         if input_type == 'IMAGE' and mime_type == 'image/tiff':
             return GQL_APPEND_MANY_FRAMES_TO_DATASET, 'GEO_SATELLITE'
         return GQL_APPEND_MANY_TO_DATASET, None
@@ -208,7 +208,7 @@ def get_request_to_execute(
         len(json_metadata_array) > 0 and
         not json_metadata_array[0].get(
             'processingParameters', {}).get('shouldUseNativeVideo', True)):
-        return GQL_APPEND_MANY_FRAMES_TO_DATASET, 'VIDEO'
+        return GQL_APPEND_MANY_FRAMES_TO_DATASET, 'VIDEO_LEGACY'
     return GQL_APPEND_MANY_TO_DATASET, None
 
 
@@ -336,7 +336,7 @@ def generate_json_metadata_array(as_frames, fps, nb_files, input_type):
     """
 
     json_metadata_array = None
-    if input_type == 'FRAME':
+    if input_type in ('FRAME', 'VIDEO'):
         json_metadata_array = [
             {'processingParameters': {
                 'shouldKeepNativeFrameRate': fps is None,

--- a/kili/mutations/project/__init__.py
+++ b/kili/mutations/project/__init__.py
@@ -98,7 +98,7 @@ class MutationsProject:
             instructions : Instructions of the project.
             interface_category: Always use 'IV2'.
             input_type: Currently, one of `AUDIO`, `FRAME`, `IMAGE`, `PDF`, `TEXT`,
-                `VIDEO`.
+                `VIDEO`, `VIDEO_LEGACY`.
             json_interface: The json parameters of the project, see Edit your interface.
             min_consensus_size: Should be between 1 and 10
                 Number of people that will annotate the same asset, for consensus computation.
@@ -214,6 +214,8 @@ class MutationsProject:
             For more detailed examples on how to create projects,
                 see [the recipe](https://github.com/kili-technology/kili-python-sdk/blob/master/recipes/create_project.ipynb).
         """
+        if input_type == 'FRAME':
+            warnings.warn("FRAME input type is deprecated. Please use VIDEO instead")
         variables = {
             'data': {'description': description,
                      'inputType': input_type,

--- a/test/cli/test_project.py
+++ b/test/cli/test_project.py
@@ -18,7 +18,7 @@ def mocked__projects(project_id=None, **_):
     if project_id == 'image_project':
         return [{'id': 'image_project', 'inputType': 'IMAGE'}]
     if project_id == 'frame_project':
-        return [{'id': 'frame_project', 'inputType': 'FRAME'}]
+        return [{'id': 'frame_project', 'inputType': 'VIDEO'}]
     if project_id == None:
         return [{'id': 'text_project', 'title': 'text_project', 'description': ' a project with text',
                  'numberOfAssets': 10, 'numberOfRemainingAssets': 10},

--- a/test/mutations/test_asset.py
+++ b/test/mutations/test_asset.py
@@ -80,7 +80,7 @@ class TestMimeType():
         content_array = [path]
         json_content_array = None
         processed_content = process_content(
-            'FRAME', content_array, json_content_array)
+            'VIDEO', content_array, json_content_array)
         assert(processed_content == [None])
 
     def test_cannot_upload_text_to_pdf_project(self):


### PR DESCRIPTION
- [ ] I opened a merge request on `kili` on a branch with the same name than the branch of the current pull request and forced security tests.
- [ ] I opened a pull request on the Node playground if the changes are breaking.
