### PR TITLE
Yolo export in CLI and SDK

### DIFF
--- a/kili/authentication.py
+++ b/kili/authentication.py
@@ -24,7 +24,7 @@ def get_version_without_patch(version):
     return ".".join(version.split(".")[:-1])
 
 
-class KiliAuth:
+class KiliAuth:  # pylint: disable=too-many-instance-attributes
     """
     from kili.client import Kili
     kili = Kili(api_key=api_key)
@@ -36,6 +36,8 @@ class KiliAuth:
     ):
         self.session = requests.Session()
         self.client_name = client_name
+        self.api_key = api_key
+        self.api_endpoint = api_endpoint
 
         self.verify = verify
 

--- a/kili/cli/helpers.py
+++ b/kili/cli/helpers.py
@@ -11,7 +11,7 @@ from ..client import Kili
 # pylint: disable=consider-using-f-string
 
 
-def get_kili_client(api_key: str, api_endpoint: str):
+def get_kili_client(api_key: Optional[str], api_endpoint: Optional[str]):
     """Instantiate a kili client for the CLI functions"""
     return Kili(api_key=api_key, api_endpoint=api_endpoint, client_name=GraphQLClientName.CLI)
 

--- a/kili/cli/project/__init__.py
+++ b/kili/cli/project/__init__.py
@@ -5,6 +5,7 @@ import click
 from kili.cli.common_args import CONTEXT_SETTINGS
 from kili.cli.project.create import create_project
 from kili.cli.project.describe import describe_project
+from kili.cli.project.export import export_labels
 from kili.cli.project.import_ import import_assets
 from kili.cli.project.label import import_labels
 from kili.cli.project.list_ import list_projects
@@ -22,3 +23,4 @@ project.add_command(import_assets, name="import")
 project.add_command(import_labels, name="label")
 project.add_command(list_projects, name="list")
 project.add_command(member, name="member")
+project.add_command(export_labels, name="export")

--- a/kili/cli/project/export.py
+++ b/kili/cli/project/export.py
@@ -1,0 +1,96 @@
+"""CLI's project export subcommand"""
+
+from typing import Optional
+
+import click
+from typeguard import typechecked
+from typing_extensions import get_args
+
+from kili import services
+from kili.cli.common_args import Options
+from kili.cli.helpers import get_kili_client
+from kili.services.export.exceptions import NoCompatibleJobError
+from kili.services.export.typing import LabelFormat, SplitOption
+
+
+@click.command(name="export")
+@click.option(
+    "--output-format",
+    type=click.Choice(get_args(LabelFormat)),
+    help="Format into which the label data will be converted",
+    required=True,
+)
+@click.option(
+    "--layout",
+    type=click.Choice(get_args(SplitOption)),
+    default="merged",
+    help="Layout of the label files",
+)
+@click.option(
+    "--output-file", type=str, help="File into which the labels are saved.", required=True
+)
+@Options.api_key
+@Options.endpoint
+@Options.project_id
+@Options.verbose
+@typechecked
+# pylint: disable=too-many-arguments
+def export_labels(
+    output_format: LabelFormat,
+    output_file: str,
+    layout: SplitOption,
+    api_key: Optional[str],
+    endpoint: Optional[str],
+    project_id: str,
+    verbose: bool,
+):
+    """
+    Export the Kili labels of a project to a given format.
+
+    \b
+    The supported formats are:
+    - Yolo V4 for object detection (bounding box) tasks.
+    - Yolo V5 for object detection (bounding box) tasks.
+    - Kili (coming soon) for all tasks.
+    - COCO (coming soon) for object detection tasks.
+    - Pascal VOC (coming soon) for object detection tasks.
+    \b
+    \b
+    !!! Examples
+        ```
+        kili project export \\
+            --project-id <project_id> \\
+            --output-format yolo_v5 \\
+            --output-file /tmp/export.zip
+        ```
+        ```
+        kili project export \\
+            --project-id <project_id> \\
+            --output-format yolo_v4 \\
+            --output-file /tmp/export_split.zip \\
+            --layout split
+        ```
+    \b
+    \b
+    !!! warning "Unsupported exports"
+        Currently, this command does not support the export of videos that have not
+        been cut into separated frames.
+
+        For such exports, please use the Kili UI.
+    """
+    kili = get_kili_client(api_key=api_key, api_endpoint=endpoint)
+
+    try:
+        services.export_labels(
+            kili,
+            asset_ids=None,
+            project_id=project_id,
+            export_type="latest",
+            label_format=output_format,
+            split_option=layout,
+            output_file=output_file,
+            disable_tqdm=not verbose,
+            log_level="INFO" if verbose else "WARNING",
+        )
+    except NoCompatibleJobError as excp:
+        print(str(excp))

--- a/kili/project/__init__.py
+++ b/kili/project/__init__.py
@@ -1,4 +1,17 @@
 """Project module."""
+from typing import List, Optional, cast
+
+from typeguard import typechecked
+
+from kili.services import export_labels
+from kili.services.export.typing import (
+    AssetId,
+    InputType,
+    LabelFormat,
+    LogLevel,
+    ProjectId,
+    SplitOption,
+)
 
 
 class Project:  # pylint: disable=too-few-public-methods
@@ -9,8 +22,52 @@ class Project:  # pylint: disable=too-few-public-methods
     It also allows queries from this project such as its assets, labels etc.
     """
 
-    def __init__(self, client, project_id, input_type, title):
+    def __init__(  # pylint: disable=too-many-arguments
+        self, project_id: ProjectId, input_type: InputType, title: str, client
+    ):
         self.project_id = project_id
-        self.client = client
         self.title = title
         self.input_type = input_type
+        self.client = client
+
+    @typechecked
+    def export(  # pylint: disable=too-many-arguments
+        self,
+        output_filename: str,
+        output_format: LabelFormat,
+        asset_ids: Optional[List[AssetId]] = None,
+        layout: SplitOption = "split",
+        disable_tqdm: bool = False,
+        log_level: LogLevel = "INFO",
+    ) -> None:
+        """Export the project assets with the requested format into the requested output path.
+
+        Usage:
+        ```
+        from kili.client import Kili
+        kili = Kili()
+        project = kili.get_project("your_project_id")
+        project.export("export.zip", output_format="yolo_v4")
+        ```
+
+        Args:
+            output_filename: Relative or full path of the archive that will contain
+            the exported data.
+            output_format: Format of the exported labels.
+            asset_ids: Optional list of the assets from which to export the labels.
+            layout: Layout of the exported files: "split" means there is one folder
+            per job, "merged" that there is one folder with every labels.
+            disable_tqdm: Disable the progress bar if True.
+            log_level: Level of debugging.
+        """
+        export_labels(
+            self.client,
+            asset_ids=cast(Optional[List[str]], asset_ids),
+            project_id=self.project_id,
+            export_type="latest",
+            label_format=output_format,
+            split_option=layout,
+            output_file=output_filename,
+            disable_tqdm=disable_tqdm,
+            log_level=log_level,
+        )

--- a/kili/services/__init__.py
+++ b/kili/services/__init__.py
@@ -1,0 +1,57 @@
+"""
+Python SDK service layer
+"""
+from typing import List, Optional
+
+from typing_extensions import get_args
+
+from kili.services.export.format.base import (
+    ContentRepositoryParams,
+    ExportParams,
+    LoggerParams,
+)
+from kili.services.export.format.yolo import YoloExporterSelector
+from kili.services.export.typing import ExportType, LabelFormat, LogLevel, SplitOption
+
+
+def export_labels(  # pylint: disable=too-many-arguments
+    kili,
+    asset_ids: Optional[List[str]],
+    project_id: str,
+    export_type: ExportType,
+    label_format: LabelFormat,
+    split_option: SplitOption,
+    output_file: str,
+    disable_tqdm: bool,
+    log_level: LogLevel,
+) -> None:
+    """
+    Export the selected assets into the required format, and save it into a file archive.
+    """
+    export_params = ExportParams(
+        assets_ids=asset_ids,
+        project_id=project_id,
+        export_type=export_type,
+        label_format=label_format,
+        split_option=split_option,
+        output_file=output_file,
+    )
+
+    logger_params = LoggerParams(
+        disable_tqdm=disable_tqdm,
+        level=log_level,
+    )
+
+    content_repository_params = ContentRepositoryParams(
+        router_endpoint=kili.auth.api_endpoint,
+        router_headers={
+            "Authorization": f"X-API-Key: {kili.auth.api_key}",
+        },
+    )
+
+    if label_format in get_args(LabelFormat):
+        YoloExporterSelector.export_project(
+            kili, export_params, logger_params, content_repository_params
+        )
+    else:
+        raise ValueError(f'Label format "{label_format}" is not implemented or does not exist.')

--- a/kili/services/export/exceptions.py
+++ b/kili/services/export/exceptions.py
@@ -1,0 +1,15 @@
+"""
+Export-related exceptions
+"""
+
+
+class DownloadError(Exception):
+    """
+    Exception thrown when the contents cannot be downloaded.
+    """
+
+
+class NoCompatibleJobError(Exception):
+    """
+    Exception thrown when there is no job compatible with the format.
+    """

--- a/kili/services/export/format/base.py
+++ b/kili/services/export/format/base.py
@@ -1,0 +1,127 @@
+"""
+Base class for all formatters and other utility classes.
+"""
+
+import os
+import shutil
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import Dict, List, NamedTuple, Optional
+
+from kili.orm import JobMLTask, JobTool
+
+from ..typing import ExportType, LabelFormat, LogLevel, SplitOption
+
+
+class ExportParams(NamedTuple):
+    """
+    Contains all parameters that change the result of the export
+    """
+
+    assets_ids: Optional[List[str]]
+    export_type: ExportType
+    project_id: str
+    label_format: LabelFormat
+    split_option: SplitOption
+    output_file: str
+
+
+class LoggerParams(NamedTuple):
+    """
+    Contains all parameters related to logging.
+    """
+
+    disable_tqdm: bool
+    level: LogLevel
+
+
+class ContentRepositoryParams(NamedTuple):
+    """
+    Contains all the parameters related to the content repository.
+    """
+
+    router_endpoint: str
+    router_headers: Dict[str, str]
+
+
+class BaseExporterSelector(ABC):
+    # pylint: disable=too-few-public-methods
+
+    """
+    Abstract class defining a standard signature for all formatters
+    """
+
+    @staticmethod
+    @abstractmethod
+    def export_project(
+        kili,
+        export_params: ExportParams,
+        logger_params: LoggerParams,
+        content_repository_params: ContentRepositoryParams,
+    ) -> str:
+        """
+        Export a project to a json.
+        Return the name of the exported archive file in the bucket.
+        """
+
+
+class BaseExporter(ABC):
+    """
+    Abstract class defining the interface for all exporters.
+    """
+
+    def __init__(
+        self, project_id, export_type, label_format, disable_tqdm, kili, logger, content_repository
+    ):
+        self.project_id = project_id
+        self.export_type = export_type
+        self.label_format = label_format
+        self.disable_tqdm = disable_tqdm
+        self.kili = kili
+        self.logger = logger
+        self.content_repository = content_repository
+
+    @abstractmethod
+    def process_and_save(self, assets: List[Dict], output_filename: str) -> None:
+        """
+        Converts the asset and save them into an archive.
+        """
+
+    def make_archive(self, root_folder: str, output_filename: str) -> str:
+        """
+        Make the export archive
+        """
+        path_folder = os.path.join(root_folder, self.project_id)
+        path_archive = shutil.make_archive(path_folder, "zip", path_folder)
+        shutil.copy(path_archive, output_filename)
+        return output_filename
+
+    def get_project_and_init(self):
+        """
+        Get and validate the project
+        """
+        json_interface = self.kili.projects(
+            project_id=self.project_id, fields=["jsonInterface"], disable_tqdm=True
+        )[0]["jsonInterface"]
+
+        ml_task = JobMLTask.ObjectDetection
+        tool = JobTool.Rectangle
+
+        return json_interface, ml_task, tool
+
+    def create_readme_kili_file(self, root_folder: str) -> None:
+        """
+        Create a README.kili.txt file to give information about exported labels
+        """
+        readme_file_name = os.path.join(root_folder, self.project_id, "README.kili.txt")
+        project_info = self.kili.projects(
+            project_id=self.project_id, fields=["title", "id", "description"], disable_tqdm=True
+        )[0]
+        with open(readme_file_name, "wb") as fout:
+            fout.write("Exported Labels from KILI\n=========================\n\n".encode())
+            fout.write(f"- Project name: {project_info['title']}\n".encode())
+            fout.write(f"- Project identifier: {self.project_id}\n".encode())
+            fout.write(f"- Project description: {project_info['description']}\n".encode())
+            fout.write(f'- Export date: {datetime.now().strftime("%Y%m%d-%H%M%S")}\n'.encode())
+            fout.write(f"- Exported format: {self.label_format}\n".encode())
+            fout.write(f"- Exported labels: {self.export_type}\n".encode())

--- a/kili/services/export/format/yolo/__init__.py
+++ b/kili/services/export/format/yolo/__init__.py
@@ -1,0 +1,85 @@
+"""
+Functions to export a project to YOLOv4 or v5 format
+"""
+
+import logging
+
+from kili.services.export.typing import LogLevel
+
+from ...repository import SDKContentRepository
+from ...tools import fetch_assets
+from ..base import (
+    BaseExporterSelector,
+    ContentRepositoryParams,
+    ExportParams,
+    LoggerParams,
+)
+from .merge import YoloMergeExporter
+from .split import YoloSplitExporter
+
+
+class YoloExporterSelector(BaseExporterSelector):
+    # pylint: disable=too-few-public-methods
+
+    """
+    Formatter to export to YOLOv4 or YOLOv5
+    """
+
+    @staticmethod
+    def export_project(
+        kili,
+        export_params: ExportParams,
+        logger_params: LoggerParams,
+        content_repository_params: ContentRepositoryParams,
+    ) -> None:
+        """
+        Export a project to YOLO v4 or v5 format
+        """
+        logger = YoloExporterSelector.get_logger(logger_params.level)
+
+        logger.info("Fetching assets ...")
+        assets = fetch_assets(
+            kili,
+            project_id=export_params.project_id,
+            asset_ids=export_params.assets_ids,
+            export_type=export_params.export_type,
+            label_type_in=["DEFAULT", "REVIEW"],
+            disable_tqdm=logger_params.disable_tqdm,
+        )
+        content_repository = SDKContentRepository(
+            content_repository_params.router_endpoint,
+            content_repository_params.router_headers,
+            verify_ssl=True,
+        )
+        if export_params.split_option == "split":
+
+            return YoloSplitExporter(
+                export_params.project_id,
+                export_params.export_type,
+                export_params.label_format,
+                logger_params.disable_tqdm,
+                kili,
+                logger,
+                content_repository,
+            ).process_and_save(assets, export_params.output_file)
+
+        return YoloMergeExporter(
+            export_params.project_id,
+            export_params.export_type,
+            export_params.label_format,
+            logger_params.disable_tqdm,
+            kili,
+            logger,
+            content_repository,
+        ).process_and_save(assets, export_params.output_file)
+
+    @staticmethod
+    def get_logger(level: LogLevel):
+        logger = logging.getLogger("kili.services.export")
+        logger.setLevel(level)
+        if logger.hasHandlers():
+            logger.handlers.clear()
+        handler = logging.StreamHandler()
+        handler.setLevel(logging.DEBUG)
+        logger.addHandler(handler)
+        return logger

--- a/kili/services/export/format/yolo/common.py
+++ b/kili/services/export/format/yolo/common.py
@@ -1,0 +1,268 @@
+import csv
+import json
+import logging
+import os
+from typing import Dict, List, Set
+
+from tqdm.autonotebook import tqdm
+
+from ...repository import AbstractContentRepository, DownloadError
+from ...typing import JobCategory, LabelFormat, YoloAnnotation
+from ..base import BaseExporter
+
+
+class LabelFrames:
+    """
+    Holds asset frames data.
+    """
+
+    @staticmethod
+    def from_asset(asset, job_ids) -> "LabelFrames":
+        """
+        Instantiate the label frames from the asset. It handles the case when there are several
+        frames by label or a single one.
+        """
+        frames = {}
+        number_of_frames = 0
+        is_frame_group = False
+        if "jsonResponse" in asset["latestLabel"]:
+            number_of_frames = len(asset["latestLabel"]["jsonResponse"])
+            for idx in range(number_of_frames):
+                if str(idx) in asset["latestLabel"]["jsonResponse"]:
+                    is_frame_group = True
+                    frame_asset = asset["latestLabel"]["jsonResponse"][str(idx)]
+                    for job_id in job_ids:
+                        if (
+                            job_id in frame_asset
+                            and "annotations" in frame_asset[job_id]
+                            and frame_asset[job_id]["annotations"]
+                        ):
+                            frames[idx] = {"latestLabel": {"jsonResponse": frame_asset}}
+                            break
+
+        if not frames:
+            frames[-1] = asset
+        return LabelFrames(frames, number_of_frames, is_frame_group, asset["externalId"])
+
+    def __init__(
+        self, frames: Dict[int, Dict], number_frames: int, is_frame_group: bool, external_id: str
+    ) -> None:
+        self.frames: Dict[int, Dict] = frames
+        self.number_frames: int = number_frames
+        self.is_frame_group: bool = is_frame_group
+        self.external_id: str = external_id
+
+    def get_leading_zeros(self) -> int:
+        """
+        Get leading zeros for file name building
+        """
+        return len(str(self.number_frames))
+
+    def get_label_filename(self, idx: int) -> str:
+        """
+        Get label filemame for index
+        """
+        return f"{self.external_id}_{str(idx + 1).zfill(self.get_leading_zeros())}"
+
+
+class YoloExporter(BaseExporter):
+    def write_labels_into_single_folder(
+        self,
+        assets: List[Dict],
+        categories_id: Dict[str, JobCategory],
+        labels_folder: str,
+        images_folder: str,
+        base_folder: str,
+    ):
+        _write_class_file(base_folder, categories_id, self.label_format)
+
+        remote_content = []
+        video_metadata = {}
+
+        for asset in tqdm(assets, disable=self.disable_tqdm):
+            asset_remote_content, video_filenames = _process_asset(
+                asset, images_folder, labels_folder, categories_id, self.content_repository
+            )
+            if video_filenames:
+                video_metadata[asset["externalId"]] = video_filenames
+            remote_content.extend(asset_remote_content)
+
+        if video_metadata:
+            _write_video_metadata_file(video_metadata, base_folder)
+
+        if len(remote_content) > 0:
+            _write_remote_content_file(remote_content, images_folder)
+
+
+def _convert_from_kili_to_yolo_format(
+    job_id: str, label: Dict, category_ids: Dict[str, JobCategory]
+) -> List[YoloAnnotation]:
+    # pylint: disable=too-many-locals
+    """
+    Extract formatted annotations from labels and save the zip in the buckets.
+    """
+    if label is None or "jsonResponse" not in label:
+        return []
+    json_response = label["jsonResponse"]
+    if not (job_id in json_response and "annotations" in json_response[job_id]):
+        return []
+    annotations = json_response[job_id]["annotations"]
+    converted_annotations = []
+    for annotation in annotations:
+        category_idx: JobCategory = category_ids[
+            get_category_full_name(job_id, annotation["categories"][0]["name"])
+        ]
+        if "boundingPoly" not in annotation:
+            continue
+        bounding_poly = annotation["boundingPoly"]
+        if len(bounding_poly) < 1 or "normalizedVertices" not in bounding_poly[0]:
+            continue
+        normalized_vertices = bounding_poly[0]["normalizedVertices"]
+        x_s = [vertice["x"] for vertice in normalized_vertices]
+        y_s = [vertice["y"] for vertice in normalized_vertices]
+        x_min, y_min = min(x_s), min(y_s)
+        x_max, y_max = max(x_s), max(y_s)
+        _x_, _y_ = (x_max + x_min) / 2, (y_max + y_min) / 2
+        _w_, _h_ = x_max - x_min, y_max - y_min
+
+        converted_annotations.append((category_idx.id, _x_, _y_, _w_, _h_))
+    return converted_annotations
+
+
+def get_category_full_name(job_id: str, category_name: str):
+    """
+    Return a full name to identify uniquely a category
+    """
+    return f"{job_id}__{category_name}"
+
+
+def _process_asset(
+    asset: Dict,
+    images_folder: str,
+    labels_folder: str,
+    category_ids: Dict[str, JobCategory],
+    content_repository: AbstractContentRepository,
+):
+    # pylint: disable=too-many-locals, too-many-branches
+    """
+    Process an asset for all job_ids of category_ids.
+    """
+    asset_remote_content = []
+    job_ids = set(map(lambda job_category: job_category.job_id, category_ids.values()))
+
+    label_frames = LabelFrames.from_asset(asset, job_ids)
+
+    content_frames = content_repository.get_content_frames_paths(asset)
+
+    video_filenames = []
+
+    for idx, frame in label_frames.frames.items():
+        if label_frames.is_frame_group:
+            filename = label_frames.get_label_filename(idx)
+            video_filenames.append(filename)
+        else:
+            filename = asset["externalId"]
+
+        frame_labels = _get_frame_labels(frame, job_ids, category_ids)
+
+        if not frame_labels:
+            continue
+
+        _write_labels_to_file(labels_folder, filename, frame_labels)
+
+        content_frame = content_frames[idx] if content_frames else asset["content"]
+        if content_repository.is_serving(content_frame):
+            if content_frames and not label_frames.is_frame_group:
+                try:
+                    _write_content_frame_to_file(
+                        content_frame, images_folder, filename, content_repository
+                    )
+                except DownloadError as download_error:
+                    asset_id = asset["id"]
+                    logging.warning(f"for asset {asset_id}" + str(download_error))
+        else:
+            asset_remote_content.append([asset["externalId"], content_frame, f"{filename}.txt"])
+
+    if (
+        not content_frames
+        and label_frames.is_frame_group
+        and content_repository.is_serving(asset["content"])
+    ):
+        raise NotImplementedError("Export of annotations on videos is not supported yet.")
+
+    return asset_remote_content, video_filenames
+
+
+def _write_class_file(folder: str, category_ids: Dict[str, JobCategory], label_format: LabelFormat):
+    """
+    Create a file that contains meta information about the export, depending of Yolo version
+    """
+    if label_format == "yolo_v4":
+        with open(os.path.join(folder, "classes.txt"), "wb") as fout:
+            for job_category in category_ids.values():
+                fout.write(f"{job_category.id} {job_category.category_name}\n".encode())
+    if label_format == "yolo_v5":
+        with open(os.path.join(folder, "data.yaml"), "wb") as fout:
+            categories = ""
+            for job_category in category_ids.values():
+                categories += f"'{job_category.category_name}', "
+            fout.write(f"nc: {len(category_ids.items())}\n".encode())
+            fout.write(f"names: [{categories[:-2]}]\n".encode())
+
+
+def _get_frame_labels(
+    frame: Dict, job_ids: Set[str], category_ids: Dict[str, JobCategory]
+) -> List[YoloAnnotation]:
+    annotations = []
+    for job_id in job_ids:
+        job_annotations = _convert_from_kili_to_yolo_format(
+            job_id, frame["latestLabel"], category_ids
+        )
+        annotations += job_annotations
+
+    return annotations
+
+
+def _write_content_frame_to_file(
+    url_content_frame: str,
+    images_folder: str,
+    filename: str,
+    content_repository: AbstractContentRepository,
+):
+    content_iterator = content_repository.get_content_stream(url_content_frame, 1024)
+    with open(os.path.join(images_folder, f"{filename}.jpg"), "wb") as fout:
+        for block in content_iterator:
+            if not block:
+                break
+            fout.write(block)
+
+
+def _write_labels_to_file(
+    labels_folder: str, filename: str, annotations: List[YoloAnnotation]
+) -> None:
+    with open(os.path.join(labels_folder, f"{filename}.txt"), "wb") as fout:
+        for category_idx, _x_, _y_, _w_, _h_ in annotations:
+            fout.write(f"{category_idx} {_x_} {_y_} {_w_} {_h_}\n".encode())
+
+
+def _write_video_metadata_file(video_metadata: Dict, base_folder: str) -> None:
+    """
+    Write video metadata file
+    """
+    video_metadata_json = json.dumps(video_metadata, sort_keys=True, indent=4)
+    if video_metadata_json is not None:
+        meta_json_path = os.path.join(base_folder, "video_meta.json")
+        with open(meta_json_path, "wb") as output_file:
+            output_file.write(video_metadata_json.encode("utf-8"))
+
+
+def _write_remote_content_file(remote_content: List[str], images_folder: str) -> None:
+    """
+    Write remote content file
+    """
+    remote_content_header = ["external id", "url", "label file"]
+    remote_file_path = os.path.join(images_folder, "remote_assets.csv")
+    with open(remote_file_path, "w", encoding="utf8") as file:
+        writer = csv.writer(file)
+        writer.writerow(remote_content_header)
+        writer.writerows(remote_content)

--- a/kili/services/export/format/yolo/merge.py
+++ b/kili/services/export/format/yolo/merge.py
@@ -1,0 +1,68 @@
+"""
+Functions to export a project to YOLOv4 or v5 format, with a merged folder layout
+"""
+import os
+from tempfile import TemporaryDirectory
+from typing import Dict, List
+
+from ...exceptions import NoCompatibleJobError
+from ...format.yolo.common import YoloExporter, get_category_full_name
+from ...typing import JobCategory
+
+
+class YoloMergeExporter(YoloExporter):
+    """
+    Handles the Yolo export to merged folders.
+    """
+
+    def process_and_save(self, assets: List[Dict], output_filename: str) -> None:
+        self.logger.info("Exporting to yolo format merged...")
+        json_interface, ml_task, tool = self.get_project_and_init()
+        merged_categories_id = self._get_merged_categories(json_interface, ml_task, tool)
+        if not merged_categories_id:
+            raise NoCompatibleJobError(
+                f"Error: There is no job in project {self.project_id} "
+                f"that can be converted to the {self.label_format} format."
+            )
+
+        with TemporaryDirectory() as root_folder:
+            base_folder = os.path.join(root_folder, self.project_id)
+            images_folder = os.path.join(base_folder, "images")
+            labels_folder = os.path.join(base_folder, "labels")
+            os.makedirs(images_folder)
+            os.makedirs(labels_folder)
+            self.write_labels_into_single_folder(
+                assets,
+                merged_categories_id,
+                labels_folder,
+                images_folder,
+                base_folder,
+            )
+            self.create_readme_kili_file(root_folder)
+            self.make_archive(root_folder, output_filename)
+
+        self.logger.warning(output_filename)
+
+    @classmethod
+    def _get_merged_categories(
+        cls, json_interface: Dict, ml_task: str, tool: str
+    ) -> Dict[str, JobCategory]:
+        """
+        Return a dictionary of JobCategory instances by category full name.
+        """
+        cat_number = 0
+        merged_categories_id: Dict[str, JobCategory] = {}
+        for job_id, job in json_interface.get("jobs", {}).items():
+            if (
+                job.get("mlTask") != ml_task
+                or tool not in job.get("tools", [])
+                or job.get("isModel")
+            ):
+                continue
+            for category in job.get("content", {}).get("categories", {}):
+                merged_categories_id[get_category_full_name(job_id, category)] = JobCategory(
+                    category_name=category, id=cat_number, job_id=job_id
+                )
+                cat_number += 1
+
+        return merged_categories_id

--- a/kili/services/export/format/yolo/split.py
+++ b/kili/services/export/format/yolo/split.py
@@ -1,0 +1,89 @@
+"""
+Handles the Yolo export with the split layout
+"""
+
+import os
+from tempfile import TemporaryDirectory
+from typing import Dict, List
+
+from ...exceptions import NoCompatibleJobError
+from ...format.yolo.common import YoloExporter, get_category_full_name
+from ...typing import JobCategory
+
+
+class YoloSplitExporter(YoloExporter):
+    """
+    Handles the Yolo format export into split folders
+    """
+
+    def process_and_save(self, assets: List[Dict], output_filename: str) -> None:
+        self.logger.info("Exporting to yolo format split...")
+
+        json_interface, ml_task, tool = self.get_project_and_init()
+        categories_by_job = self._get_categories_by_job(json_interface, ml_task, tool)
+        if not categories_by_job:
+            raise NoCompatibleJobError(
+                f"Error: There is no job in project {self.project_id} "
+                f"that can be converted to the {self.label_format} format."
+            )
+
+        with TemporaryDirectory() as root_folder:
+            images_folder = os.path.join(root_folder, self.project_id, "images")
+            os.makedirs(images_folder)
+            self._write_jobs_labels_into_split_folders(
+                assets,
+                categories_by_job,
+                root_folder,
+                images_folder,
+            )
+            self.create_readme_kili_file(root_folder)
+            self.make_archive(root_folder, output_filename)
+
+        self.logger.warning(output_filename)
+
+    @classmethod
+    def _get_categories_by_job(
+        cls, json_interface: Dict, ml_task: str, tool: str
+    ) -> Dict[str, Dict[str, JobCategory]]:
+        """
+        Return a dictionary of JobCategory instances by category full name and job id.
+        """
+        categories_by_job: Dict[str, Dict[str, JobCategory]] = {}
+        for job_id, job in json_interface.get("jobs", {}).items():
+            if (
+                job.get("mlTask") != ml_task
+                or tool not in job.get("tools", [])
+                or job.get("isModel")
+            ):
+                continue
+            categories: Dict[str, JobCategory] = {}
+            for cat_id, category in enumerate(job.get("content", {}).get("categories", {})):
+                categories[get_category_full_name(job_id, category)] = JobCategory(
+                    category_name=category, id=cat_id, job_id=job_id
+                )
+            categories_by_job[job_id] = categories
+        return categories_by_job
+
+    def _write_jobs_labels_into_split_folders(
+        self,
+        assets: List[Dict],
+        categories_by_job: Dict[str, Dict[str, JobCategory]],
+        root_folder: str,
+        images_folder: str,
+    ) -> None:
+        """
+        Write assets into split folders.
+        """
+        for job_id, category_ids in categories_by_job.items():
+
+            base_folder = os.path.join(root_folder, self.project_id, job_id)
+            labels_folder = os.path.join(base_folder, "labels")
+            os.makedirs(labels_folder)
+
+            self.write_labels_into_single_folder(
+                assets,
+                category_ids,
+                labels_folder,
+                images_folder,
+                base_folder,
+            )

--- a/kili/services/export/repository.py
+++ b/kili/services/export/repository.py
@@ -1,0 +1,76 @@
+"""
+Gets the
+"""
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Iterator, List
+
+import requests
+
+from .exceptions import DownloadError
+
+
+class AbstractContentRepository(ABC):
+    """
+    Interface to the content repository
+    """
+
+    def __init__(
+        self, router_endpoint: str, router_headers: Dict[str, str], verify_ssl: bool
+    ) -> None:
+        self.router_endpoint = router_endpoint
+        self.router_headers = router_headers
+        self.verify_ssl = verify_ssl
+        assert router_endpoint, "The router endpoint string should not be empty"
+
+    @abstractmethod
+    def get_frames(self, content_url: str) -> List[str]:
+        pass
+
+    @abstractmethod
+    def get_content_stream(self, content_url: str, block_size: int) -> Iterator[Any]:
+        pass
+
+    def get_content_frames_paths(self, asset: Dict) -> List[str]:
+        """
+        Get list of links to frames from the file located at asset[jsonContent]. Returns an empty list
+        if `content` in the asset exists.
+        """
+        content_frames = []
+
+        if not asset["content"] and asset["jsonContent"]:
+            content_frames = self.get_frames(asset["jsonContent"])
+
+        return content_frames
+
+    def is_serving(self, url: str) -> bool:
+        """
+        Return a boolean defining if the asset is served by Kili or not
+        """
+        return url.startswith(self.router_endpoint)
+
+
+class SDKContentRepository(AbstractContentRepository):
+    """
+    Handle content fetching from the server from the SDK
+    """
+
+    def get_frames(self, content_url: str) -> List[str]:
+        frames: List[str] = []
+        headers = None
+        if content_url.startswith(self.router_endpoint):
+            headers = self.router_headers
+        json_content_resp = requests.get(content_url, headers=headers, verify=self.verify_ssl)
+
+        if json_content_resp.ok:
+            frames = list(json_content_resp.json().values())
+        return frames
+
+    def get_content_stream(self, content_url: str, block_size: int) -> Iterator[Any]:
+
+        response = requests.get(
+            content_url, stream=True, headers=self.router_headers, verify=self.verify_ssl
+        )
+        if not response.ok:
+            raise DownloadError(f"Error while downloading image {content_url}")
+
+        return response.iter_content(block_size)

--- a/kili/services/export/tools.py
+++ b/kili/services/export/tools.py
@@ -1,0 +1,105 @@
+"""
+Set of common functions used by different export formats
+"""
+from typing import List, Optional
+
+from kili.orm import AnnotationFormat
+
+DEFAULT_FIELDS = [  # TODO: check if this is still relevant
+    "id",
+    "content",
+    "externalId",
+    "jsonMetadata",
+    "labels.author.id",
+    "labels.author.email",
+    "labels.author.firstname",
+    "labels.author.lastname",
+    "labels.jsonResponse",
+    "labels.createdAt",
+    "labels.isLatestLabelForUser",
+    "labels.labelType",
+    "labels.modelName",
+]
+LATEST_LABEL_FIELDS = [
+    "id",
+    "content",
+    "externalId",
+    "jsonContent",
+    "jsonMetadata",
+    "latestLabel.author.id",
+    "latestLabel.author.email",
+    "latestLabel.jsonResponse",
+    "latestLabel.author.firstname",
+    "latestLabel.author.lastname",
+    "latestLabel.createdAt",
+    "latestLabel.isLatestLabelForUser",
+    "latestLabel.labelType",
+    "latestLabel.modelName",
+]
+
+
+def attach_name_to_assets_labels_author(assets, export_type):
+    """
+    Adds `name` field for author, by concatenating his/her first and last name
+    """
+    for asset in assets:
+        if export_type.lower() == AnnotationFormat.Latest.lower():
+            latest_label = asset["latestLabel"]
+            if latest_label:
+                firstname = latest_label["author"]["firstname"]
+                lastname = latest_label["author"]["lastname"]
+                latest_label["author"]["name"] = f"{firstname} {lastname}"
+            continue
+        for label in asset.get("labels", []):
+            firstname = label["author"]["firstname"]
+            lastname = label["author"]["lastname"]
+            label["author"]["name"] = f"{firstname} {lastname}"
+
+
+def fetch_assets(
+    kili,
+    project_id: str,
+    asset_ids: Optional[List[str]],
+    export_type,
+    label_type_in=None,
+    disable_tqdm: bool = False,
+):
+    """
+    Fetches assets where ID are in asset_ids if the list has more than one element,
+    else all the assets of the project
+
+    Parameters
+    ----------
+    - project_id: project id
+    - assets_ids: list of asset IDs
+    - export_type: type of export (latest label or all labels)
+    - label_type_in: types of label to fetch (default, reviewed, ...)
+    """
+    fields = get_fields_to_fetch(export_type)
+    assets = None
+    if asset_ids is not None and len(asset_ids) > 0:
+        assets = kili.assets(
+            asset_id_in=asset_ids,
+            project_id=project_id,
+            fields=fields,
+            label_type_in=label_type_in,
+            disable_tqdm=disable_tqdm,
+        )
+    else:
+        assets = kili.assets(
+            project_id=project_id,
+            fields=fields,
+            label_type_in=label_type_in,
+            disable_tqdm=disable_tqdm,
+        )
+    attach_name_to_assets_labels_author(assets, export_type)
+    return assets
+
+
+def get_fields_to_fetch(export_type):
+    """
+    Returns the fields to fetch depending on the export type
+    """
+    if export_type.lower() == AnnotationFormat.Latest.lower():
+        return LATEST_LABEL_FIELDS
+    return DEFAULT_FIELDS

--- a/kili/services/export/typing.py
+++ b/kili/services/export/typing.py
@@ -1,0 +1,27 @@
+"""
+Types used by the conversion service
+"""
+from typing import NamedTuple, NewType, Tuple, Union
+
+from typing_extensions import Literal
+
+LabelFormat = Literal["yolo_v4", "yolo_v5"]
+InputType = Literal["TEXT", "IMAGE"]
+ExportType = Literal["latest", "normal"]
+AssetId = NewType("AssetId", str)
+ProjectId = NewType("ProjectId", str)
+SplitOption = Literal["split", "merged"]
+LogLevel = Union[int, Literal["ERROR", "WARNING", "DEBUG", "INFO", "CRITICAL"]]
+
+
+class JobCategory(NamedTuple):
+    """
+    Contains information for a category
+    """
+
+    category_name: str
+    id: int
+    job_id: str
+
+
+YoloAnnotation = Tuple[int, float, float, float, float]

--- a/recipes/ocr_pre_annotations.ipynb
+++ b/recipes/ocr_pre_annotations.ipynb
@@ -464,7 +464,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.7.13 ('python-sdk')",
    "language": "python",
    "name": "python3"
   },
@@ -478,7 +478,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.7.13"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "de396e6bb0ca1b0abec04a877b6eb6711952a215fc7f5dc02d30f83999f7a5a6"
+   }
   }
  },
  "nbformat": 4,

--- a/test/cli/test_project.py
+++ b/test/cli/test_project.py
@@ -9,6 +9,7 @@ from click.testing import CliRunner
 
 from kili.cli.project.create import create_project
 from kili.cli.project.describe import describe_project
+from kili.cli.project.export import export_labels
 from kili.cli.project.import_ import import_assets
 from kili.cli.project.label import import_labels
 from kili.cli.project.list_ import list_projects
@@ -23,6 +24,38 @@ def mocked__projects(project_id=None, **_):
         return [{"id": "text_project", "inputType": "TEXT"}]
     if project_id == "image_project":
         return [{"id": "image_project", "inputType": "IMAGE"}]
+    if project_id == "object_detection":
+        job_payload = {
+            "mlTask": "OBJECT_DETECTION",
+            "tools": ["rectangle"],
+            "instruction": "Categories",
+            "required": 1,
+            "isChild": False,
+            "content": {
+                "categories": {
+                    "OBJECT_A": {
+                        "name": "OBJECT A",
+                    },
+                    "OBJECT_B": {
+                        "name": "OBJECT B",
+                    },
+                },
+                "input": "radio",
+            },
+        }
+        json_interface = {
+            "jobs": {
+                "JOB_0": job_payload,
+            }
+        }
+        return [
+            {
+                "title": "test OD project",
+                "id": "object_detection",
+                "description": "This is a test project",
+                "jsonInterface": json_interface,
+            }
+        ]
     if project_id == "frame_project":
         return [{"id": "frame_project", "inputType": "VIDEO"}]
     if project_id == None:
@@ -69,19 +102,57 @@ def mocked__projects(project_id=None, **_):
         ]
 
 
-def mocked__project_assets(**_):
-    return [
-        {"externalId": "asset1"},
-        {"externalId": "asset2"},
-        {"externalId": "asset3"},
-        {"externalId": "asset4"},
-        {"externalId": "asset5"},
-        {"externalId": "asset6"},
-    ]
+def mocked__project_assets(project_id=None, **_):
+    if project_id == "object_detection":
+        job_object_detection = {
+            "JOB_0": {
+                "annotations": [
+                    {
+                        "categories": [{"confidence": 100, "name": "OBJECT_A"}],
+                        "jobName": "JOB_0",
+                        "mid": "2022040515434712-7532",
+                        "mlTask": "OBJECT_DETECTION",
+                        "boundingPoly": [
+                            {
+                                "normalizedVertices": [
+                                    {"x": 0.16504140348233334, "y": 0.7986938935103378},
+                                    {"x": 0.16504140348233334, "y": 0.2605618833516984},
+                                    {"x": 0.8377886490672706, "y": 0.2605618833516984},
+                                    {"x": 0.8377886490672706, "y": 0.7986938935103378},
+                                ]
+                            }
+                        ],
+                        "type": "rectangle",
+                        "children": {},
+                    }
+                ]
+            }
+        }
+
+        return [
+            {
+                "latestLabel": {
+                    "jsonResponse": job_object_detection,
+                    "author": {"firstname": "Jean-Pierre", "lastname": "Dupont"},
+                },
+                "externalId": "car_1",
+                "content": "https://storage.googleapis.com/label-public-staging/car/car_1.jpg",
+                "jsonContent": "",
+            }
+        ]
+    else:
+        return [
+            {"externalId": "asset1"},
+            {"externalId": "asset2"},
+            {"externalId": "asset3"},
+            {"externalId": "asset4"},
+            {"externalId": "asset5"},
+            {"externalId": "asset6"},
+        ]
 
 
 kili_client = MagicMock()
-kili_client.auth.client.endpoint = "https://staging.cloud.kili-technology.com/api/label/v2/graphql"
+kili_client.auth.api_endpoint = "https://staging.cloud.kili-technology.com/api/label/v2/graphql"
 kili_client.projects = project_mock = MagicMock(side_effect=mocked__projects)
 kili_client.append_to_labels = append_to_labels_mock = MagicMock()
 kili_client.create_predictions = create_predictions_mock = MagicMock()
@@ -236,6 +307,7 @@ class TestCLIProject:
                     )
 
     def test_import(self, mocker):
+
         TEST_CASES = [
             {
                 "case_name": "AAU, when I import a list of file to an image project, I see a success",
@@ -380,9 +452,33 @@ class TestCLIProject:
                     arguments.append(v)
                 if test_case.get("flags"):
                     arguments.extend(["--" + flag for flag in test_case["flags"]])
-                print(arguments)
                 result = runner.invoke(import_assets, arguments)
                 debug_subprocess_pytest(result)
                 append_many_to_dataset_mock.assert_called_with(
                     **test_case["expected_mutation_payload"]
                 )
+
+    def test_export(self, mocker):
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+
+            result = runner.invoke(
+                export_labels,
+                [
+                    "--output-format",
+                    "yolo_v4",
+                    "--output-file",
+                    "export.zip",
+                    "--project-id",
+                    "object_detection",
+                    "--layout",
+                    "split",
+                    "--verbose",
+                    "--api-key",
+                    "toto",
+                    "--endpoint",
+                    "localhost",
+                ],
+            )
+            debug_subprocess_pytest(result)
+            assert result.output.count("export.zip")

--- a/test/services/export/expected/classes.txt
+++ b/test/services/export/expected/classes.txt
@@ -1,0 +1,2 @@
+0 OBJECT_A
+1 OBJECT_B

--- a/test/services/export/expected/data.yaml
+++ b/test/services/export/expected/data.yaml
@@ -1,0 +1,2 @@
+nc: 2
+names: ['OBJECT_A', 'OBJECT_B']

--- a/test/services/export/fakes/fake_content_repository.py
+++ b/test/services/export/fakes/fake_content_repository.py
@@ -1,0 +1,14 @@
+from typing import Any, Dict, Iterator, List
+
+from kili.services.export.repository import AbstractContentRepository
+
+
+class FakeContentRepository(AbstractContentRepository):
+    def get_frames(self, content_url: str, router_headers: Dict) -> List[str]:
+        return []
+
+    def get_content_stream(
+        self, content_url: str, block_size: int, router_headers: Dict
+    ) -> Iterator[Any]:
+        for i in []:
+            yield i

--- a/test/services/export/fakes/fake_data.py
+++ b/test/services/export/fakes/fake_data.py
@@ -1,0 +1,79 @@
+from typing import Dict
+
+from kili.services.export.typing import JobCategory
+
+job_category_a: JobCategory = JobCategory(category_name="OBJECT_A", id=0, job_id="JOB_0")
+job_category_b: JobCategory = JobCategory(category_name="OBJECT_B", id=1, job_id="JOB_0")
+category_ids: Dict[str, JobCategory] = {
+    "JOB_0__OBJECT_A": job_category_a,
+    "JOB_0__OBJECT_B": job_category_b,
+}
+job_object_detection = {
+    "JOB_0": {
+        "annotations": [
+            {
+                "categories": [{"confidence": 100, "name": "OBJECT_A"}],
+                "jobName": "JOB_0",
+                "mid": "2022040515434712-7532",
+                "mlTask": "OBJECT_DETECTION",
+                "boundingPoly": [
+                    {
+                        "normalizedVertices": [
+                            {"x": 0.16504140348233334, "y": 0.7986938935103378},
+                            {"x": 0.16504140348233334, "y": 0.2605618833516984},
+                            {"x": 0.8377886490672706, "y": 0.2605618833516984},
+                            {"x": 0.8377886490672706, "y": 0.7986938935103378},
+                        ]
+                    }
+                ],
+                "type": "rectangle",
+                "children": {},
+            }
+        ]
+    }
+}
+asset_image = {
+    "latestLabel": {
+        "jsonResponse": job_object_detection,
+        "author": {"firstname": "Jean-Pierre", "lastname": "Dupont"},
+    },
+    "externalId": "car_1",
+    "content": "https://storage.googleapis.com/label-public-staging/car/car_1.jpg",
+    "jsonContent": "",
+}
+
+asset_video = {
+    "latestLabel": {
+        "jsonResponse": {
+            "0": job_object_detection,
+            "1": job_object_detection,
+            "2": job_object_detection,
+            "3": job_object_detection,
+        }
+    },
+    "externalId": "video_1",
+    "content": "https://storage.googleapis.com/label-public-staging/video1/video1.mp4",
+    "jsonContent": "",
+}
+
+asset_video_frames = {
+    "latestLabel": {
+        "jsonResponse": [
+            {
+                "0": job_object_detection,
+                "1": job_object_detection,
+                "2": job_object_detection,
+                "3": job_object_detection,
+            },
+            {
+                "0": job_object_detection,
+                "1": job_object_detection,
+                "2": job_object_detection,
+                "3": job_object_detection,
+            },
+        ]
+    },
+    "externalId": "video_1",
+    "content": "https://storage.googleapis.com/label-public-staging/video1/video1.mp4",
+    "jsonContent": "",
+}

--- a/test/services/export/fakes/fake_kili.py
+++ b/test/services/export/fakes/fake_kili.py
@@ -1,0 +1,115 @@
+"""
+Fake Kili object
+"""
+
+from test.services.export.fakes.fake_data import asset_image
+from typing import List, Optional
+
+
+class FakeAuth:
+
+    api_key = ""
+    api_endpoint = "http://content-repository"
+
+
+class FakeKili:
+    """
+    Handke .assets and .project methods of Kili
+    """
+
+    auth = FakeAuth()
+
+    def assets(
+        self,
+        project_id: str,
+        fields: List[str],
+        label_type_in: Optional[List[str]] = None,
+        asset_id_in: Optional[List[str]] = None,
+        disable_tqdm: bool = False,
+    ):
+        """
+        Fake assets
+        """
+        _ = fields, label_type_in, asset_id_in, disable_tqdm
+        if project_id == "object_detection":
+            return [asset_image]
+        elif project_id == "text_classification":
+            return []
+        else:
+            return []
+
+    def projects(self, project_id: str, fields: List[str], disable_tqdm: bool = False):
+        """
+        Fake projects
+        """
+        _ = fields, disable_tqdm
+        if project_id == "object_detection":
+            job_payload = {
+                "mlTask": "OBJECT_DETECTION",
+                "tools": ["rectangle"],
+                "instruction": "Categories",
+                "required": 1,
+                "isChild": False,
+                "content": {
+                    "categories": {
+                        "OBJECT_A": {
+                            "name": "OBJECT A",
+                        },
+                        "OBJECT_B": {
+                            "name": "OBJECT B",
+                        },
+                    },
+                    "input": "radio",
+                },
+            }
+            json_interface = {
+                "jobs": {
+                    "JOB_0": job_payload,
+                    "JOB_1": job_payload,
+                    "JOB_2": job_payload,
+                    "JOB_3": job_payload,
+                }
+            }
+            return [
+                {
+                    "title": "test OD project",
+                    "id": "object_detection",
+                    "description": "This is a test project",
+                    "jsonInterface": json_interface,
+                }
+            ]
+        elif project_id == "text_classification":
+            job_payload = {
+                "mlTask": "CLASSIFICATION",
+                "instruction": "Categories",
+                "required": 1,
+                "isChild": False,
+                "content": {
+                    "categories": {
+                        "OBJECT_A": {
+                            "name": "OBJECT A",
+                        },
+                        "OBJECT_B": {
+                            "name": "OBJECT B",
+                        },
+                    },
+                    "input": "radio",
+                },
+            }
+            json_interface = {
+                "jobs": {
+                    "JOB_0": job_payload,
+                }
+            }
+
+            return [
+                {
+                    "title": "test text project",
+                    "id": "text_classification",
+                    "description": "This is a TC test project",
+                    "jsonInterface": json_interface,
+                }
+            ]
+
+        else:
+            return []

--- a/test/services/export/test_export.py
+++ b/test/services/export/test_export.py
@@ -1,0 +1,265 @@
+# pylint: disable=missing-docstring
+import glob
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from test.services.export.fakes.fake_content_repository import FakeContentRepository
+from test.services.export.fakes.fake_data import asset_image, asset_video, category_ids
+from test.services.export.fakes.fake_kili import FakeKili
+from unittest import TestCase
+from zipfile import ZipFile
+
+import pytest
+
+from kili.services import export_labels
+from kili.services.export.exceptions import NoCompatibleJobError
+from kili.services.export.format.yolo.common import (
+    _convert_from_kili_to_yolo_format,
+    _process_asset,
+    _write_class_file,
+)
+
+
+def get_file_tree(folder: str):
+    """
+    Returns the file tree in the shape of a dictionary.
+    Example:
+    {
+        "images": {"remote_assets.csv": {}},
+        "JOB_0": {
+            "labels": {
+                "car_1.txt": {},
+            },
+            "data.yaml": {},
+        },
+        "JOB_1": {"labels": {}, "data.yaml": {}},
+        "JOB_2": {"labels": {}, "data.yaml": {}},
+        "JOB_3": {"labels": {}, "data.yaml": {}},
+        "README.kili.txt": {},
+    }
+    """
+    dct = {}
+    filepaths = [
+        f.replace(os.path.join(folder, ""), "")
+        for f in glob.iglob(folder + "**/**", recursive=True)
+    ]
+    for f_p in filepaths:
+        p = dct
+        for x in f_p.split("/"):
+            if len(x):
+                p = p.setdefault(x, {})
+    return dct
+
+
+class YoloTestCase(TestCase):
+    def test_process_asset_for_job_image_not_served_by_kili(self):
+        with TemporaryDirectory() as images_folder:
+            with TemporaryDirectory() as labels_folder:
+                fake_content_repository = FakeContentRepository("https://contentrep", {}, False)
+                asset_remote_content, video_filenames = _process_asset(
+                    asset_image, images_folder, labels_folder, category_ids, fake_content_repository
+                )
+
+                nb_files = len(
+                    [
+                        name
+                        for name in os.listdir(labels_folder)
+                        if os.path.isfile(os.path.join(labels_folder, name))
+                    ]
+                )
+
+                self.assertTrue(os.path.isfile(os.path.join(labels_folder, "car_1.txt")))
+                self.assertEqual(nb_files, 1)
+                self.assertEqual(
+                    asset_remote_content,
+                    [
+                        [
+                            "car_1",
+                            "https://storage.googleapis.com/label-public-staging/car/car_1.jpg",
+                            "car_1.txt",
+                        ]
+                    ],
+                )
+                self.assertEqual(len(video_filenames), 0)
+
+    def test_process_asset_for_job_frame_not_served_by_kili(self):
+        with TemporaryDirectory() as images_folder:
+            with TemporaryDirectory() as labels_folder:
+                fake_content_repository = FakeContentRepository("https://contentrep", {}, False)
+                asset_remote_content, video_filenames = _process_asset(
+                    asset_video, images_folder, labels_folder, category_ids, fake_content_repository
+                )
+
+                nb_files = len(
+                    [
+                        name
+                        for name in os.listdir(labels_folder)
+                        if os.path.isfile(os.path.join(labels_folder, name))
+                    ]
+                )
+
+                self.assertEqual(nb_files, 4)
+
+                for i in range(nb_files):
+                    self.assertTrue(
+                        os.path.isfile(os.path.join(labels_folder, f"video_1_{i+1}.txt"))
+                    )
+
+                expected_content = [
+                    [
+                        "video_1",
+                        "https://storage.googleapis.com/label-public-staging/video1/video1.mp4",
+                        f"video_1_{i+1}.txt",
+                    ]
+                    for i in range(4)
+                ]
+                self.assertEqual(asset_remote_content, expected_content)
+
+                expected_video_filenames = [f"video_1_{i+1}" for i in range(4)]
+                self.assertEqual(len(video_filenames), 4)
+                self.assertEqual(video_filenames, expected_video_filenames)
+
+    def test_convert_from_kili_to_yolo_format(self):
+        converted_annotations = _convert_from_kili_to_yolo_format(
+            "JOB_0", asset_image["latestLabel"], category_ids
+        )
+        expected_annotations = [
+            (0, 0.501415026274802, 0.5296278884310182, 0.6727472455849373, 0.5381320101586394)
+        ]
+        self.assertEqual(len(converted_annotations), 1)
+        self.assertEqual(converted_annotations, expected_annotations)
+
+    def test_write_class_file_yolo_v4(self):
+        with TemporaryDirectory() as directory:
+            _write_class_file(directory, category_ids, "yolo_v4")
+            self.assertTrue(os.path.isfile(os.path.join(directory, "classes.txt")))
+            with open(os.path.join(directory, "classes.txt"), "rb") as created_file:
+                with open("./test/services/export/expected/classes.txt", "rb") as expected_file:
+                    self.assertEqual(expected_file.read(), created_file.read())
+
+    def test_write_class_file_yolo_v5(self):
+        with TemporaryDirectory() as directory:
+            _write_class_file(directory, category_ids, "yolo_v5")
+            self.assertTrue(os.path.isfile(os.path.join(directory, "data.yaml")))
+            with open(os.path.join(directory, "data.yaml"), "rb") as created_file:
+                with open("./test/services/export/expected/data.yaml", "rb") as expected_file:
+                    self.assertEqual(expected_file.read(), created_file.read())
+
+    def test_conversion_service(self):
+        use_cases = [
+            {
+                "export_kwargs": {
+                    "project_id": "object_detection",
+                    "label_format": "yolo_v5",
+                    "split_option": "split",
+                },
+                "file_tree_expected": {
+                    "images": {"remote_assets.csv": {}},
+                    "JOB_0": {
+                        "labels": {
+                            "car_1.txt": {},
+                        },
+                        "data.yaml": {},
+                    },
+                    "JOB_1": {"labels": {}, "data.yaml": {}},
+                    "JOB_2": {"labels": {}, "data.yaml": {}},
+                    "JOB_3": {"labels": {}, "data.yaml": {}},
+                    "README.kili.txt": {},
+                },
+            },
+            {
+                "export_kwargs": {
+                    "project_id": "object_detection",
+                    "label_format": "yolo_v5",
+                    "split_option": "merged",
+                },
+                "file_tree_expected": {
+                    "images": {"remote_assets.csv": {}},
+                    "labels": {"car_1.txt": {}},
+                    "data.yaml": {},
+                    "README.kili.txt": {},
+                },
+            },
+            {
+                "export_kwargs": {
+                    "project_id": "object_detection",
+                    "label_format": "yolo_v4",
+                    "split_option": "merged",
+                },
+                "file_tree_expected": {
+                    "images": {"remote_assets.csv": {}},
+                    "labels": {"car_1.txt": {}},
+                    "classes.txt": {},
+                    "README.kili.txt": {},
+                },
+            },
+        ]
+
+        for use_case in use_cases:
+            with TemporaryDirectory() as export_folder:
+                with TemporaryDirectory() as extract_folder:
+
+                    path_zipfile = Path(export_folder) / "export.zip"
+                    path_zipfile.parent.mkdir(parents=True, exist_ok=True)
+
+                    fake_kili = FakeKili()
+                    default_kwargs = {
+                        "asset_ids": [],
+                        "split_option": "merged",
+                        "export_type": "latest",
+                        "output_file": str(path_zipfile),
+                        "disable_tqdm": True,
+                        "log_level": "INFO",
+                    }
+
+                    default_kwargs.update(use_case["export_kwargs"])
+
+                    export_labels(
+                        fake_kili,
+                        **default_kwargs,
+                    )
+
+                    Path(extract_folder).mkdir(parents=True, exist_ok=True)
+                    with ZipFile(path_zipfile, "r") as z_f:
+                        z_f.extractall(extract_folder)
+
+                    file_tree_result = get_file_tree(extract_folder)
+
+                    file_tree_expected = use_case["file_tree_expected"]
+
+                    assert file_tree_result == file_tree_expected
+
+    def test_conversion_service_errors(self):
+
+        use_cases = [
+            {
+                "export_kwargs": {
+                    "project_id": "text_classification",
+                    "label_format": "yolo_v4",
+                    "split_option": "merged",
+                },
+            }
+        ]
+
+        for use_case in use_cases:
+            with TemporaryDirectory() as export_folder:
+
+                path_zipfile = Path(export_folder) / "export.zip"
+                path_zipfile.parent.mkdir(parents=True, exist_ok=True)
+
+                fake_kili = FakeKili()
+                default_kwargs = {
+                    "asset_ids": [],
+                    "split_option": "merged",
+                    "export_type": "latest",
+                    "output_file": str(path_zipfile),
+                    "disable_tqdm": True,
+                    "log_level": "INFO",
+                }
+
+                default_kwargs.update(use_case["export_kwargs"])
+                with pytest.raises(NoCompatibleJobError):
+                    export_labels(
+                        fake_kili,
+                        **default_kwargs,
+                    )


### PR DESCRIPTION
This PR adds the export feature to the CLI and the SDK. The Yolo formats have been implemented for now.
This is more or less a copy-paste of the code of `label-export`, with the following modifications:
* removal of the web-specific code
* change of the enum types to literal (more convenient for the end-user)
* `YoloExporterSelector` handles the exporter selection (split or merged layout) and initializes the dependencies. This is not a proper dependency injection, this will be done later.
* `YoloSplitExporter` and `YoloMergedExporter` handle the export operations and common code is factorized in the parent class.
* `ContentRepository` objects handle fetching the assets from the backend.
* A service layer has been added to handle the calls from the Python client through `project` and the CLI.