### PR TITLE
fix: asset import cli call

### DIFF
--- a/kili/cli/project/label.py
+++ b/kili/cli/project/label.py
@@ -171,7 +171,6 @@ def import_labels(
                 label_asset_external_id=external_ids[i],
                 json_response=json_response,
                 project_id=project_id,
-                label_asset_id=None,
             )
 
     print(f"{len(label_index_to_import)} labels have been successfully imported")

--- a/kili/graphql/operations/asset/mutations.py
+++ b/kili/graphql/operations/asset/mutations.py
@@ -1,7 +1,7 @@
 """
 Assets related mutations
 """
-from kili.graphQL.operations.asset.fragments import PROJECT_FRAGMENT_ID
+from kili.graphql.operations.asset.fragments import PROJECT_FRAGMENT_ID
 
 GQL_APPEND_MANY_TO_DATASET = f"""
 mutation(


### PR DESCRIPTION
I don't really know why `"label_asset_id": None` is now output when `label_asset_external_id` is called, but that fixes the issue.