### PR TITLE
chore: unify tqdm across the client

### DIFF
--- a/kili/services/asset_import/base.py
+++ b/kili/services/asset_import/base.py
@@ -7,8 +7,6 @@ from concurrent.futures import ThreadPoolExecutor
 from json import dumps
 from typing import Callable, List, NamedTuple
 
-from tqdm import tqdm
-
 from kili.authentication import KiliAuth
 from kili.graphql.operations.asset.mutations import (
     GQL_APPEND_MANY_FRAMES_TO_DATASET,
@@ -18,6 +16,7 @@ from kili.helpers import format_result, is_url
 from kili.orm import Asset
 from kili.queries.asset import QueriesAsset
 from kili.utils import bucket, pagination
+from kili.utils.tqdm import tqdm
 
 from .constants import (
     ASSET_FIELDS_DEFAULT_VALUE,

--- a/kili/services/export/format/yolo/common.py
+++ b/kili/services/export/format/yolo/common.py
@@ -8,11 +8,10 @@ import logging
 import os
 from typing import Dict, List, Set
 
-from tqdm.autonotebook import tqdm
-
 from kili.services.export.format.base import BaseExporter
 from kili.services.export.repository import AbstractContentRepository, DownloadError
 from kili.services.export.types import JobCategory, LabelFormat, YoloAnnotation
+from kili.utils.tqdm import tqdm
 
 
 class LabelFrames:

--- a/kili/services/label_import/importer/__init__.py
+++ b/kili/services/label_import/importer/__init__.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import Any, Dict, List, NamedTuple, Optional, Type, cast
 
 import yaml
-from tqdm.autonotebook import tqdm
 
 from kili.helpers import get_file_paths_to_upload
 from kili.services.helpers import (
@@ -28,6 +27,7 @@ from kili.services.label_import.parser import (
 )
 from kili.services.label_import.types import Classes, LabelFormat, LabelToImport
 from kili.services.types import LabelType, LogLevel, ProjectId
+from kili.utils.tqdm import tqdm
 
 
 class LoggerParams(NamedTuple):

--- a/kili/utils/pagination.py
+++ b/kili/utils/pagination.py
@@ -5,10 +5,9 @@ import functools
 import time
 from typing import Callable, Dict, Iterator, List, Optional
 
-from tqdm import tqdm
-
 from kili.constants import MUTATION_BATCH_SIZE, THROTTLING_DELAY
 from kili.exceptions import GraphQLError
+from kili.utils.tqdm import tqdm
 
 # pylint: disable=too-many-arguments,too-many-locals
 

--- a/kili/utils/tqdm.py
+++ b/kili/utils/tqdm.py
@@ -1,0 +1,6 @@
+"""
+Kili tqdm
+"""
+from tqdm.auto import tqdm
+
+__all__ = ["tqdm"]


### PR DESCRIPTION
Checked locally that the warning is not there anymore.