### PR TITLE
feat: launch daily test on bump and add possibility to bump from a sp…

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -2,7 +2,10 @@ name: Daily tests
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 17 * * 1-5"
+    - cron: '0 17 * * 1-5'
+  push:
+    branches:
+      - 'release/**'
 jobs:
   recipes:
     runs-on: ubuntu-latest

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,7 @@ if [[ "$1" == "bump:"* ]]
 
     #create or reset release branch
     git checkout master
-    git pull origin master --tags
+    git pull origin master
     git checkout -B release/bump-version-$(date +%s) $COMMIT
 
     echo "Creating a new branch from master commit $COMMIT"
@@ -33,8 +33,7 @@ if [[ "$1" == "bump:"* ]]
         | grep new_version | sed -r s,"^.*=",,`
 
     echo "Bumping to version $new_version"
-    git tag -a $new_version -m "Release $new_version"
-    git push origin master --tags
+    git push
 
     gh pr create \
         --fill \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,10 +9,19 @@ if [[ "$1" == "bump:"* ]]
             exit 1
     fi
 
+    if [ -z "$2" ]
+        then
+        COMMIT='HEAD'
+    else
+        COMMIT=$2
+    fi
+
     #create or reset release branch
     git checkout master
-    git pull
-    git checkout -B release/bump-version-$(date +%s)
+    git pull origin master --tags
+    git checkout -B release/bump-version-$(date +%s) $COMMIT
+
+    echo "Creating a new branch from master commit $COMMIT"
 
     # increment version in the kili/__init__.py file and in setup.cfg
     new_version=`bump2version \
@@ -24,7 +33,8 @@ if [[ "$1" == "bump:"* ]]
         | grep new_version | sed -r s,"^.*=",,`
 
     echo "Bumping to version $new_version"
-    git push
+    git tag -a $new_version -m "Release $new_version"
+    git push origin master --tags
 
     gh pr create \
         --fill \


### PR DESCRIPTION
- recipes workflow are now launched when on branches that begins by "release/" (same as in the script in entrypoint.sh)
- it is now possible to bump from a specific commit. If no commit is given, HEAD will be used by default
- the bump commit is now tagged with the release number
