### PR TITLE
build: remove the pull from the master branch

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,7 @@ function create_release_branch() {
     read -p 'from commit (default: HEAD): ' commit
     commit="${commit:=HEAD}"
 
-    git pull origin master -q
+    git pull -q
 
     #get the new version
     new_version=$(bump_version dry-run)


### PR DESCRIPTION
we don't want to pull the master branch into a release branch