### PR TITLE
test: add e2e tests for windows

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -13,6 +13,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    env:
+      KILI_API_CLOUD_VISION: ${{ secrets.KILI_API_CLOUD_VISION }}
+      KILI_API_ENDPOINT: https://staging.cloud.kili-technology.com/api/label/v2/graphql
+      KILI_API_KEY: ${{ secrets.KILI_USER_API_KEY }}
+      KILI_USER_EMAIL: ${{ secrets.KILI_USER_EMAIL }}
+      KILI_USER_ID: ${{ secrets.KILI_USER_ID }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -28,16 +34,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
-      - name: Test notebooks
-        run: |
-          pytest -sv tests/test_notebooks.py
-          pytest -sv tests/integration -k ".py"
-        env:
-          KILI_API_CLOUD_VISION: ${{ secrets.KILI_API_CLOUD_VISION }}
-          KILI_API_ENDPOINT: https://staging.cloud.kili-technology.com/api/label/v2/graphql
-          KILI_API_KEY: ${{ secrets.KILI_USER_API_KEY }}
-          KILI_USER_EMAIL: ${{ secrets.KILI_USER_EMAIL }}
-          KILI_USER_ID: ${{ secrets.KILI_USER_ID }}
+      - name: Notebook tests
+        run: pytest -sv tests/test_notebooks.py
+
+      - name: Integration tests
+        run: pytest -sv tests/integration -k ".py"
 
       - name: Slack notification if failure
         if: failure()

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -7,9 +7,12 @@ on:
       - master
 jobs:
   recipes:
-    runs-on: ubuntu-latest
     timeout-minutes: 10
     name: Recipes test
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -29,7 +29,9 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Test notebooks
-        run: pytest -sv tests/test_notebooks.py tests/integration/*.py
+        run: |
+          pytest -sv tests/test_notebooks.py
+          pytest -sv tests/integration -k ".py"
         env:
           KILI_API_CLOUD_VISION: ${{ secrets.KILI_API_CLOUD_VISION }}
           KILI_API_ENDPOINT: https://staging.cloud.kili-technology.com/api/label/v2/graphql

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -34,7 +34,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
-      - name: Notebook tests
+      - name: Notebook tests windows
+        if: ${{ matrix.os }} == 'windows-latest'
+        run: pytest -sv tests/test_notebooks.py --deselect=tests/test_notebooks.py::test_all_recipes[recipes/frame_dicom_data.ipynb] --deselect=tests/test_notebooks.py::test_all_recipes[recipes/medical_imaging.ipynb]
+
+      - name: Notebook tests linux
+        if: ${{ matrix.os }} == 'ubuntu-latest'
         run: pytest -sv tests/test_notebooks.py
 
       - name: Integration tests


### PR DESCRIPTION
Two notebooks fail because they currently cannot run on Windows: https://github.com/kili-technology/kili-python-sdk/actions/runs/3620652184/jobs/6103126008

I had to modify the pytest command since glob patterns don't seem to be working on Windows.