### PR TITLE
ci: add workflow create draft release

### DIFF
--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -58,24 +58,24 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      # - name: Slack notification
-      #   id: slack
-      #   if: success()
-      #   uses: slackapi/slack-github-action@v1.18.0
-      #   with:
-      #     payload: |
-      #       {
-      #         "text": "Draft release ${{ env.NEW_PATCH_VERSION }} is ready.",
-      #         "blocks": [
-      #           {
-      #             "type": "section",
-      #             "text": {
-      #               "type": "mrkdwn",
-      #               "text": "Draft release ${{ env.NEW_PATCH_VERSION }} is ready."
-      #             }
-      #           }
-      #         ]
-      #       }
-      #   env:
-      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_PYTHON_SDK }}
-      #     SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Slack notification
+        id: slack
+        if: success()
+        uses: slackapi/slack-github-action@v1.18.0
+        with:
+          payload: |
+            {
+              "text": "Draft release ${{ env.NEW_PATCH_VERSION }} is ready.",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Draft release ${{ env.NEW_PATCH_VERSION }} is ready."
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_PYTHON_SDK }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -47,13 +47,13 @@ jobs:
           echo $new_version
           echo "NEW_PATCH_VERSION=$new_version" >> $GITHUB_ENV
 
-      # - name: Tag patch
-      #   run: |
-      #     git tag -f -a ${{ env.NEW_PATCH_VERSION }} -m "Release ${{ env.NEW_PATCH_VERSION }}"
-      #     git push origin ${{ env.NEW_PATCH_VERSION }}
+      - name: Tag patch and push
+        run: |
+          git tag -f -a ${{ env.NEW_PATCH_VERSION }} -m "Release ${{ env.NEW_PATCH_VERSION }}"
+          git push origin ${{ env.NEW_PATCH_VERSION }}
 
-      # - name: Create draft release
-      #   run: gh release create ${{ env.NEW_PATCH_VERSION }} --draft --title "Release ${{ env.NEW_PATCH_VERSION }}" --generate-notes
+      - name: Create draft release
+        run: gh release create ${{ env.NEW_PATCH_VERSION }} --draft --title "Release ${{ env.NEW_PATCH_VERSION }}" --generate-notes
 
       # - name: Slack notification
       #   id: slack

--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -36,4 +36,43 @@ jobs:
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
 
       - name: checkout to latest minor release branch
-        run: git checkout release/${{ inputs.releaseVersion }}
+        run: |
+          git fetch origin release/${{ inputs.releaseVersion }}
+          git checkout release/${{ inputs.releaseVersion }}
+          git status
+
+      - name: bump patch version commit
+        run: |
+          new_version=$(./entrypoint.sh bump_version commit patch)
+          echo $new_version
+          echo "NEW_PATCH_VERSION=$new_version" >> $GITHUB_ENV
+
+      # - name: Tag patch
+      #   run: |
+      #     git tag -f -a ${{ env.NEW_PATCH_VERSION }} -m "Release ${{ env.NEW_PATCH_VERSION }}"
+      #     git push origin ${{ env.NEW_PATCH_VERSION }}
+
+      # - name: Create draft release
+      #   run: gh release create ${{ env.NEW_PATCH_VERSION }} --draft --title "Release ${{ env.NEW_PATCH_VERSION }}" --generate-notes
+
+      # - name: Slack notification
+      #   id: slack
+      #   if: success()
+      #   uses: slackapi/slack-github-action@v1.18.0
+      #   with:
+      #     payload: |
+      #       {
+      #         "text": "Draft release ${{ env.NEW_PATCH_VERSION }} is ready.",
+      #         "blocks": [
+      #           {
+      #             "type": "section",
+      #             "text": {
+      #               "type": "mrkdwn",
+      #               "text": "Draft release ${{ env.NEW_PATCH_VERSION }} is ready."
+      #             }
+      #           }
+      #         ]
+      #       }
+      #   env:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_PYTHON_SDK }}
+      #     SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -41,19 +41,22 @@ jobs:
           git checkout release/${{ inputs.releaseVersion }}
           git status
 
-      - name: bump patch version commit
+      - name: bump patch version and commit
         run: |
           new_version=$(./entrypoint.sh bump_version commit patch)
           echo $new_version
           echo "NEW_PATCH_VERSION=$new_version" >> $GITHUB_ENV
+          git push
 
-      - name: Tag patch and push
+      - name: Tag patch commit and push
         run: |
           git tag -f -a ${{ env.NEW_PATCH_VERSION }} -m "Release ${{ env.NEW_PATCH_VERSION }}"
           git push origin ${{ env.NEW_PATCH_VERSION }}
 
       - name: Create draft release
         run: gh release create ${{ env.NEW_PATCH_VERSION }} --draft --title "Release ${{ env.NEW_PATCH_VERSION }}" --generate-notes
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       # - name: Slack notification
       #   id: slack


### PR DESCRIPTION
CI: https://github.com/kili-technology/kili-python-sdk/actions/runs/3674590867/jobs/6212990123

fake release branch used to test the workflow: https://github.com/kili-technology/kili-python-sdk/compare/master...release/2.778.0

tag 2.778.1 added: https://github.com/kili-technology/kili-python-sdk/tags

draft release created: https://github.com/kili-technology/kili-python-sdk/releases

TODO after this PR is done:
- delete release/2.777.0 and release/2.778.0 branches
- 2.778.1 tag