### PR TITLE
fix: export COCO labels with no annotations

### DIFF
--- a/src/kili/services/export/format/coco/__init__.py
+++ b/src/kili/services/export/format/coco/__init__.py
@@ -192,16 +192,13 @@ def _get_coco_images_and_annotations(
 ) -> Tuple[List[_CocoImage], List[_CocoAnnotation]]:
     coco_images = []
     coco_annotations = []
-    annotation_offset = -1
+    annotation_offset = 0
     for asset_i, asset in tqdm(
         enumerate(assets),
         desc="Convert to coco format",
     ):
-        if job_name not in asset["latestLabel"]["jsonResponse"]:
-            continue
         file_name = Path(shutil.copy(asset["content"], data_dir))
         width, height = Image.open(asset["content"]).size
-
         coco_image = _CocoImage(
             id=asset_i,
             license=0,
@@ -210,13 +207,18 @@ def _get_coco_images_and_annotations(
             width=width,
             date_captured=None,
         )
+
         coco_images.append(coco_image)
-        coco_img_annotations, annotation_offset = _get_coco_image_annotations(
-            asset["latestLabel"]["jsonResponse"][job_name]["annotations"],
-            cat_kili_id_to_coco_id,
-            annotation_offset,
-            coco_image,
-        )
+        if job_name not in asset["latestLabel"]["jsonResponse"]:
+            coco_img_annotations = []
+            # annotation offset is unchanged
+        else:
+            coco_img_annotations, annotation_offset = _get_coco_image_annotations(
+                asset["latestLabel"]["jsonResponse"][job_name]["annotations"],
+                cat_kili_id_to_coco_id,
+                annotation_offset,
+                coco_image,
+            )
         coco_annotations.extend(coco_img_annotations)
     return coco_images, coco_annotations
 

--- a/tests/services/export/expected/car_1_without_annotation.xml
+++ b/tests/services/export/expected/car_1_without_annotation.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<annotation>
+   <folder/>
+   <filename>car_1.xml</filename>
+   <path/>
+   <source>
+      <database>Kili Technology</database>
+   </source>
+   <size>
+      <width>1920</width>
+      <height>1080</height>
+      <depth>3</depth>
+   </size>
+   <segmented/>
+</annotation>

--- a/tests/services/export/fakes/fake_data.py
+++ b/tests/services/export/fakes/fake_data.py
@@ -43,6 +43,16 @@ asset_image_1 = {
     "jsonContent": "",
 }
 
+asset_image_1_without_label = {
+    "latestLabel": {
+        "jsonResponse": {},
+        "author": {"firstname": "Jean-Pierre", "lastname": "Dupont"},
+    },
+    "externalId": "car_2",
+    "content": "https://storage.googleapis.com/label-public-staging/car/car_2.jpg",
+    "jsonContent": "",
+}
+
 asset_image_2 = {
     "latestLabel": {
         "jsonResponse": job_object_detection,
@@ -52,6 +62,7 @@ asset_image_2 = {
     "content": "https://storage.googleapis.com/label-public-staging/car/car_2.jpg",
     "jsonContent": "",
 }
+
 
 asset_video = {
     "latestLabel": {

--- a/tests/services/export/fakes/fake_data.py
+++ b/tests/services/export/fakes/fake_data.py
@@ -43,7 +43,7 @@ asset_image_1 = {
     "jsonContent": "",
 }
 
-asset_image_1_without_label = {
+asset_image_1_without_annotation = {
     "latestLabel": {
         "jsonResponse": {},
         "author": {"firstname": "Jean-Pierre", "lastname": "Dupont"},

--- a/tests/services/export/test_coco.py
+++ b/tests/services/export/test_coco.py
@@ -15,44 +15,46 @@ from kili.services.types import JobName
 class CocoTestCase(TestCase):
     @staticmethod
     def get_asset(content_path: Path, with_annotation: bool) -> Asset:
-        annotations = []
+        json_response = {"author": {"firstname": "Jean-Pierre", "lastname": "Dupont"}}
         if with_annotation:
-            annotations = [
+            json_response.update(
                 {
-                    "categories": [{"confidence": 100, "name": "OBJECT_A"}],
-                    "jobName": "JOB_0",
-                    "mid": "2022040515434712-7532",
-                    "mlTask": "OBJECT_DETECTION",
-                    "boundingPoly": [
-                        {
-                            "normalizedVertices": [
-                                {
-                                    "x": 0.0,
-                                    "y": 0.0,
-                                },
-                                {
-                                    "x": 1.0,
-                                    "y": 0.0,
-                                },
-                                {
-                                    "x": 0.0,
-                                    "y": 1.0,
-                                },
-                            ]
-                        }
-                    ],
-                    "type": "semantic",
-                    "children": {},
+                    "JOB_0": {
+                        "annotations": [
+                            {
+                                "categories": [{"confidence": 100, "name": "OBJECT_A"}],
+                                "jobName": "JOB_0",
+                                "mid": "2022040515434712-7532",
+                                "mlTask": "OBJECT_DETECTION",
+                                "boundingPoly": [
+                                    {
+                                        "normalizedVertices": [
+                                            {
+                                                "x": 0.0,
+                                                "y": 0.0,
+                                            },
+                                            {
+                                                "x": 1.0,
+                                                "y": 0.0,
+                                            },
+                                            {
+                                                "x": 0.0,
+                                                "y": 1.0,
+                                            },
+                                        ]
+                                    }
+                                ],
+                                "type": "semantic",
+                                "children": {},
+                            }
+                        ]
+                    }
                 }
-            ]
+            )
+
         return Asset(
             {
-                "latestLabel": {
-                    "jsonResponse": {
-                        "JOB_0": {"annotations": annotations},
-                        "author": {"firstname": "Jean-Pierre", "lastname": "Dupont"},
-                    },
-                },
+                "latestLabel": {"jsonResponse": json_response},
                 "externalId": "car_1",
                 "jsonContent": "",
                 "content": str(content_path),

--- a/tests/services/export/test_coco.py
+++ b/tests/services/export/test_coco.py
@@ -3,7 +3,6 @@ import json
 from datetime import datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from unittest import TestCase
 
 import requests
 
@@ -12,188 +11,183 @@ from kili.services.export.format.coco import _convert_kili_semantic_to_coco
 from kili.services.types import JobName
 
 
-class CocoTestCase(TestCase):
-    @staticmethod
-    def get_asset(content_path: Path, with_annotation: bool) -> Asset:
-        # without annotation means that: there is a label for the asset
-        # but there is no labeling data for the job.
-        # `annotations=[]` should not exist.
-        json_response = {"author": {"firstname": "Jean-Pierre", "lastname": "Dupont"}}
-        if with_annotation:
-            json_response.update(
-                {
-                    "JOB_0": {
-                        "annotations": [
-                            {
-                                "categories": [{"confidence": 100, "name": "OBJECT_A"}],
-                                "jobName": "JOB_0",
-                                "mid": "2022040515434712-7532",
-                                "mlTask": "OBJECT_DETECTION",
-                                "boundingPoly": [
-                                    {
-                                        "normalizedVertices": [
-                                            {
-                                                "x": 0.0,
-                                                "y": 0.0,
-                                            },
-                                            {
-                                                "x": 1.0,
-                                                "y": 0.0,
-                                            },
-                                            {
-                                                "x": 0.0,
-                                                "y": 1.0,
-                                            },
-                                        ]
-                                    }
-                                ],
-                                "type": "semantic",
-                                "children": {},
-                            }
-                        ]
-                    }
-                }
-            )
-
-        return Asset(
+def get_asset(content_path: Path, with_annotation: bool) -> Asset:
+    # without annotation means that: there is a label for the asset
+    # but there is no labeling data for the job.
+    # `annotations=[]` should not exist.
+    json_response = {"author": {"firstname": "Jean-Pierre", "lastname": "Dupont"}}
+    if with_annotation:
+        json_response.update(
             {
-                "latestLabel": {"jsonResponse": json_response},
-                "externalId": "car_1",
-                "jsonContent": "",
-                "content": str(content_path),
+                "JOB_0": {
+                    "annotations": [
+                        {
+                            "categories": [{"confidence": 100, "name": "OBJECT_A"}],
+                            "jobName": "JOB_0",
+                            "mid": "2022040515434712-7532",
+                            "mlTask": "OBJECT_DETECTION",
+                            "boundingPoly": [
+                                {
+                                    "normalizedVertices": [
+                                        {
+                                            "x": 0.0,
+                                            "y": 0.0,
+                                        },
+                                        {
+                                            "x": 1.0,
+                                            "y": 0.0,
+                                        },
+                                        {
+                                            "x": 0.0,
+                                            "y": 1.0,
+                                        },
+                                    ]
+                                }
+                            ],
+                            "type": "semantic",
+                            "children": {},
+                        }
+                    ]
+                }
             }
         )
 
-    def test__get_coco_image_annotations(self):
-        with TemporaryDirectory() as tmp_dir:
-            job_name = "JOB_0"
-            output_file = Path(tmp_dir) / job_name / "labels.json"
-            image_url = "https://storage.googleapis.com/label-public-staging/car/car_1.jpg"
-            r = requests.get(image_url, allow_redirects=True)
-            local_file_path = tmp_dir / Path("car_1.jpg")
-            local_file_path.open("wb").write(r.content)
-            _convert_kili_semantic_to_coco(
-                job_name=JobName(job_name),
-                assets=[CocoTestCase.get_asset(local_file_path, with_annotation=True)],
-                output_dir=Path(tmp_dir),
-                job={
-                    "mlTask": "OBJECT_DETECTION",
-                    "content": {
-                        "categories": {
-                            "OBJECT_A": {"name": "Object A"},
-                            "OBJECT_B": {"name": "Object B"},
-                        }
-                    },
-                    "instruction": "",
-                    "isChild": False,
-                    "isNew": False,
-                    "isVisible": True,
-                    "models": {},
-                    "required": True,
-                    "tools": ["semantic"],
-                },
-                title="Test project",
-            )
-            with output_file.open("r", encoding="utf-8") as f:
-                coco_annotation = json.loads(f.read())
-                result = {
-                    "info": {
-                        "year": "2022",
-                        "version": "1.0",
-                        "description": "Test project - Exported from Kili Python Client",
-                        "contributor": "Kili Technology",
-                        "url": "https://kili-technology.com",
-                    },
-                    "licenses": [],
-                    "categories": [
-                        {"id": 1, "name": "OBJECT_B", "supercategory": ""},
-                        {"id": 0, "name": "OBJECT_A", "supercategory": ""},
-                    ],
-                    "images": [
-                        {
-                            "id": 0,
-                            "license": 0,
-                            "file_name": "/var/folders/4d/cyyb2jg15k74pw6y661rlnm00000gn/T/tmp7ck1ykp4/data/car_1.jpg",
-                            "height": 1080,
-                            "width": 1920,
-                            "date_captured": None,
-                        }
-                    ],
-                    "annotations": [
-                        {
-                            "id": 0,
-                            "image_id": 0,
-                            "category_id": 0,
-                            "bbox": [0, 0, 1920, 1080],
-                            "segmentation": [[0.0, 0.0, 1920.0, 0.0, 0.0, 1080.0]],
-                            "area": 2073600,
-                            "iscrowd": 0,
-                        }
-                    ],
-                }
-                assert "Test project" in coco_annotation["info"]["description"]
-                categories_by_id = {cat["id"]: cat["name"] for cat in coco_annotation["categories"]}
-                assert coco_annotation["images"][0]["file_name"] == "data/car_1.jpg"
-                assert coco_annotation["images"][0]["width"] == 1920
-                assert coco_annotation["images"][0]["height"] == 1080
-                assert coco_annotation["annotations"][0]["image_id"] == 0
-                assert (
-                    categories_by_id[coco_annotation["annotations"][0]["category_id"]] == "OBJECT_A"
-                )
-                assert coco_annotation["annotations"][0]["bbox"] == [0, 0, 1920, 1080]
-                assert coco_annotation["annotations"][0]["segmentation"] == [
-                    [0.0, 0.0, 1920.0, 0.0, 0.0, 1080.0]
-                ]
-                assert coco_annotation["annotations"][0]["area"] == 2073600
+    return Asset(
+        {
+            "latestLabel": {"jsonResponse": json_response},
+            "externalId": "car_1",
+            "jsonContent": "",
+            "content": str(content_path),
+        }
+    )
 
-                good_date = True
-                try:
-                    datetime.strptime(
-                        coco_annotation["info"]["date_created"], "%Y-%m-%dT%H:%M:%S.%f"
-                    )
-                except ValueError:
-                    good_date = False
-                assert good_date, (
-                    "The date is not in the right format: "
-                    + coco_annotation["info"]["date_created"]
-                )
 
-    def test__get_coco_image_annotations_without_annotation(self):
-        with TemporaryDirectory() as tmp_dir:
-            job_name = "JOB_0"
-            output_file = Path(tmp_dir) / job_name / "labels.json"
-            image_url = "https://storage.googleapis.com/label-public-staging/car/car_1.jpg"
-            r = requests.get(image_url, allow_redirects=True, timeout=10)
-            local_file_path = tmp_dir / Path("car_1.jpg")
-            local_file_path.open("wb").write(r.content)
-            _convert_kili_semantic_to_coco(
-                job_name=JobName(job_name),
-                assets=[CocoTestCase.get_asset(local_file_path, with_annotation=False)],
-                output_dir=Path(tmp_dir),
-                job={
-                    "mlTask": "OBJECT_DETECTION",
-                    "content": {
-                        "categories": {
-                            "OBJECT_A": {"name": "Object A"},
-                            "OBJECT_B": {"name": "Object B"},
-                        }
-                    },
-                    "instruction": "",
-                    "isChild": False,
-                    "isNew": False,
-                    "isVisible": True,
-                    "models": {},
-                    "required": True,
-                    "tools": ["semantic"],
+def test__get_coco_image_annotations():
+    with TemporaryDirectory() as tmp_dir:
+        job_name = "JOB_0"
+        output_file = Path(tmp_dir) / job_name / "labels.json"
+        image_url = "https://storage.googleapis.com/label-public-staging/car/car_1.jpg"
+        r = requests.get(image_url, allow_redirects=True)
+        local_file_path = tmp_dir / Path("car_1.jpg")
+        local_file_path.open("wb").write(r.content)
+        _convert_kili_semantic_to_coco(
+            job_name=JobName(job_name),
+            assets=[get_asset(local_file_path, with_annotation=True)],
+            output_dir=Path(tmp_dir),
+            job={
+                "mlTask": "OBJECT_DETECTION",
+                "content": {
+                    "categories": {
+                        "OBJECT_A": {"name": "Object A"},
+                        "OBJECT_B": {"name": "Object B"},
+                    }
                 },
-                title="Test project",
+                "instruction": "",
+                "isChild": False,
+                "isNew": False,
+                "isVisible": True,
+                "models": {},
+                "required": True,
+                "tools": ["semantic"],
+            },
+            title="Test project",
+        )
+        with output_file.open("r", encoding="utf-8") as f:
+            coco_annotation = json.loads(f.read())
+            result = {
+                "info": {
+                    "year": "2022",
+                    "version": "1.0",
+                    "description": "Test project - Exported from Kili Python Client",
+                    "contributor": "Kili Technology",
+                    "url": "https://kili-technology.com",
+                },
+                "licenses": [],
+                "categories": [
+                    {"id": 1, "name": "OBJECT_B", "supercategory": ""},
+                    {"id": 0, "name": "OBJECT_A", "supercategory": ""},
+                ],
+                "images": [
+                    {
+                        "id": 0,
+                        "license": 0,
+                        "file_name": "/var/folders/4d/cyyb2jg15k74pw6y661rlnm00000gn/T/tmp7ck1ykp4/data/car_1.jpg",
+                        "height": 1080,
+                        "width": 1920,
+                        "date_captured": None,
+                    }
+                ],
+                "annotations": [
+                    {
+                        "id": 0,
+                        "image_id": 0,
+                        "category_id": 0,
+                        "bbox": [0, 0, 1920, 1080],
+                        "segmentation": [[0.0, 0.0, 1920.0, 0.0, 0.0, 1080.0]],
+                        "area": 2073600,
+                        "iscrowd": 0,
+                    }
+                ],
+            }
+            assert "Test project" in coco_annotation["info"]["description"]
+            categories_by_id = {cat["id"]: cat["name"] for cat in coco_annotation["categories"]}
+            assert coco_annotation["images"][0]["file_name"] == "data/car_1.jpg"
+            assert coco_annotation["images"][0]["width"] == 1920
+            assert coco_annotation["images"][0]["height"] == 1080
+            assert coco_annotation["annotations"][0]["image_id"] == 0
+            assert categories_by_id[coco_annotation["annotations"][0]["category_id"]] == "OBJECT_A"
+            assert coco_annotation["annotations"][0]["bbox"] == [0, 0, 1920, 1080]
+            assert coco_annotation["annotations"][0]["segmentation"] == [
+                [0.0, 0.0, 1920.0, 0.0, 0.0, 1080.0]
+            ]
+            assert coco_annotation["annotations"][0]["area"] == 2073600
+
+            good_date = True
+            try:
+                datetime.strptime(coco_annotation["info"]["date_created"], "%Y-%m-%dT%H:%M:%S.%f")
+            except ValueError:
+                good_date = False
+            assert good_date, (
+                "The date is not in the right format: " + coco_annotation["info"]["date_created"]
             )
 
-            with output_file.open("r", encoding="utf-8") as f:
-                coco_annotation = json.loads(f.read())
 
-                assert "Test project" in coco_annotation["info"]["description"]
-                assert coco_annotation["images"][0]["file_name"] == "data/car_1.jpg"
-                assert coco_annotation["images"][0]["width"] == 1920
-                assert coco_annotation["images"][0]["height"] == 1080
-                assert len(coco_annotation["annotations"]) == 0
+def test__get_coco_image_annotations_without_annotation():
+    with TemporaryDirectory() as tmp_dir:
+        job_name = "JOB_0"
+        output_file = Path(tmp_dir) / job_name / "labels.json"
+        image_url = "https://storage.googleapis.com/label-public-staging/car/car_1.jpg"
+        r = requests.get(image_url, allow_redirects=True, timeout=10)
+        local_file_path = tmp_dir / Path("car_1.jpg")
+        local_file_path.open("wb").write(r.content)
+        _convert_kili_semantic_to_coco(
+            job_name=JobName(job_name),
+            assets=[get_asset(local_file_path, with_annotation=False)],
+            output_dir=Path(tmp_dir),
+            job={
+                "mlTask": "OBJECT_DETECTION",
+                "content": {
+                    "categories": {
+                        "OBJECT_A": {"name": "Object A"},
+                        "OBJECT_B": {"name": "Object B"},
+                    }
+                },
+                "instruction": "",
+                "isChild": False,
+                "isNew": False,
+                "isVisible": True,
+                "models": {},
+                "required": True,
+                "tools": ["semantic"],
+            },
+            title="Test project",
+        )
+
+        with output_file.open("r", encoding="utf-8") as f:
+            coco_annotation = json.loads(f.read())
+
+            assert "Test project" in coco_annotation["info"]["description"]
+            assert coco_annotation["images"][0]["file_name"] == "data/car_1.jpg"
+            assert coco_annotation["images"][0]["width"] == 1920
+            assert coco_annotation["images"][0]["height"] == 1080
+            assert len(coco_annotation["annotations"]) == 0

--- a/tests/services/export/test_coco.py
+++ b/tests/services/export/test_coco.py
@@ -3,6 +3,7 @@ import json
 from datetime import datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Dict
 
 import requests
 
@@ -17,40 +18,39 @@ def get_asset(content_path: Path, with_annotation: bool) -> Asset:
     # `annotations=[]` should not exist.
     json_response = {"author": {"firstname": "Jean-Pierre", "lastname": "Dupont"}}
     if with_annotation:
-        json_response.update(
-            {
-                "JOB_0": {
-                    "annotations": [
-                        {
-                            "categories": [{"confidence": 100, "name": "OBJECT_A"}],
-                            "jobName": "JOB_0",
-                            "mid": "2022040515434712-7532",
-                            "mlTask": "OBJECT_DETECTION",
-                            "boundingPoly": [
-                                {
-                                    "normalizedVertices": [
-                                        {
-                                            "x": 0.0,
-                                            "y": 0.0,
-                                        },
-                                        {
-                                            "x": 1.0,
-                                            "y": 0.0,
-                                        },
-                                        {
-                                            "x": 0.0,
-                                            "y": 1.0,
-                                        },
-                                    ]
-                                }
-                            ],
-                            "type": "semantic",
-                            "children": {},
-                        }
-                    ]
-                }
-            }
-        )
+        json_response = {
+            **json_response,
+            "JOB_0": {
+                "annotations": [
+                    {
+                        "categories": [{"confidence": 100, "name": "OBJECT_A"}],
+                        "jobName": "JOB_0",
+                        "mid": "2022040515434712-7532",
+                        "mlTask": "OBJECT_DETECTION",
+                        "boundingPoly": [
+                            {
+                                "normalizedVertices": [
+                                    {
+                                        "x": 0.0,
+                                        "y": 0.0,
+                                    },
+                                    {
+                                        "x": 1.0,
+                                        "y": 0.0,
+                                    },
+                                    {
+                                        "x": 0.0,
+                                        "y": 1.0,
+                                    },
+                                ]
+                            }
+                        ],
+                        "type": "semantic",
+                        "children": {},
+                    }
+                ]
+            },
+        }
 
     return Asset(
         {

--- a/tests/services/export/test_coco.py
+++ b/tests/services/export/test_coco.py
@@ -70,7 +70,7 @@ class CocoTestCase(TestCase):
             output_file = Path(tmp_dir) / job_name / "labels.json"
             image_url = "https://storage.googleapis.com/label-public-staging/car/car_1.jpg"
             r = requests.get(image_url, allow_redirects=True)
-            local_file_path = Path("car_1.jpg")
+            local_file_path = tmp_dir / Path("car_1.jpg")
             local_file_path.open("wb").write(r.content)
             _convert_kili_semantic_to_coco(
                 job_name=JobName(job_name),
@@ -164,7 +164,7 @@ class CocoTestCase(TestCase):
             output_file = Path(tmp_dir) / job_name / "labels.json"
             image_url = "https://storage.googleapis.com/label-public-staging/car/car_1.jpg"
             r = requests.get(image_url, allow_redirects=True, timeout=10)
-            local_file_path = Path("car_1.jpg")
+            local_file_path = tmp_dir / Path("car_1.jpg")
             local_file_path.open("wb").write(r.content)
             _convert_kili_semantic_to_coco(
                 job_name=JobName(job_name),

--- a/tests/services/export/test_coco.py
+++ b/tests/services/export/test_coco.py
@@ -15,6 +15,9 @@ from kili.services.types import JobName
 class CocoTestCase(TestCase):
     @staticmethod
     def get_asset(content_path: Path, with_annotation: bool) -> Asset:
+        # without annotation means that: there is a label for the asset
+        # but there is no labeling data for the job.
+        # `annotations=[]` should not exist.
         json_response = {"author": {"firstname": "Jean-Pierre", "lastname": "Dupont"}}
         if with_annotation:
             json_response.update(

--- a/tests/services/export/test_export.py
+++ b/tests/services/export/test_export.py
@@ -150,7 +150,7 @@ def get_file_tree(folder: str):
         ),
     ],
 )
-def test_export_service(name, test_case):
+def test_export_service_layout(name, test_case):
     with TemporaryDirectory() as export_folder:
         with TemporaryDirectory() as extract_folder:
             path_zipfile = Path(export_folder) / "export.zip"

--- a/tests/services/export/test_voc.py
+++ b/tests/services/export/test_voc.py
@@ -1,7 +1,10 @@
 from pathlib import Path
 
 from kili.services.export.format.voc import _convert_from_kili_to_voc_format
-from tests.services.export.fakes.fake_data import asset_image_1
+from tests.services.export.fakes.fake_data import (
+    asset_image_1,
+    asset_image_1_without_annotation,
+)
 
 
 def test__convert_from_kili_to_voc_format():
@@ -15,4 +18,18 @@ def test__convert_from_kili_to_voc_format():
     expected_annotations = Path("./tests/services/export/expected/car_1.xml").read_text(
         encoding="utf-8"
     )
+    assert annotations == expected_annotations
+
+
+def test__convert_from_kili_to_voc_format_no_annotation():
+    parameters = {"filename": f'{asset_image_1["externalId"]}.xml'}
+    annotations = _convert_from_kili_to_voc_format(
+        response=asset_image_1_without_annotation,
+        img_width=1920,
+        img_height=1080,
+        parameters=parameters,
+    )
+    expected_annotations = Path(
+        "./tests/services/export/expected/car_1_without_annotation.xml"
+    ).read_text(encoding="utf-8")
     assert annotations == expected_annotations

--- a/tests/services/export/test_yolo.py
+++ b/tests/services/export/test_yolo.py
@@ -12,6 +12,7 @@ from kili.utils.tempfile import TemporaryDirectory
 from tests.services.export.fakes.fake_content_repository import FakeContentRepository
 from tests.services.export.fakes.fake_data import (
     asset_image_1,
+    asset_image_1_without_label,
     asset_video,
     category_ids,
 )
@@ -89,6 +90,12 @@ class YoloTestCase(TestCase):
         ]
         assert len(converted_annotations) == 1
         assert converted_annotations == expected_annotations
+
+    def test_convert_from_kili_to_yolo_format_no_annotation(self):
+        converted_annotations = _convert_from_kili_to_yolo_format(
+            "JOB_0", asset_image_1_without_label["latestLabel"], category_ids
+        )
+        assert len(converted_annotations) == 0
 
     def test_write_class_file_yolo_v4(self):
         with TemporaryDirectory() as directory:

--- a/tests/services/export/test_yolo.py
+++ b/tests/services/export/test_yolo.py
@@ -12,7 +12,7 @@ from kili.utils.tempfile import TemporaryDirectory
 from tests.services.export.fakes.fake_content_repository import FakeContentRepository
 from tests.services.export.fakes.fake_data import (
     asset_image_1,
-    asset_image_1_without_label,
+    asset_image_1_without_annotation,
     asset_video,
     category_ids,
 )
@@ -93,7 +93,7 @@ class YoloTestCase(TestCase):
 
     def test_convert_from_kili_to_yolo_format_no_annotation(self):
         converted_annotations = _convert_from_kili_to_yolo_format(
-            "JOB_0", asset_image_1_without_label["latestLabel"], category_ids
+            "JOB_0", asset_image_1_without_annotation["latestLabel"], category_ids
         )
         assert len(converted_annotations) == 0
 


### PR DESCRIPTION
- tests: added failing test for COCO export when no annotations
- tests: added failing test for COCO export when no annotations
- tests: Yolo without annotations
- tests: Pascal VOC without annotations
- tests: file  written in tmp dir
- fix: COCO handles images without annotations
- tests: rm unittest
- fix: pyright
