### PR TITLE
feat: add external ids parameter to methods

### DIFF
--- a/src/kili/mutations/asset/__init__.py
+++ b/src/kili/mutations/asset/__init__.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, Union
 from typeguard import typechecked
 
 from kili.authentication import KiliAuth
+from kili.exceptions import MissingArgumentError
 from kili.helpers import format_result
 from kili.mutations.asset.helpers import process_update_properties_in_assets_parameters
 from kili.mutations.asset.queries import (
@@ -196,7 +197,7 @@ class MutationsAsset:
                 " `kili.change_asset_external_ids()` method instead to change asset external IDs.",
                 DeprecationWarning,
             )
-            raise ValueError("Please provide either `asset_ids` or `external_ids`.")
+            raise MissingArgumentError("Please provide either `asset_ids` or `external_ids`.")
 
         asset_ids = get_asset_ids_or_throw_error(self, asset_ids, external_ids, project_id)
 
@@ -253,14 +254,18 @@ class MutationsAsset:
     @typechecked
     def change_asset_external_ids(
         self,
-        asset_ids: List[str],
         new_external_ids: List[str],
+        asset_ids: Optional[List[str]] = None,
+        external_ids: Optional[List[str]] = None,
+        project_id: Optional[str] = None,
     ) -> List[Dict]:
-        """Update the names (external IDs) of one or more assets.
+        """Update the external IDs of one or more assets.
 
         Args:
-            asset_ids: The asset IDs to modify.
             new_external_ids: The new external IDs of the assets.
+            asset_ids: The asset IDs to modify.
+            external_ids: The external asset IDs to modify (if `asset_ids` is not already provided).
+            project_id: The project ID. Only required if `external_ids` argument is provided.
 
         Returns:
             A result object which indicates if the mutation was successful,
@@ -268,10 +273,11 @@ class MutationsAsset:
 
         Examples:
             >>> kili.change_asset_external_ids(
-                    asset_ids=["ckg22d81r0jrg0885unmuswj8", "ckg22d81s0jrh0885pdxfd03n"],
                     new_external_ids=["asset1", "asset2"],
+                    asset_ids=["ckg22d81r0jrg0885unmuswj8", "ckg22d81s0jrh0885pdxfd03n"],
                 )
         """
+        asset_ids = get_asset_ids_or_throw_error(self, asset_ids, external_ids, project_id)
 
         parameters = {
             "asset_ids": asset_ids,

--- a/src/kili/mutations/asset/__init__.py
+++ b/src/kili/mutations/asset/__init__.py
@@ -18,10 +18,10 @@ from kili.mutations.asset.queries import (
 )
 from kili.orm import Asset
 from kili.services.asset_import import import_assets
-from kili.services.helpers import infer_ids_from_external_ids
 from kili.utils.pagination import _mutate_from_paginated_call
 
 from ...queries.asset import QueriesAsset
+from .helpers import get_asset_ids_or_throw_error
 
 
 class MutationsAsset:
@@ -189,25 +189,16 @@ class MutationsAsset:
                     to_be_labeled_by_array=[['test+pierre@kili-technology.com'], None],
                 )
         """
-        if asset_ids is None and external_ids is None:
-            raise ValueError("Please provide either `asset_ids` or `external_ids`.")
-
         if asset_ids is not None and external_ids is not None:
             warnings.warn(
                 "The use of `external_ids` argument has changed. It is now used to identify which"
-                " properties of which assets to update. Please use `kili.rename_assets()` method"
-                " instead to change asset names (external IDs).",
+                " properties of which assets to update. Please use"
+                " `kili.change_asset_external_id()` method instead to change asset external IDs.",
                 DeprecationWarning,
             )
             raise ValueError("Please provide either `asset_ids` or `external_ids`.")
 
-        if external_ids is not None and asset_ids is None:
-            if project_id is None:
-                raise ValueError("Please provide `project_id` if `external_ids` is given.")
-            id_map = infer_ids_from_external_ids(
-                kili=self, asset_external_ids=external_ids, project_id=project_id
-            )
-            asset_ids = [id_map[id] for id in external_ids]
+        asset_ids = get_asset_ids_or_throw_error(self, asset_ids, external_ids, project_id)
 
         saved_args = locals()
         parameters = {
@@ -260,7 +251,7 @@ class MutationsAsset:
         return [item for batch_list in formated_results for item in batch_list]
 
     @typechecked
-    def rename_assets(
+    def change_asset_external_id(
         self,
         asset_ids: List[str],
         new_external_ids: List[str],
@@ -276,7 +267,7 @@ class MutationsAsset:
                 or an error message.
 
         Examples:
-            >>> kili.rename_assets(
+            >>> kili.change_asset_external_id(
                     asset_ids=["ckg22d81r0jrg0885unmuswj8", "ckg22d81s0jrh0885pdxfd03n"],
                     new_external_ids=["asset1", "asset2"],
                 )
@@ -330,16 +321,7 @@ class MutationsAsset:
             A result object which indicates if the mutation was successful,
                 or an error message.
         """
-        if asset_ids is None and external_ids is None:
-            raise ValueError("Please provide either `asset_ids` or `external_ids`.")
-
-        if external_ids is not None and asset_ids is None:
-            if project_id is None:
-                raise ValueError("Please provide `project_id` if `external_ids` is given.")
-            id_map = infer_ids_from_external_ids(
-                kili=self, asset_external_ids=external_ids, project_id=project_id
-            )
-            asset_ids = [id_map[id] for id in external_ids]
+        asset_ids = get_asset_ids_or_throw_error(self, asset_ids, external_ids, project_id)
 
         properties_to_batch: Dict[str, Optional[List[Any]]] = {"asset_ids": asset_ids}
 
@@ -381,16 +363,7 @@ class MutationsAsset:
                         ],
                 )
         """
-        if asset_ids is None and external_ids is None:
-            raise ValueError("Please provide either `asset_ids` or `external_ids`.")
-
-        if external_ids is not None and asset_ids is None:
-            if project_id is None:
-                raise ValueError("Please provide `project_id` if `external_ids` is given.")
-            id_map = infer_ids_from_external_ids(
-                kili=self, asset_external_ids=external_ids, project_id=project_id
-            )
-            asset_ids = [id_map[id] for id in external_ids]
+        asset_ids = get_asset_ids_or_throw_error(self, asset_ids, external_ids, project_id)
 
         properties_to_batch: Dict[str, Optional[List[Any]]] = {"asset_ids": asset_ids}
 
@@ -442,16 +415,7 @@ class MutationsAsset:
                         ],
                 )
         """
-        if asset_ids is None and external_ids is None:
-            raise ValueError("Please provide either `asset_ids` or `external_ids`.")
-
-        if external_ids is not None and asset_ids is None:
-            if project_id is None:
-                raise ValueError("Please provide `project_id` if `external_ids` is given.")
-            id_map = infer_ids_from_external_ids(
-                kili=self, asset_external_ids=external_ids, project_id=project_id
-            )
-            asset_ids = [id_map[id] for id in external_ids]
+        asset_ids = get_asset_ids_or_throw_error(self, asset_ids, external_ids, project_id)
 
         properties_to_batch: Dict[str, Optional[List[Any]]] = {"asset_ids": asset_ids}
 

--- a/src/kili/mutations/asset/__init__.py
+++ b/src/kili/mutations/asset/__init__.py
@@ -17,6 +17,7 @@ from kili.mutations.asset.queries import (
 )
 from kili.orm import Asset
 from kili.services.asset_import import import_assets
+from kili.services.helpers import infer_ids_from_external_ids
 from kili.utils.pagination import _mutate_from_paginated_call
 
 from ...queries.asset import QueriesAsset
@@ -240,16 +241,34 @@ class MutationsAsset:
         return [item for batch_list in formated_results for item in batch_list]
 
     @typechecked
-    def delete_many_from_dataset(self, asset_ids: List[str]) -> Asset:
+    def delete_many_from_dataset(
+        self,
+        asset_ids: Optional[List[str]] = None,
+        external_ids: Optional[List[str]] = None,
+        project_id: Optional[str] = None,
+    ) -> Asset:
         """Delete assets from a project.
 
         Args:
-            asset_ids: The list of identifiers of the assets to delete.
+            asset_ids: The list of asset internal IDs to delete.
+            external_ids: The list of asset external IDs to delete.
+            project_id: The project ID. Only required if `external_ids` argument is provided.
 
         Returns:
             A result object which indicates if the mutation was successful,
                 or an error message.
         """
+        if asset_ids is None and external_ids is None:
+            raise ValueError("Please provide either `asset_ids` or `external_ids`.")
+
+        if external_ids is not None and asset_ids is None:
+            if project_id is None:
+                raise ValueError("Please provide `project_id` if `external_ids` is given.")
+            id_map = infer_ids_from_external_ids(
+                kili=self, asset_external_ids=external_ids, project_id=project_id
+            )
+            asset_ids = [id_map[id] for id in external_ids]
+
         properties_to_batch: Dict[str, Optional[List[Any]]] = {"asset_ids": asset_ids}
 
         def generate_variables(batch):
@@ -261,14 +280,21 @@ class MutationsAsset:
         return format_result("data", results[0], Asset)
 
     @typechecked
-    def add_to_review(self, asset_ids: List[str]) -> Optional[Dict[str, Any]]:
+    def add_to_review(
+        self,
+        asset_ids: Optional[List[str]] = None,
+        external_ids: Optional[List[str]] = None,
+        project_id: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
         """Add assets to review.
 
         !!! warning
             Assets without any label will be ignored.
 
         Args:
-            asset_ids: The asset IDs to add to review.
+            asset_ids: The asset internal IDs to add to review.
+            external_ids: The asset external IDs to add to review.
+            project_id: The project ID. Only required if `external_ids` argument is provided.
 
         Returns:
             A dict object with the project `id` and the `asset_ids` of assets moved to review.
@@ -283,6 +309,17 @@ class MutationsAsset:
                         ],
                 )
         """
+        if asset_ids is None and external_ids is None:
+            raise ValueError("Please provide either `asset_ids` or `external_ids`.")
+
+        if external_ids is not None and asset_ids is None:
+            if project_id is None:
+                raise ValueError("Please provide `project_id` if `external_ids` is given.")
+            id_map = infer_ids_from_external_ids(
+                kili=self, asset_external_ids=external_ids, project_id=project_id
+            )
+            asset_ids = [id_map[id] for id in external_ids]
+
         properties_to_batch: Dict[str, Optional[List[Any]]] = {"asset_ids": asset_ids}
 
         def generate_variables(batch):
@@ -308,11 +345,18 @@ class MutationsAsset:
         return result
 
     @typechecked
-    def send_back_to_queue(self, asset_ids: List[str]) -> Dict[str, Any]:
+    def send_back_to_queue(
+        self,
+        asset_ids: Optional[List[str]] = None,
+        external_ids: Optional[List[str]] = None,
+        project_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """Send assets back to queue.
 
         Args:
-            asset_ids: The IDs of the assets to send back to queue.
+            asset_ids: List of internal IDs of assets to send back to queue.
+            external_ids: List of external IDs of assets to send back to queue.
+            project_id: The project ID. Only required if `external_ids` argument is provided.
 
         Returns:
             A dict object with the project `id` and the `asset_ids` of assets moved to queue.
@@ -326,6 +370,17 @@ class MutationsAsset:
                         ],
                 )
         """
+        if asset_ids is None and external_ids is None:
+            raise ValueError("Please provide either `asset_ids` or `external_ids`.")
+
+        if external_ids is not None and asset_ids is None:
+            if project_id is None:
+                raise ValueError("Please provide `project_id` if `external_ids` is given.")
+            id_map = infer_ids_from_external_ids(
+                kili=self, asset_external_ids=external_ids, project_id=project_id
+            )
+            asset_ids = [id_map[id] for id in external_ids]
+
         properties_to_batch: Dict[str, Optional[List[Any]]] = {"asset_ids": asset_ids}
 
         def generate_variables(batch):

--- a/src/kili/mutations/asset/__init__.py
+++ b/src/kili/mutations/asset/__init__.py
@@ -193,7 +193,7 @@ class MutationsAsset:
             warnings.warn(
                 "The use of `external_ids` argument has changed. It is now used to identify which"
                 " properties of which assets to update. Please use"
-                " `kili.change_asset_external_id()` method instead to change asset external IDs.",
+                " `kili.change_asset_external_ids()` method instead to change asset external IDs.",
                 DeprecationWarning,
             )
             raise ValueError("Please provide either `asset_ids` or `external_ids`.")
@@ -251,7 +251,7 @@ class MutationsAsset:
         return [item for batch_list in formated_results for item in batch_list]
 
     @typechecked
-    def change_asset_external_id(
+    def change_asset_external_ids(
         self,
         asset_ids: List[str],
         new_external_ids: List[str],
@@ -267,7 +267,7 @@ class MutationsAsset:
                 or an error message.
 
         Examples:
-            >>> kili.change_asset_external_id(
+            >>> kili.change_asset_external_ids(
                     asset_ids=["ckg22d81r0jrg0885unmuswj8", "ckg22d81s0jrh0885pdxfd03n"],
                     new_external_ids=["asset1", "asset2"],
                 )

--- a/src/kili/mutations/asset/helpers.py
+++ b/src/kili/mutations/asset/helpers.py
@@ -47,9 +47,10 @@ def get_asset_ids_or_throw_error(
     """
     check_asset_identifier_arguments(project_id, asset_ids, external_ids)
 
-    id_map = infer_ids_from_external_ids(
-        kili=kili, asset_external_ids=external_ids, project_id=project_id  # type: ignore
-    )
-    asset_ids = [id_map[id] for id in external_ids]  # type: ignore
+    if asset_ids is None:
+        id_map = infer_ids_from_external_ids(
+            kili=kili, asset_external_ids=external_ids, project_id=project_id  # type: ignore
+        )
+        asset_ids = [id_map[id] for id in external_ids]  # type: ignore
 
-    return asset_ids  # type: ignore
+    return asset_ids

--- a/src/kili/mutations/asset/helpers.py
+++ b/src/kili/mutations/asset/helpers.py
@@ -1,7 +1,9 @@
 """
 Helpers for the asset mutations
 """
-from typing import Dict
+from typing import Dict, List, Optional
+
+from kili.services.helpers import infer_ids_from_external_ids
 
 from ...helpers import convert_to_list_of_none, format_metadata, is_none_or_empty
 
@@ -31,3 +33,26 @@ def process_update_properties_in_assets_parameters(properties) -> Dict:
         map(is_none_or_empty, properties["to_be_labeled_by_array"])
     )
     return properties
+
+
+def get_asset_ids_or_throw_error(
+    kili,
+    asset_ids: Optional[List[str]] = None,
+    external_ids: Optional[List[str]] = None,
+    project_id: Optional[str] = None,
+) -> List[str]:
+    """
+    Check if external id to internal id is valid and needed.
+    """
+    if asset_ids is None and external_ids is None:
+        raise ValueError("Please provide either `asset_ids` or `external_ids`.")
+
+    if external_ids is not None and asset_ids is None:
+        if project_id is None:
+            raise ValueError("Please provide `project_id` if `external_ids` is given.")
+        id_map = infer_ids_from_external_ids(
+            kili=kili, asset_external_ids=external_ids, project_id=project_id
+        )
+        asset_ids = [id_map[id] for id in external_ids]
+
+    return asset_ids

--- a/src/kili/mutations/asset/helpers.py
+++ b/src/kili/mutations/asset/helpers.py
@@ -3,6 +3,7 @@ Helpers for the asset mutations
 """
 from typing import Dict, List, Optional
 
+from kili.mutations.helpers import check_asset_identifier_arguments
 from kili.services.helpers import infer_ids_from_external_ids
 
 from ...helpers import convert_to_list_of_none, format_metadata, is_none_or_empty
@@ -37,22 +38,18 @@ def process_update_properties_in_assets_parameters(properties) -> Dict:
 
 def get_asset_ids_or_throw_error(
     kili,
-    asset_ids: Optional[List[str]] = None,
-    external_ids: Optional[List[str]] = None,
-    project_id: Optional[str] = None,
+    asset_ids: Optional[List[str]],
+    external_ids: Optional[List[str]],
+    project_id: Optional[str],
 ) -> List[str]:
     """
-    Check if external id to internal id is valid and needed.
+    Check if external id to internal id conversion is valid and needed.
     """
-    if asset_ids is None and external_ids is None:
-        raise ValueError("Please provide either `asset_ids` or `external_ids`.")
+    check_asset_identifier_arguments(project_id, asset_ids, external_ids)
 
-    if external_ids is not None and asset_ids is None:
-        if project_id is None:
-            raise ValueError("Please provide `project_id` if `external_ids` is given.")
-        id_map = infer_ids_from_external_ids(
-            kili=kili, asset_external_ids=external_ids, project_id=project_id
-        )
-        asset_ids = [id_map[id] for id in external_ids]
+    id_map = infer_ids_from_external_ids(
+        kili=kili, asset_external_ids=external_ids, project_id=project_id  # type: ignore
+    )
+    asset_ids = [id_map[id] for id in external_ids]  # type: ignore
 
     return asset_ids  # type: ignore

--- a/src/kili/mutations/asset/helpers.py
+++ b/src/kili/mutations/asset/helpers.py
@@ -55,4 +55,4 @@ def get_asset_ids_or_throw_error(
         )
         asset_ids = [id_map[id] for id in external_ids]
 
-    return asset_ids
+    return asset_ids  # type: ignore

--- a/src/kili/mutations/helpers.py
+++ b/src/kili/mutations/helpers.py
@@ -11,15 +11,18 @@ def check_asset_identifier_arguments(
     asset_id_array: Optional[List[str]],
     asset_external_id_array: Optional[List[str]],
 ):
-    "Check that a list of assets can be identified either by their asset ids or their external Ids"
+    """
+    Check that a list of assets can be identified either by their asset IDs or their external IDs
+    """
+
     if asset_id_array is not None:
         if asset_external_id_array is not None:
             raise IncompatibleArgumentsError(
-                "Either provide asset ids or asset external ids. Not Both at the same time"
+                "Either provide asset IDs or asset external IDs. Not both at the same time."
             )
         return True
     if project_id is None or asset_external_id_array is None:
         raise MissingArgumentError(
-            "Either provide asset_id_array or project_id and asset_external_id_array"
+            "Either provide asset IDs or project ID with asset external IDs."
         )
     return True

--- a/src/kili/mutations/label/__init__.py
+++ b/src/kili/mutations/label/__init__.py
@@ -41,20 +41,22 @@ class MutationsLabel:
     def create_predictions(
         self,
         project_id: str,
-        external_id_array: List[str],
+        external_id_array: Optional[List[str]] = None,
         model_name_array: Optional[List[str]] = None,
         json_response_array: Optional[List[dict]] = None,
         model_name: Optional[str] = None,
+        asset_id_array: Optional[List[str]] = None,
     ) -> dict:
         # pylint: disable=line-too-long
         """Create predictions for specific assets.
 
         Args:
-            project_id: Identifier of the project
-            external_id_array: The external identifiers of the assets for which we want to add predictions
-            model_name_array: In case you want to precise from which model the label originated
+            project_id: Identifier of the project.
+            external_id_array: The external IDs of the assets for which we want to add predictions.
+            model_name_array: In case you want to precise from which model the label originated.
             json_response_array: The predictions are given here. For examples,
                 see [the recipe](https://docs.kili-technology.com/recipes/importing-labels-and-predictions).
+            asset_id_array: The internal IDs of the assets for which we want to add predictions.
 
         Returns:
             A result object which indicates if the mutation was successful, or an error message.
@@ -67,11 +69,7 @@ class MutationsLabel:
                 "json_response_array is empty, you must provide at least one prediction to upload"
             )
         assert_all_arrays_have_same_size(
-            [
-                external_id_array,
-                json_response_array,
-                model_name_array,
-            ]
+            [external_id_array, json_response_array, model_name_array, asset_id_array]
         )
         if model_name is None:
             if model_name_array is None:
@@ -91,11 +89,13 @@ class MutationsLabel:
 
         labels = [
             {
+                "asset_id": asset_id,
                 "asset_external_id": asset_external_id,
                 "json_response": json_response,
             }
-            for (asset_external_id, json_response) in list(
+            for (asset_id, asset_external_id, json_response) in list(
                 zip(
+                    asset_id_array or [None] * len(json_response_array),
                     external_id_array or [None] * len(json_response_array),
                     json_response_array,
                 )
@@ -187,13 +187,15 @@ class MutationsLabel:
         """Append labels to assets.
 
         Args:
-            asset_id_array: list of asset ids to append labels on
+            asset_id_array: list of asset internal ids to append labels on
             json_response_array: list of labels to append
             author_id_array: list of the author id of the labels
             seconds_to_label_array: list of times taken to produce the label, in seconds
             model_name: Only useful when uploading predictions.
                 Name of the model when uploading predictions
             label_type: Can be one of `AUTOSAVE`, `DEFAULT`, `PREDICTION`, `REVIEW` or `INFERENCE`
+            project_id: Identifier of the project
+            asset_external_id_array: list of asset external ids to append labels on
 
         Returns:
             A result object which indicates if the mutation was successful,

--- a/src/kili/mutations/label/__init__.py
+++ b/src/kili/mutations/label/__init__.py
@@ -11,7 +11,7 @@ from typeguard import typechecked
 from kili import services
 from kili.enums import LabelType
 from kili.helpers import deprecate, format_result
-from kili.mutations.label.helpers import check_asset_identifier_arguments
+from kili.mutations.helpers import check_asset_identifier_arguments
 from kili.mutations.label.queries import (
     GQL_APPEND_TO_LABELS,
     GQL_CREATE_HONEYPOT,

--- a/src/kili/queries/label/__init__.py
+++ b/src/kili/queries/label/__init__.py
@@ -6,7 +6,6 @@ import pandas as pd
 from typeguard import typechecked
 
 from kili import services
-from kili.client import KiliAuth
 from kili.constants import NO_ACCESS_RIGHT
 from kili.helpers import format_result, fragment_builder, validate_category_search_query
 from kili.queries.asset import QueriesAsset
@@ -25,7 +24,7 @@ class QueriesLabel:
 
     # pylint: disable=too-many-arguments,too-many-locals
 
-    def __init__(self, auth: KiliAuth):
+    def __init__(self, auth):
         """Initialize the subclass.
 
         Args:

--- a/src/kili/services/helpers.py
+++ b/src/kili/services/helpers.py
@@ -48,9 +48,13 @@ def is_target_job_in_json_interface(kili, project_id: str, target_job_name: str)
     return target_job_name in json_interface["jobs"]
 
 
-def infer_ids_from_external_ids(kili, asset_external_ids: List[str], project_id: str):
+def infer_ids_from_external_ids(
+    kili, asset_external_ids: List[str], project_id: str
+) -> Dict[str, str]:
     """
-    Infer asset ids from their external ids and project Id
+    Infer asset ids from their external ids and project Id.
+
+    Returns a dict that maps external ids to internal ids.
 
     Args:
         asset_id: asset id

--- a/tests/e2e/test_mutations_asset.py
+++ b/tests/e2e/test_mutations_asset.py
@@ -102,10 +102,10 @@ def test_send_back_to_queue(kili, src_project):
     assert sorted(ret["asset_ids"]) == sorted(asset_ids[:2])
 
 
-def test_change_asset_external_id(kili, src_project):
+def test_change_asset_external_ids(kili, src_project):
     assets = kili.assets(src_project["id"], fields=["id"])
     asset_ids = [asset["id"] for asset in assets]
-    ret = kili.change_asset_external_id(asset_ids[:2], new_external_ids=["111", "222"])
+    ret = kili.change_asset_external_ids(asset_ids[:2], new_external_ids=["111", "222"])
 
     assert len(ret) == 2
     assert sorted([asset["id"] for asset in ret]) == sorted(asset_ids[:2])

--- a/tests/e2e/test_mutations_asset.py
+++ b/tests/e2e/test_mutations_asset.py
@@ -130,12 +130,12 @@ def test_update_properties_in_assets_external_id(kili, src_project):
 
     ret = kili.update_properties_in_assets(
         external_ids=[asset["externalId"] for asset in assets],
-        is_honeypot_array=[True, False, False],
+        priorities=[1, 0, 0],
         project_id=src_project["id"],
     )
     assert len(ret) == 3
 
-    assets_new = kili.assets(src_project["id"], fields=["id", "externalId", "isHoneypot"])
+    assets_new = kili.assets(src_project["id"], fields=["id", "externalId", "priority"])
 
     assert [asset["externalId"] for asset in assets_new] == ["1", "2", "3"]
-    assert [asset["isHoneypot"] for asset in assets_new] == [True, False, False]
+    assert [asset["priority"] for asset in assets_new] == [1, 0, 0]

--- a/tests/e2e/test_mutations_asset.py
+++ b/tests/e2e/test_mutations_asset.py
@@ -105,7 +105,7 @@ def test_send_back_to_queue(kili, src_project):
 def test_change_asset_external_ids(kili, src_project):
     assets = kili.assets(src_project["id"], fields=["id"])
     asset_ids = [asset["id"] for asset in assets]
-    ret = kili.change_asset_external_ids(asset_ids[:2], new_external_ids=["111", "222"])
+    ret = kili.change_asset_external_ids(asset_ids=asset_ids[:2], new_external_ids=["111", "222"])
 
     assert len(ret) == 2
     assert sorted([asset["id"] for asset in ret]) == sorted(asset_ids[:2])

--- a/tests/e2e/test_mutations_asset.py
+++ b/tests/e2e/test_mutations_asset.py
@@ -102,10 +102,10 @@ def test_send_back_to_queue(kili, src_project):
     assert sorted(ret["asset_ids"]) == sorted(asset_ids[:2])
 
 
-def test_rename_assets(kili, src_project):
+def test_change_asset_external_id(kili, src_project):
     assets = kili.assets(src_project["id"], fields=["id"])
     asset_ids = [asset["id"] for asset in assets]
-    ret = kili.rename_assets(asset_ids[:2], new_external_ids=["111", "222"])
+    ret = kili.change_asset_external_id(asset_ids[:2], new_external_ids=["111", "222"])
 
     assert len(ret) == 2
     assert sorted([asset["id"] for asset in ret]) == sorted(asset_ids[:2])

--- a/tests/e2e/test_mutations_asset.py
+++ b/tests/e2e/test_mutations_asset.py
@@ -100,3 +100,42 @@ def test_send_back_to_queue(kili, src_project):
 
     assert ret["id"] == src_project["id"]
     assert sorted(ret["asset_ids"]) == sorted(asset_ids[:2])
+
+
+def test_rename_assets(kili, src_project):
+    assets = kili.assets(src_project["id"], fields=["id"])
+    asset_ids = [asset["id"] for asset in assets]
+    ret = kili.rename_assets(asset_ids[:2], new_external_ids=["111", "222"])
+
+    assert len(ret) == 2
+    assert sorted([asset["id"] for asset in ret]) == sorted(asset_ids[:2])
+
+    assets = kili.assets(src_project["id"], fields=["externalId"])
+    assert sorted([asset["externalId"] for asset in assets]) == ["111", "222", "3"]
+
+
+def test_update_properties_in_assets_errors(kili):
+    with pytest.raises(ValueError):
+        kili.update_properties_in_assets(asset_ids=None, external_ids=None)
+
+    with pytest.raises(ValueError):
+        kili.update_properties_in_assets(asset_ids=["1"], external_ids=["1"])
+
+    with pytest.raises(ValueError):
+        kili.update_properties_in_assets(asset_ids=None, external_ids=["1"], project_id=None)
+
+
+def test_update_properties_in_assets_external_id(kili, src_project):
+    assets = kili.assets(src_project["id"], fields=["id", "externalId"])
+
+    ret = kili.update_properties_in_assets(
+        external_ids=[asset["externalId"] for asset in assets],
+        is_honeypot_array=[True, False, False],
+        project_id=src_project["id"],
+    )
+    assert len(ret) == 3
+
+    assets_new = kili.assets(src_project["id"], fields=["id", "externalId", "isHoneypot"])
+
+    assert [asset["externalId"] for asset in assets_new] == ["1", "2", "3"]
+    assert [asset["isHoneypot"] for asset in assets_new] == [True, False, False]


### PR DESCRIPTION
TODO:
- [x] export_labels : there is asset_ids , necessary → external_ids
- [x] append_labels : asset_id_array → external_id_array
- [x] create_predictions : add asset_id_array
- [x] add_to_review : add external_ids
- [x] delete_many_from_dataset : add external_ids
- [x] send_back_to_queue : add external_ids
- [x] update_properties_in_assets : ⚠️ external_ids should be used for another purpose ⇒ create new method `change_asset_external_ids()`

For `update_properties_in_assets`, if both `external_ids` and `asset_ids` are provided, it raises and says we can't provide both anymore.
