### PR TITLE
fix: add metadataType in Project type

### DIFF
--- a/src/kili/types.py
+++ b/src/kili/types.py
@@ -141,6 +141,7 @@ class ProjectWithoutDataset(TypedDict, total=False):
     interface: Dict
     interfaceCompute: Dict
     jsonInterface: Dict
+    metadataTypes: Dict
     minConsensusSize: int
     mlTasks: str
     mlTasksCompute: str


### PR DESCRIPTION
@Jonas1312 Here is the cause.
When executing the mutation, it returns a Project. Then we query the new project to have the fields changed.
When a user ask for fields to query, we compare it the the object type define in kili/types to warn him if he asks a wrong field and do not launch the query to the backend. Here we just didn't add the metadataTypes in the Project Type so the query is refused.
This error is new because the fact that we do a query in update_properties_in_project is new