### PR TITLE
ci: increase timeout for unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           pylint src/kili
   unittest:
     runs-on: ubuntu-latest
-    timeout-minutes: 4
+    timeout-minutes: 6
     name: Unit tests
     strategy:
       matrix:


### PR DESCRIPTION
python 3.11 tests take more than 4 minutes sometimes: https://github.com/kili-technology/kili-python-sdk/actions/runs/3872411293