### PR TITLE
ci: increase timeout for e2e tests

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -7,7 +7,7 @@ on:
       - master
 jobs:
   recipes:
-    timeout-minutes: 13
+    timeout-minutes: 15
     name: Recipes test
     strategy:
       matrix:


### PR DESCRIPTION
e2e tests on windows take a bit longer:
- https://github.com/kili-technology/kili-python-sdk/actions/runs/3874197594/jobs/6605106175
- https://github.com/kili-technology/kili-python-sdk/actions/runs/3873949154/jobs/6604567448