### PR TITLE
fix: fix bug in `export_labels`

### DIFF
--- a/src/kili/services/export/__init__.py
+++ b/src/kili/services/export/__init__.py
@@ -36,7 +36,7 @@ def export_labels(  # pylint: disable=too-many-arguments, too-many-locals
     """
     Export the selected assets into the required format, and save it into a file archive.
     """
-    get_project(kili.auth.client, project_id, ["id"])
+    get_project(kili, project_id, ["id"])
 
     if with_assets:
         count = kili.count_assets(project_id)


### PR DESCRIPTION
```python
kili.export_labels("clcrqd3sl0ajz0lnbc3tt43nf", "export_coco.zip", fmt="coco")
```

gives: `AttributeError: 'GraphQLClient' object has no attribute 'auth'`

`get_project` expects `kili` but got `kili.auth.client`

```python
def get_project(kili, project_id: str, fields: List[str]):
    """Get a project from its id or raise a NotFound Error if not found"""
    projects = cast(
        List[Dict],
        ProjectQuery(kili.auth.client)(  # CRASH HERE
            ProjectWhere(project_id=project_id), fields, QueryOptions(disable_tqdm=True)
        ),
    )
    if len(projects) == 0:
        raise NotFound(
            f"project ID: {project_id}. Maybe your KILI_API_KEY does not belong to a member of the"
            " project."
        )
    return projects[0]
```