### PR TITLE
test: fix windows unit testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,18 @@ jobs:
         run: |
           pylint src/kili
   unittest:
-    runs-on: ubuntu-latest
     timeout-minutes: 6
     name: Unit tests
     strategy:
       matrix:
-        python-version: ["3.7", "3.11"]
+        include:
+          - os: ubuntu-latest
+            python-version: 3.7
+          - os: windows-latest
+            python-version: 3.7
+          - os: ubuntu-latest
+            python-version: 3.11
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           pylint src/kili
   unittest:
-    timeout-minutes: 6
+    timeout-minutes: 9
     name: Unit tests
     strategy:
       matrix:

--- a/src/kili/services/export/format/base.py
+++ b/src/kili/services/export/format/base.py
@@ -125,7 +125,8 @@ class AbstractExporter(ABC):  # pylint: disable=too-many-instance-attributes
         Write remote content file
         """
         remote_content_header = ["external id", "url", "label file"]
-        with (images_folder / "remote_assets.csv").open("w", encoding="utf8") as file:
+        # newline="" to disable universal newlines translation (bug fix for windows)
+        with (images_folder / "remote_assets.csv").open("w", newline="", encoding="utf8") as file:
             writer = csv.writer(file)
             writer.writerow(remote_content_header)
             writer.writerows(remote_content)

--- a/src/kili/services/export/format/coco/__init__.py
+++ b/src/kili/services/export/format/coco/__init__.py
@@ -227,7 +227,7 @@ def _get_coco_images_and_annotations(
         coco_image = _CocoImage(
             id=asset_i,
             license=0,
-            file_name=str("data" / Path(file_name.parts[-1])),
+            file_name=str("data" + "/" + file_name.parts[-1]),
             height=height,
             width=width,
             date_captured=None,

--- a/src/kili/services/label_import/parser/__init__.py
+++ b/src/kili/services/label_import/parser/__init__.py
@@ -41,6 +41,8 @@ class YoloLabelParser(AbstractLabelParser):  # pylint: disable=too-few-public-me
         with open(label_file, "r", encoding="ascii") as l_f:
             csv_reader = csv.reader(l_f, delimiter=" ")
             for row in csv_reader:
+                if len(row) == 0:
+                    continue
                 vertices, category, proba = self._parse(row)
                 annotations.append(
                     {

--- a/tests/cli/project/test_project.py
+++ b/tests/cli/project/test_project.py
@@ -2,6 +2,7 @@
 
 import csv
 import os
+from pathlib import Path
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
@@ -75,7 +76,10 @@ class TestCLIProject:
                 "case_name": (
                     "AAU, when I import a list of file to an image project, I see a success"
                 ),
-                "files": ["test_tree/image1.png", "test_tree/leaf/image3.png"],
+                "files": [
+                    str(Path("test_tree") / "image1.png"),
+                    str(Path("test_tree") / "leaf" / "image3.png"),
+                ],
                 "options": {
                     "project-id": "image_project",
                 },
@@ -84,11 +88,11 @@ class TestCLIProject:
                     "image_project",
                     [
                         {
-                            "content": "test_tree/image1.png",
+                            "content": str(Path("test_tree") / "image1.png"),
                             "external_id": "image1",
                         },
                         {
-                            "content": "test_tree/leaf/image3.png",
+                            "content": str(Path("test_tree") / "leaf" / "image3.png"),
                             "external_id": "image3",
                         },
                     ],
@@ -97,7 +101,10 @@ class TestCLIProject:
             },
             {
                 "case_name": "AAU, when I import files with stars, I see a success",
-                "files": ["test_tree/**.jpg", "test_tree/leaf/**.jpg"],
+                "files": [
+                    str(Path("test_tree") / "**.jpg"),
+                    str(Path("test_tree") / "leaf" / "**.jpg"),
+                ],
                 "options": {
                     "project-id": "image_project",
                 },
@@ -106,11 +113,11 @@ class TestCLIProject:
                     "image_project",
                     [
                         {
-                            "content": "test_tree/image2.jpg",
+                            "content": str(Path("test_tree") / "image2.jpg"),
                             "external_id": "image2",
                         },
                         {
-                            "content": "test_tree/leaf/image4.jpg",
+                            "content": str(Path("test_tree") / "leaf" / "image4.jpg"),
                             "external_id": "image4",
                         },
                     ],
@@ -119,20 +126,29 @@ class TestCLIProject:
             },
             {
                 "case_name": "AAU, when I import a files to a text project, I see a success",
-                "files": ["test_tree/", "test_tree/leaf"],
+                "files": [str(Path("test_tree/")), str(Path("test_tree") / "leaf")],
                 "options": {"project-id": "text_project"},
                 "expected_service_payload": (
                     ANY,
                     "text_project",
                     [
-                        {"content": "test_tree/image1.png", "external_id": "image1"},
-                        {"content": "test_tree/image2.jpg", "external_id": "image2"},
-                        {"content": "test_tree/leaf/image3.png", "external_id": "image3"},
-                        {"content": "test_tree/leaf/image4.jpg", "external_id": "image4"},
-                        {"content": "test_tree/leaf/texte2.txt", "external_id": "texte2"},
-                        {"content": "test_tree/texte1.txt", "external_id": "texte1"},
-                        {"content": "test_tree/video1.mp4", "external_id": "video1"},
-                        {"content": "test_tree/video2.mp4", "external_id": "video2"},
+                        {"content": str(Path("test_tree") / "image1.png"), "external_id": "image1"},
+                        {"content": str(Path("test_tree") / "image2.jpg"), "external_id": "image2"},
+                        {
+                            "content": str(Path("test_tree") / "leaf" / "image3.png"),
+                            "external_id": "image3",
+                        },
+                        {
+                            "content": str(Path("test_tree") / "leaf" / "image4.jpg"),
+                            "external_id": "image4",
+                        },
+                        {
+                            "content": str(Path("test_tree") / "leaf" / "texte2.txt"),
+                            "external_id": "texte2",
+                        },
+                        {"content": str(Path("test_tree") / "texte1.txt"), "external_id": "texte1"},
+                        {"content": str(Path("test_tree") / "video1.mp4"), "external_id": "video1"},
+                        {"content": str(Path("test_tree") / "video2.mp4"), "external_id": "video2"},
                     ],
                     ANY,
                 ),
@@ -142,7 +158,7 @@ class TestCLIProject:
                     "AAU, when I import videos to a video project, as native by changing the fps, I"
                     " see a success"
                 ),
-                "files": ["test_tree/"],
+                "files": [str(Path("test_tree/"))],
                 "options": {
                     "project-id": "frame_project",
                     "fps": "10",
@@ -152,7 +168,7 @@ class TestCLIProject:
                     "frame_project",
                     [
                         {
-                            "content": "test_tree/image1.png",
+                            "content": str(Path("test_tree") / "image1.png"),
                             "external_id": "image1",
                             "json_metadata": {
                                 "processingParameters": {
@@ -163,7 +179,7 @@ class TestCLIProject:
                             },
                         },
                         {
-                            "content": "test_tree/image2.jpg",
+                            "content": str(Path("test_tree") / "image2.jpg"),
                             "external_id": "image2",
                             "json_metadata": {
                                 "processingParameters": {
@@ -174,7 +190,7 @@ class TestCLIProject:
                             },
                         },
                         {
-                            "content": "test_tree/texte1.txt",
+                            "content": str(Path("test_tree") / "texte1.txt"),
                             "external_id": "texte1",
                             "json_metadata": {
                                 "processingParameters": {
@@ -185,7 +201,7 @@ class TestCLIProject:
                             },
                         },
                         {
-                            "content": "test_tree/video1.mp4",
+                            "content": str(Path("test_tree") / "video1.mp4"),
                             "external_id": "video1",
                             "json_metadata": {
                                 "processingParameters": {
@@ -196,7 +212,7 @@ class TestCLIProject:
                             },
                         },
                         {
-                            "content": "test_tree/video2.mp4",
+                            "content": str(Path("test_tree") / "video2.mp4"),
                             "external_id": "video2",
                             "json_metadata": {
                                 "processingParameters": {
@@ -215,7 +231,7 @@ class TestCLIProject:
                     "AAU, when I import videos to a video project, as frames with the native frame"
                     " rate, I see a success"
                 ),
-                "files": ["test_tree/"],
+                "files": [str(Path("test_tree/"))],
                 "options": {
                     "project-id": "frame_project",
                 },
@@ -225,7 +241,7 @@ class TestCLIProject:
                     "frame_project",
                     [
                         {
-                            "content": "test_tree/image1.png",
+                            "content": str(Path("test_tree") / "image1.png"),
                             "external_id": "image1",
                             "json_metadata": {
                                 "processingParameters": {
@@ -236,7 +252,7 @@ class TestCLIProject:
                             },
                         },
                         {
-                            "content": "test_tree/image2.jpg",
+                            "content": str(Path("test_tree") / "image2.jpg"),
                             "external_id": "image2",
                             "json_metadata": {
                                 "processingParameters": {
@@ -247,7 +263,7 @@ class TestCLIProject:
                             },
                         },
                         {
-                            "content": "test_tree/texte1.txt",
+                            "content": str(Path("test_tree") / "texte1.txt"),
                             "external_id": "texte1",
                             "json_metadata": {
                                 "processingParameters": {
@@ -258,7 +274,7 @@ class TestCLIProject:
                             },
                         },
                         {
-                            "content": "test_tree/video1.mp4",
+                            "content": str(Path("test_tree") / "video1.mp4"),
                             "external_id": "video1",
                             "json_metadata": {
                                 "processingParameters": {
@@ -269,7 +285,7 @@ class TestCLIProject:
                             },
                         },
                         {
-                            "content": "test_tree/video2.mp4",
+                            "content": str(Path("test_tree") / "video2.mp4"),
                             "external_id": "video2",
                             "json_metadata": {
                                 "processingParameters": {
@@ -295,7 +311,7 @@ class TestCLIProject:
                     "image_project",
                     [
                         {
-                            "content": "test_tree/leaf/image3.png",
+                            "content": str(Path("test_tree") / "leaf" / "image3.png"),
                             "external_id": "image3",
                         },
                         {
@@ -326,7 +342,7 @@ class TestCLIProject:
             with open("assets_to_import.csv", "w", newline="") as f:
                 writer = csv.writer(f)
                 writer.writerow(["external_id", "content"])
-                writer.writerow(["image3", "test_tree/leaf/image3.png"])
+                writer.writerow(["image3", str(Path("test_tree") / "leaf" / "image3.png")])
                 writer.writerow(
                     [
                         "test",

--- a/tests/cli/project/test_project.py
+++ b/tests/cli/project/test_project.py
@@ -322,7 +322,8 @@ class TestCLIProject:
             open("test_tree/leaf/image3.png", "w")
             open("test_tree/leaf/image4.jpg", "w")
             open("test_tree/leaf/texte2.txt", "w")
-            with open("assets_to_import.csv", "w") as f:
+            # newline="" to disable universal newlines translation (bug fix for windows)
+            with open("assets_to_import.csv", "w", newline="") as f:
                 writer = csv.writer(f)
                 writer.writerow(["external_id", "content"])
                 writer.writerow(["image3", "test_tree/leaf/image3.png"])

--- a/tests/cli/project/test_project_member.py
+++ b/tests/cli/project/test_project_member.py
@@ -161,8 +161,9 @@ class TestCLIProjectMember:
         ]
         runner = CliRunner()
         with runner.isolated_filesystem():
-            # pylint: disable=unspecified-encodind
-            with open("user_list.csv", "w") as f:
+            # pylint: disable=unspecified-encoding
+            with open("user_list.csv", "w", newline="") as f:
+                # newline="" to disable universal newlines translation (bug fix for windows)
                 writer = csv.writer(f)
                 writer.writerow(["email"])
                 writer.writerow(["alice@test.com"])
@@ -224,8 +225,9 @@ class TestCLIProjectMember:
         ]
         runner = CliRunner()
         with runner.isolated_filesystem():
-            # pylint: disable=unspecified-encodind
-            with open("user_list.csv", "w") as f:
+            # pylint: disable=unspecified-encoding
+            # newline="" to disable universal newlines translation (bug fix for windows)
+            with open("user_list.csv", "w", newline="") as f:
                 writer = csv.writer(f)
                 writer.writerow(["email"])
                 writer.writerow(["john.doe@test.com"])
@@ -281,8 +283,9 @@ class TestCLIProjectMember:
         ]
         runner = CliRunner()
         with runner.isolated_filesystem():
-            # pylint: disable=unspecified-encodind
-            with open("user_list.csv", "w") as f:
+            # pylint: disable=unspecified-encoding
+            # newline="" to disable universal newlines translation (bug fix for windows)
+            with open("user_list.csv", "w", newline="") as f:
                 writer = csv.writer(f)
                 writer.writerow(["email"])
                 writer.writerow(["john.doe@test.com"])

--- a/tests/services/export/test_export.py
+++ b/tests/services/export/test_export.py
@@ -43,7 +43,7 @@ def get_file_tree(folder: str):
     ]
     for f_p in filepaths:
         p = dct
-        for x in f_p.split("/"):
+        for x in f_p.split(os.sep):
             if len(x):
                 p = p.setdefault(x, {})
     return dct

--- a/tests/services/export/test_yolo.py
+++ b/tests/services/export/test_yolo.py
@@ -103,22 +103,22 @@ class YoloTestCase(TestCase):
         with TemporaryDirectory() as directory:
             _write_class_file(directory, category_ids, "yolo_v4")
             assert (directory / "classes.txt").is_file()
-            with (directory / "classes.txt").open("rb") as created_file:
-                with open("./tests/services/export/expected/classes.txt", "rb") as expected_file:
+            with (directory / "classes.txt").open("r") as created_file:
+                with open("./tests/services/export/expected/classes.txt", "r") as expected_file:
                     assert expected_file.read() == created_file.read()
 
     def test_write_class_file_yolo_v5(self):
         with TemporaryDirectory() as directory:
             _write_class_file(directory, category_ids, "yolo_v5")
             assert (directory / "data.yaml").is_file()
-            with (directory / "data.yaml").open("rb") as created_file:
-                with open("./tests/services/export/expected/data_v5.yaml", "rb") as expected_file:
+            with (directory / "data.yaml").open("r") as created_file:
+                with open("./tests/services/export/expected/data_v5.yaml", "r") as expected_file:
                     assert expected_file.read() == created_file.read()
 
     def test_write_class_file_yolo_v7(self):
         with TemporaryDirectory() as directory:
             _write_class_file(directory, category_ids, "yolo_v7")
             assert (directory / "data.yaml").is_file()
-            with (directory / "data.yaml").open("rb") as created_file:
-                with open("./tests/services/export/expected/data_v7.yaml", "rb") as expected_file:
+            with (directory / "data.yaml").open("r") as created_file:
+                with open("./tests/services/export/expected/data_v7.yaml", "r") as expected_file:
                     assert expected_file.read() == created_file.read()

--- a/tests/services/import_labels/test_import_from_files.py
+++ b/tests/services/import_labels/test_import_from_files.py
@@ -23,7 +23,8 @@ from tests.services.import_labels.test_cases_from_files import TEST_CASES
 
 
 def _generate_label_file(yolo_rows: List[List], filename: str):
-    with Path(filename).open("w", encoding="utf-8") as y_f:
+    # newline="" to disable universal newlines translation
+    with Path(filename).open("w", newline="", encoding="utf-8") as y_f:
         wrt = csv.writer(y_f, delimiter=" ")
         wrt.writerows((str(a) for a in r) for r in yolo_rows)
 

--- a/tests/services/import_labels/test_import_from_files.py
+++ b/tests/services/import_labels/test_import_from_files.py
@@ -23,7 +23,7 @@ from tests.services.import_labels.test_cases_from_files import TEST_CASES
 
 
 def _generate_label_file(yolo_rows: List[List], filename: str):
-    # newline="" to disable universal newlines translation
+    # newline="" to disable universal newlines translation (bug fix for windows)
     with Path(filename).open("w", newline="", encoding="utf-8") as y_f:
         wrt = csv.writer(y_f, delimiter=" ")
         wrt.writerows((str(a) for a in r) for r in yolo_rows)
@@ -31,7 +31,8 @@ def _generate_label_file(yolo_rows: List[List], filename: str):
 
 def _generate_meta_file(yolo_classes, yolo_meta_path, input_format):
     if input_format == "yolo_v4":
-        with open(yolo_meta_path, "w", encoding="utf-8") as y_m:
+        # newline="" to disable universal newlines translation (bug fix for windows)
+        with open(yolo_meta_path, "w", newline="", encoding="utf-8") as y_m:
             wrt = csv.writer(y_m, delimiter=" ")
             wrt.writerows((str(a) for a in r) for r in yolo_classes)
     elif input_format == "yolo_v5":
@@ -116,7 +117,8 @@ def test_import_labels_from_files_malformed_annotation(mocker):
         yolo_classes = inputs["yolo_classes"]
         yolo_meta_path = Path(label_folders) / inputs["meta_path"]
 
-        with open(yolo_meta_path, "w", encoding="utf-8") as y_m:
+        # newline="" to disable universal newlines translation (bug fix for windows)
+        with open(yolo_meta_path, "w", newline="", encoding="utf-8") as y_m:
             wrt = csv.writer(y_m, delimiter=" ")
             wrt.writerows((str(a) for a in r) for r in yolo_classes)
 
@@ -164,7 +166,8 @@ def test_import_labels_wrong_target_job(mocker):
         yolo_classes = inputs["yolo_classes"]
         yolo_meta_path = Path(label_folders) / inputs["meta_path"]
 
-        with open(yolo_meta_path, "w", encoding="utf-8") as y_m:
+        # newline="" to disable universal newlines translation (bug fix for windows)
+        with open(yolo_meta_path, "w", newline="", encoding="utf-8") as y_m:
             wrt = csv.writer(y_m, delimiter=" ")
             wrt.writerows((str(a) for a in r) for r in yolo_classes)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,7 +2,7 @@
 Tests for the client to return correct ee
 """
 import os
-from unittest import mock
+from unittest.mock import patch
 
 import pytest
 
@@ -10,25 +10,25 @@ from kili.client import Kili
 from kili.exceptions import AuthenticationFailed
 
 
-class TestClient:
-    """
-    test the get_project function
-    """
-
-    @mock.patch.dict(os.environ, {}, clear=True)
-    def test_no_api_key(self, monkeypatch):
+def test_no_api_key():
+    with patch.dict(os.environ):
+        os.environ.pop("KILI_API_KEY")
         with pytest.raises(AuthenticationFailed):
             _ = Kili()
 
-    @mock.patch.dict(os.environ, {}, clear=True)
-    def test_wrong_api_key(self, monkeypatch):
+
+def test_wrong_api_key():
+    with patch.dict(os.environ):
+        os.environ.pop("KILI_API_KEY")
         with pytest.raises(AuthenticationFailed) as e_info:
             _ = Kili(api_key="wrong_api_key")
 
         assert "failed with API key: *********_key" in str(e_info)
 
-    @mock.patch.dict(os.environ, {}, clear=True)
-    def test_wrong_api_key_shot(self, monkeypatch):
+
+def test_wrong_api_key_shot():
+    with patch.dict(os.environ):
+        os.environ.pop("KILI_API_KEY")
         with pytest.raises(AuthenticationFailed) as e_info:
             _ = Kili(api_key="no")
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -68,7 +68,10 @@ def mocked_count_method(*_):
 
 
 def debug_subprocess_pytest(result):
-    print(result.output)
+    try:
+        print(result.output)
+    except UnicodeEncodeError:
+        print(result.output.encode("utf-8"))
     if result.exception is not None:
         traceback.print_tb(result.exception.__traceback__)
         print(result.exception)


### PR DESCRIPTION
Windows specificities:
- `requests.get()` needs `os.environ` keys, be careful when mocking
- always create the directory before moving/copying/creating a file into it
- use `os.sep` to get the windows `\\` or unix `/` separators
- `csv.writer` requires a file object with `newline=""` : https://stackoverflow.com/questions/3191528/csv-in-python-adding-an-extra-carriage-return-on-windows
- sometimes `print()` fails to encode characters when windows cmd is set to CP-1252 encoding

TODO:
- [x] make all unit tests pass
- [x] trigger e2e tests before merging: https://github.com/kili-technology/kili-python-sdk/actions/runs/3904449606