### PR TITLE
ci: fix bugs in ci

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,7 +77,7 @@ jobs:
           git checkout release/$release_branch_version
           git checkout -b merge_release/$release_branch_version
           git push --set-upstream origin merge_release/$release_branch_version
-          gh pr create --fill --reviewer kili-technology/ml
+          gh pr create --fill
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/release_draft_minor.yml
+++ b/.github/workflows/release_draft_minor.yml
@@ -44,7 +44,12 @@ jobs:
       - name: create draft release
         run: |
           link_to_draft=$(./entrypoint.sh release:draft ${{ inputs.releaseVersion }})
+          echo "step1"
           echo $link_to_draft
+          echo "step2"
+          echo "LINK_TO_DRAFT=$link_to_draft"
+          echo "step3"
           echo "LINK_TO_DRAFT=$link_to_draft" >> $GITHUB_ENV
+          echo "step4"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release_draft_minor.yml
+++ b/.github/workflows/release_draft_minor.yml
@@ -49,3 +49,25 @@ jobs:
           echo "LINK_TO_DRAFT=$link_to_draft" >> $GITHUB_ENV
         env:
           GH_TOKEN: ${{ github.token }}
+
+      - name: Slack notification
+        id: slack
+        if: success()
+        uses: slackapi/slack-github-action@v1.18.0
+        with:
+          payload: |
+            {
+              "text": "Draft release ${{ inputs.releaseVersion }} is ready: ${{ env.LINK_TO_DRAFT }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Draft release ${{ inputs.releaseVersion }} is ready: ${{ env.LINK_TO_DRAFT }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_PYTHON_SDK }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/release_draft_minor.yml
+++ b/.github/workflows/release_draft_minor.yml
@@ -44,12 +44,8 @@ jobs:
       - name: create draft release
         run: |
           link_to_draft=$(./entrypoint.sh release:draft ${{ inputs.releaseVersion }})
-          echo "step1"
+          echo link_to_draft=$(echo $link_to_draft | grep -o 'https://[^ ]*')
           echo $link_to_draft
-          echo "step2"
-          echo "LINK_TO_DRAFT=$link_to_draft"
-          echo "step3"
           echo "LINK_TO_DRAFT=$link_to_draft" >> $GITHUB_ENV
-          echo "step4"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release_draft_minor.yml
+++ b/.github/workflows/release_draft_minor.yml
@@ -44,7 +44,7 @@ jobs:
       - name: create draft release
         run: |
           link_to_draft=$(./entrypoint.sh release:draft ${{ inputs.releaseVersion }})
-          echo link_to_draft=$(echo $link_to_draft | grep -o 'https://[^ ]*')
+          link_to_draft=$(echo $link_to_draft | grep -o 'https://[^ ]*')
           echo $link_to_draft
           echo "LINK_TO_DRAFT=$link_to_draft" >> $GITHUB_ENV
         env:

--- a/.github/workflows/release_draft_minor.yml
+++ b/.github/workflows/release_draft_minor.yml
@@ -44,28 +44,7 @@ jobs:
       - name: create draft release
         run: |
           link_to_draft=$(./entrypoint.sh release:draft ${{ inputs.releaseVersion }})
+          echo $link_to_draft
           echo "LINK_TO_DRAFT=$link_to_draft" >> $GITHUB_ENV
         env:
           GH_TOKEN: ${{ github.token }}
-
-      - name: Slack notification
-        id: slack
-        if: success()
-        uses: slackapi/slack-github-action@v1.18.0
-        with:
-          payload: |
-            {
-              "text": "Draft release ${{ inputs.releaseVersion }} is ready: ${{ env.LINK_TO_DRAFT }}",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Draft release ${{ inputs.releaseVersion }} is ready: ${{ env.LINK_TO_DRAFT }}"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_PYTHON_SDK }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/release_draft_patch.yml
+++ b/.github/workflows/release_draft_patch.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Create draft release
         run: |
           link_to_draft=$(gh release create ${{ env.NEW_PATCH_VERSION }} --draft --title "Release ${{ env.NEW_PATCH_VERSION }}" --generate-notes --notes-start-tag ${{ env.CURRENT_PATCH_VERSION }})
+          echo $link_to_draft
           echo "LINK_TO_DRAFT=$link_to_draft" >> $GITHUB_ENV
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release_draft_patch.yml
+++ b/.github/workflows/release_draft_patch.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Create draft release
         run: |
           link_to_draft=$(gh release create ${{ env.NEW_PATCH_VERSION }} --draft --title "Release ${{ env.NEW_PATCH_VERSION }}" --generate-notes --notes-start-tag ${{ env.CURRENT_PATCH_VERSION }})
-          echo link_to_draft=$(echo $link_to_draft | grep -o 'https://[^ ]*')
+          link_to_draft=$(echo $link_to_draft | grep -o 'https://[^ ]*')
           echo $link_to_draft
           echo "LINK_TO_DRAFT=$link_to_draft" >> $GITHUB_ENV
         env:

--- a/.github/workflows/release_draft_patch.yml
+++ b/.github/workflows/release_draft_patch.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Create draft release
         run: |
           link_to_draft=$(gh release create ${{ env.NEW_PATCH_VERSION }} --draft --title "Release ${{ env.NEW_PATCH_VERSION }}" --generate-notes --notes-start-tag ${{ env.CURRENT_PATCH_VERSION }})
+          echo link_to_draft=$(echo $link_to_draft | grep -o 'https://[^ ]*')
           echo $link_to_draft
           echo "LINK_TO_DRAFT=$link_to_draft" >> $GITHUB_ENV
         env:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -103,8 +103,8 @@ function create_draft_release() {
     fi
 
     # tag and push the tag
-    git tag -f -a $release_version -m "Release $release_version"
-    git push origin $release_version
+    # git tag -f -a $release_version -m "Release $release_version"
+    # git push origin $release_version
 
     # install gh if needed on macOS
     if [[ $OSTYPE == 'darwin'* ]] && ! [[ -x "$(command -v gh)" ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -102,9 +102,9 @@ function create_draft_release() {
         exit 1
     fi
 
-    # tag and push the tag
-    # git tag -f -a $release_version -m "Release $release_version"
-    # git push origin $release_version
+    tag and push the tag
+    git tag -f -a $release_version -m "Release $release_version"
+    git push origin $release_version
 
     # install gh if needed on macOS
     if [[ $OSTYPE == 'darwin'* ]] && ! [[ -x "$(command -v gh)" ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -102,7 +102,7 @@ function create_draft_release() {
         exit 1
     fi
 
-    tag and push the tag
+    # tag and push the tag
     git tag -f -a $release_version -m "Release $release_version"
     git push origin $release_version
 
@@ -112,7 +112,7 @@ function create_draft_release() {
     fi
 
     # create draft release
-    link_to_draft=$(gh release create $release_version --draft --title "Release $release_version" --generate-notes)
+    link_to_draft=$(gh release create $release_version --draft --title "Release $release_version" --generate-notes --notes-start-tag $latest_release)
 
     echo $link_to_draft
 }


### PR DESCRIPTION
- `publish.yml`:
	- remove `--reviewer` since `GH_TOKEN` needs specific rights to assign reviewers...
- `release_draft_minor.yml`
	-  the variable `link_to_draft` set from `$(./entrypoint.sh release:draft ${{ inputs.releaseVersion }})` had an extra line before the link. We filter the link with grep
- `release_draft_patch.yml`
	- I also added the grep filtering just to be sure, even though it worked well last time: https://github.com/kili-technology/kili-python-sdk/actions/workflows/release_draft_patch.yml
- `entrypoint.sh`
	- the last tag on master branch is 2.123.2. Thus, github always generates the changelogs based on this tag. We now pass `--notes-start-tag` that fetches the latest release version