### PR TITLE
ci: add ci for deploying doc

### DIFF
--- a/.github/workflows/deploy_doc.yml
+++ b/.github/workflows/deploy_doc.yml
@@ -23,7 +23,7 @@ jobs:
           echo "REF=master" >> $GITHUB_ENV
 
       - name: set checkout to latest release branch
-        if: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.branch == 'latest minor release branch') || github.event_name == 'workflow_call' }}
+        if: ${{ github.event_name == 'workflow_call' || (github.event_name == 'workflow_dispatch' && github.event.inputs.branch == 'latest minor release branch') }}
         run: |
           last_version_tag=$(curl --silent "https://api.github.com/repos/kili-technology/kili-python-sdk/releases/latest" | jq -r .tag_name)
           echo $last_version_tag

--- a/.github/workflows/deploy_doc.yml
+++ b/.github/workflows/deploy_doc.yml
@@ -1,0 +1,52 @@
+name: Deploy SDK doc
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy-documentation:
+    name: Deploy technical documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Deploy doc
+        run: |
+          git config user.name ci-bot
+          git config user.email ci-bot@example.com
+          pip install -e .
+          export version=$(python -c 'from kili import __version__; print(".".join(__version__.split(".")[:2]))')
+          git fetch origin gh-pages --depth=1
+          mike deploy --push --update-aliases $version latest
+
+      - name: Slack notification
+        id: slack
+        if: success()
+        uses: slackapi/slack-github-action@v1.18.0
+        with:
+          payload: |
+            {
+              "text": "Kili technical documentation released: https://python-sdk-docs.kili-technology.com/. \nA Hard refresh may be useful to see the latest version",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Kili technical documentation released: https://python-sdk-docs.kili-technology.com/. \nA Hard refresh may be useful to see the latest version"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_PYTHON_SDK }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/deploy_doc.yml
+++ b/.github/workflows/deploy_doc.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
         if: ${{ inputs.branch == 'latest minor release branch' }}
         with:
-          ref: ${{ env.LAST_VERSION }}
+          ref: ${{ env.LAST_VERSION_TAG }}
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/deploy_doc.yml
+++ b/.github/workflows/deploy_doc.yml
@@ -17,18 +17,13 @@ jobs:
     name: Deploy technical documentation
     runs-on: ubuntu-latest
     steps:
-      - name: set ref branch for checkout
-        if: ${{ github.event_name == 'workflow_call'}}
-        run: |
-          echo "REF=master" >> $GITHUB_ENV
-
-      - name: set ref branch for checkout if master branch
+      - name: set checkout to master branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch == 'master' }}
         run: |
           echo "REF=master" >> $GITHUB_ENV
 
-      - name: set ref branch for checkout if latest minor release branch
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch == 'latest minor release branch' }}
+      - name: set checkout to latest release branch
+        if: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.branch == 'latest minor release branch') || github.event_name == 'workflow_call' }}
         run: |
           last_version_tag=$(curl --silent "https://api.github.com/repos/kili-technology/kili-python-sdk/releases/latest" | jq -r .tag_name)
           echo $last_version_tag

--- a/.github/workflows/deploy_doc.yml
+++ b/.github/workflows/deploy_doc.yml
@@ -1,13 +1,22 @@
 name: Deploy SDK doc
 on:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   deploy-documentation:
     name: Deploy technical documentation
     runs-on: ubuntu-latest
     steps:
+      - name: get last release number
+        run: |
+          last_version_tag=$(curl --silent "https://api.github.com/repos/kili-technology/kili-python-sdk/releases/latest" | jq -r .tag_name)
+          echo $last_version_tag
+          echo "LAST_VERSION=$last_version_tag" >> $GITHUB_ENV
+
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ env.LAST_VERSION }}
 
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -20,10 +29,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
-      - name: Deploy doc
+      - name: setup git
         run: |
           git config user.name ci-bot
           git config user.email ci-bot@example.com
+
+      - name: Deploy doc
+        run: |
           pip install -e .
           export version=$(python -c 'from kili import __version__; print(".".join(__version__.split(".")[:2]))')
           git fetch origin gh-pages --depth=1

--- a/.github/workflows/deploy_doc.yml
+++ b/.github/workflows/deploy_doc.yml
@@ -17,16 +17,26 @@ jobs:
     name: Deploy technical documentation
     runs-on: ubuntu-latest
     steps:
-      - name: get last release number
+      - name: set ref branch for checkout
+        if: ${{ github.event_name == 'workflow_call'}}
+        run: |
+          echo "REF=master" >> $GITHUB_ENV
+
+      - name: set ref branch for checkout if master branch
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch == 'master' }}
+        run: |
+          echo "REF=master" >> $GITHUB_ENV
+
+      - name: set ref branch for checkout if latest minor release branch
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch == 'latest minor release branch' }}
         run: |
           last_version_tag=$(curl --silent "https://api.github.com/repos/kili-technology/kili-python-sdk/releases/latest" | jq -r .tag_name)
           echo $last_version_tag
-          echo "LAST_VERSION_TAG=$last_version_tag" >> $GITHUB_ENV
+          echo "REF=$last_version_tag" >> $GITHUB_ENV
 
       - uses: actions/checkout@v2
-        if: ${{ inputs.branch == 'latest minor release branch' }}
         with:
-          ref: ${{ env.LAST_VERSION_TAG }}
+          ref: ${{ env.REF }}
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/deploy_doc.yml
+++ b/.github/workflows/deploy_doc.yml
@@ -1,6 +1,15 @@
 name: Deploy SDK doc
 on:
   workflow_dispatch:
+    inputs:
+      branch:
+        description: "Deploy doc of which branch?"
+        required: false
+        type: choice
+        default: "master"
+        options:
+          - master
+          - latest minor release branch
   workflow_call:
 
 jobs:
@@ -12,9 +21,10 @@ jobs:
         run: |
           last_version_tag=$(curl --silent "https://api.github.com/repos/kili-technology/kili-python-sdk/releases/latest" | jq -r .tag_name)
           echo $last_version_tag
-          echo "LAST_VERSION=$last_version_tag" >> $GITHUB_ENV
+          echo "LAST_VERSION_TAG=$last_version_tag" >> $GITHUB_ENV
 
       - uses: actions/checkout@v2
+        if: ${{ inputs.branch == 'latest minor release branch' }}
         with:
           ref: ${{ env.LAST_VERSION }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,49 +82,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
   deploy-documentation:
-    name: Deploy technical documentation
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-          cache: "pip"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev]"
-
-      - name: Deploy doc
-        run: |
-          git config user.name ci-bot
-          git config user.email ci-bot@example.com
-          pip install -e .
-          export version=$(python -c 'from kili import __version__; print(".".join(__version__.split(".")[:2]))')
-          git fetch origin gh-pages --depth=1
-          mike deploy --push --update-aliases $version latest
-
-      - name: Slack notification
-        id: slack
-        if: success()
-        uses: slackapi/slack-github-action@v1.18.0
-        with:
-          payload: |
-            {
-              "text": "Kili technical documentation released: https://python-sdk-docs.kili-technology.com/. \nA Hard refresh may be useful to see the latest version",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Kili technical documentation released: https://python-sdk-docs.kili-technology.com/. \nA Hard refresh may be useful to see the latest version"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_PYTHON_SDK }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+    uses: ./.github/workflows/deploy_doc.yml@master
+    if: ${{ always() }}
+    needs: [publish]
+    secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,7 +82,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
   deploy-documentation:
-    uses: ./.github/workflows/deploy_doc.yml@master
+    uses: ./.github/workflows/deploy_doc.yml
     if: ${{ always() }}
     needs: [publish]
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,4 +85,3 @@ jobs:
     uses: ./.github/workflows/deploy_doc.yml
     if: ${{ always() }}
     needs: [publish]
-    secrets: inherit


### PR DESCRIPTION
new deploy_doc.yml workflow:
- runs on workflow_dispatch to be able to trigger it manually
- runs on workflow_call to allow it being called by publish.yml
- I am not sure that the deploy_doc.yml will checkout the repository on the release branch. So I added a step to get the latest release version, and I checkout the proper release branch

in publish.yml
- removed the doc deployment related code
- calls the deploy_doc.yml workflow when the `publish` job is finished, whether it succeeded or not
