### PR TITLE
ci: make pytest more verbose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Unit tests
-        run: pytest -ra -sv --ignore tests/test_notebooks.py --ignore tests/e2e/ --color yes  --code-highlight yes  -vv
+        run: pytest -ra -sv --color yes --code-highlight yes --durations=15 -vv --ignore tests/test_notebooks.py --ignore tests/e2e/
         env:
           KILI_API_CLOUD_VISION: ${{ secrets.KILI_API_CLOUD_VISION }}
           KILI_API_ENDPOINT: https://staging.cloud.kili-technology.com/api/label/v2/graphql

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -35,10 +35,10 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Integration tests
-        run: pytest -sv tests/e2e -k ".py"
+        run: pytest -ra -sv --color yes --code-highlight yes --durations=15 -vv tests/e2e -k ".py"
 
       - name: Notebook tests
-        run: pytest -sv tests/test_notebooks.py
+        run: pytest -ra -sv --color yes --code-highlight yes --durations=15 -vv tests/test_notebooks.py
 
       - name: Slack notification if failure
         if: failure()


### PR DESCRIPTION
- -r flag can be used to display a “short test summary info”. -a to not show passed tests
- -sv (-s to disable capturing stdout, -v for verbose mode)
- -vv to increase verbosity
- --durations=15 to get the 15 slowest tests