### PR TITLE
style: enable pylint useless-suppression message

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -67,7 +67,6 @@ disable=
         locally-disabled,
         file-ignored,
         suppressed-message,
-        useless-suppression,
         deprecated-pragma,
         use-symbolic-message-instead,
         duplicate-code
@@ -76,7 +75,7 @@ disable=
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once). See also the "--disable" option for examples.
-enable=c-extension-no-member
+enable=c-extension-no-member,useless-suppression
 
 
 [REPORTS]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,12 +3,18 @@
   "python.linting.mypyEnabled": false,
   "python.linting.flake8Enabled": true,
   "python.linting.enabled": true,
-  "python.formatting.blackArgs": ["--preview"],
+  "python.formatting.blackArgs": [
+    "--preview"
+  ],
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
   "python.testing.cwd": "${workspaceFolder}",
   "python.languageServer": "Pylance",
   "python.linting.pylintEnabled": true,
+  "python.linting.pylintArgs": [
+    "--rcfile",
+    "${workspaceFolder}/.pylintrc"
+  ],
   "python.analysis.diagnosticMode": "workspace",
   "python.analysis.typeCheckingMode": "basic",
   "editor.showUnused": true


### PR DESCRIPTION
Reported when a message is explicitly disabled for a line or a block of code, but never triggered.

Also force pylint for vscode users to use the pylintrc file