### PR TITLE
ci: fix markdown link checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Analysing the code with pylint
         run: |
           pylint src/kili
+
   unittest:
     timeout-minutes: 9
     name: Unit tests
@@ -57,15 +58,18 @@ jobs:
           KILI_API_KEY: ${{ secrets.KILI_USER_API_KEY }}
           KILI_USER_EMAIL: ${{ secrets.KILI_USER_EMAIL }}
           KILI_USER_ID: ${{ secrets.KILI_USER_ID }}
+
   markdown-link-check:
-    timeout-minutes: 15
+    timeout-minutes: 2
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - uses: actions/checkout@v2
+      - uses: lycheeverse/lychee-action@0682ed617509a52424db04e7502c1dc3df28b469
         with:
-          use-quiet-mode: "yes"
-          use-verbose-mode: "yes"
+          fail: true
+          debug: false
+          args: "--verbose --no-progress './**/*.md' --exclude '^(http|https)://cloud.kili-technology.com/api/label/v2/graphql$'"
+
   build-test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Use this link checker: https://github.com/lycheeverse/lychee

I had to exclude `--exclude '^(http|https)://cloud.kili-technology.com/api/label/v2/graphql$'`  since it returns a http 400 error code

runs in 15s: https://github.com/kili-technology/kili-python-sdk/actions/runs/3986198229/jobs/6834486502