### PR TITLE
ci: add pre-commit hook for markdown formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,28 +1,40 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: detect-private-key
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.12.0
     hooks:
       - id: black
       - id: black-jupyter
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.11.4
     hooks:
       - id: isort
         name: isort (python)
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.0
+    rev: 5.0.4
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-black>=0.1.1
           - flake8-bugbear>=20.0.0
           - flake8-unused-arguments
+  - repo: local
+    hooks:
+      - id: mdformat
+        name: format markdown files
+        language: python
+        entry: mdformat --number
+        files: .*\.md$
+        stages: [commit, merge-commit]
+        always_run: false
+        pass_filenames: true
+        additional_dependencies: [mdformat]
+        exclude: docs\/cli\/reference.md|docs\/sdk\/tutorials\/.*\.md$
   - repo: local
     hooks:
       - id: notebook-markdown-tutorials

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
         always_run: false
         pass_filenames: true
         additional_dependencies: [mdformat]
-        exclude: docs\/cli\/reference.md|docs\/sdk\/tutorials\/.*\.md$
+        exclude: docs\/sdk\/project.md|docs\/sdk\/plugins.md|docs\/cli\/reference.md|docs\/sdk\/tutorials\/.*\.md$
   - repo: local
     hooks:
       - id: notebook-markdown-tutorials

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,4 +37,5 @@ pylint src/kili
 Only code rated 10.00/10 will success in the CI.
 
 ## PR names
+
 The PR titles should follow these [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Kili Python SDK
 
-[![Python 3.7](https://img.shields.io/badge/python-3.7%20|%203.8%20|%203.9%20|%203.10%20|%203.11%20-blue.svg)](https://www.python.org/)
+[![Python 3.7](https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20-blue.svg)](https://www.python.org/)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Code style: flake8](https://img.shields.io/badge/code%20style-flake8-brightgreen.svg)](https://flake8.pycqa.org/)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/kili-technology/kili-python-sdk?label=pypi%20package)
 
----
+______________________________________________________________________
 
 **SDK Reference**: https://python-sdk-docs.kili-technology.com/
 
@@ -16,7 +16,7 @@
 
 **Website**: https://kili-technology.com/
 
----
+______________________________________________________________________
 
 ## What is Kili?
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -8,6 +8,7 @@ For the actions it supports, the CLI offers a more compact way to manage your pr
 ## Authentication
 
 - Create and copy a [Kili API key](https://docs.kili-technology.com/docs/creating-an-api-key)
+
 - Add the `KILI_API_KEY` variable in your bash environment (or in the settings of your favorite IDE) by pasting the API key value that you copied earlier:
 
   ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@ pip install kili
 ## Usage
 
 - Create and copy a [Kili API key](https://docs.kili-technology.com/docs/creating-an-api-key)
+
 - Add the `KILI_API_KEY` variable in your bash environment (or in the settings of your favorite IDE) by pasting the API key value that you copied earlier:
 
   ```bash

--- a/docs/label_export.md
+++ b/docs/label_export.md
@@ -3,17 +3,22 @@
 There are several ways to export labels from a Kili project.
 
 ## With the CLI
+
 You can export a project using the `kili project export` command:
+
 ```bash
 kili project export \
         --project-id <project_id> \
         --output-format yolo_v5 \
         --output-file /tmp/export.zip
 ```
+
 More options [here](https://python-sdk-docs.kili-technology.com/latest/cli/reference/#export).
 
 ## With the Python SDK
+
 You can also use the Python SDK:
+
 ```python
 from kili.client import Kili
 kili = Kili()
@@ -23,9 +28,11 @@ kili.export_labels(
     fmt = "yolo_v5",
 )
 ```
+
 More details [here](https://python-sdk-docs.kili-technology.com/latest/sdk/label/#kili.queries.label.__init__.QueriesLabel.export_labels).
 
 ## From the Kili UI
+
 You can refer to this [Kili documentation page](https://docs.kili-technology.com/docs/exporting-project-data).
 
 ## Available formats
@@ -39,6 +46,5 @@ You can refer to this [Kili documentation page](https://docs.kili-technology.com
 | YOLO V7       | ❌   | ✅             | ✅                      |
 | Pascal VOC    | ✅   | ✅             | ✅                      |
 | COCO          | ❌   | ✅             | ✅                      |
-
 
 And more to come!

--- a/docs/sdk/api_key.md
+++ b/docs/sdk/api_key.md
@@ -1,4 +1,5 @@
 # API Key module
 
 ## Queries
+
 ::: kili.queries.api_key.__init__.QueriesApiKey

--- a/docs/sdk/asset.md
+++ b/docs/sdk/asset.md
@@ -1,6 +1,9 @@
 # Asset module
 
 ## Queries
+
 ::: kili.queries.asset.__init__.QueriesAsset
+
 ## Mutations
+
 ::: kili.mutations.asset.__init__.MutationsAsset

--- a/docs/sdk/issue.md
+++ b/docs/sdk/issue.md
@@ -1,7 +1,9 @@
 # Issue module
 
 ## Queries
+
 ::: kili.queries.issue.__init__.QueriesIssue
 
 ## Mutations
+
 ::: kili.mutations.issue.__init__.MutationsIssue

--- a/docs/sdk/label.md
+++ b/docs/sdk/label.md
@@ -1,8 +1,13 @@
 # Label module
 
 ## Queries
+
 ::: kili.queries.label.__init__.QueriesLabel
+
 ## Mutations
+
 ::: kili.mutations.label.__init__.MutationsLabel
+
 ## Subscriptions
+
 ::: kili.subscriptions.label.__init__.SubscriptionsLabel

--- a/docs/sdk/notification.md
+++ b/docs/sdk/notification.md
@@ -1,4 +1,5 @@
 # Notification module
 
 ## Queries
+
 ::: kili.queries.notification.__init__.QueriesNotification

--- a/docs/sdk/organization.md
+++ b/docs/sdk/organization.md
@@ -1,4 +1,5 @@
 # Organization module
 
 ## Queries
+
 ::: kili.queries.organization.__init__.QueriesOrganization

--- a/docs/sdk/plugins.md
+++ b/docs/sdk/plugins.md
@@ -45,10 +45,7 @@ class PluginHandler(PluginCore):
 ```
 
 !!! note
-
-```
-The plugins run has some limitations, it can use a maximum of 512mb of ram and will timeout after 60sec of run
-```
+    The plugins run has some limitations, it can use a maximum of 512mb of ram and will timeout after 60sec of run
 
 ## Model for Plugins
 

--- a/docs/sdk/plugins.md
+++ b/docs/sdk/plugins.md
@@ -46,7 +46,9 @@ class PluginHandler(PluginCore):
 
 !!! note
 
-    The plugins run has some limitations, it can use a maximum of 512mb of ram and will timeout after 60sec of run
+```
+The plugins run has some limitations, it can use a maximum of 512mb of ram and will timeout after 60sec of run
+```
 
 ## Model for Plugins
 

--- a/docs/sdk/project.md
+++ b/docs/sdk/project.md
@@ -1,10 +1,13 @@
 # Project module
 
 ## Queries
+
 ::: kili.queries.project.__init__.QueriesProject
+
 ## Mutations
+
 ::: kili.mutations.project.__init__.MutationsProject
-    selection:
-        filters:
-            - '!internal_delete_project'
-            - '!^__'
+selection:
+filters:
+\- '!internal_delete_project'
+\- '!^\_\_'

--- a/docs/sdk/project.md
+++ b/docs/sdk/project.md
@@ -7,7 +7,7 @@
 ## Mutations
 
 ::: kili.mutations.project.__init__.MutationsProject
-selection:
-filters:
-\- '!internal_delete_project'
-\- '!^\_\_'
+    selection:
+        filters:
+            - '!internal_delete_project'
+            - '!^__'

--- a/docs/sdk/project_user.md
+++ b/docs/sdk/project_user.md
@@ -1,4 +1,5 @@
 # Project User module
 
 ## Queries
+
 ::: kili.queries.project_user.__init__.QueriesProjectUser

--- a/docs/sdk/project_version.md
+++ b/docs/sdk/project_version.md
@@ -1,6 +1,9 @@
 # Project Version module
 
 ## Queries
+
 ::: kili.queries.project_version.__init__.QueriesProjectVersion
+
 ## Mutations
+
 ::: kili.mutations.project_version.__init__.MutationsProjectVersion

--- a/docs/sdk/user.md
+++ b/docs/sdk/user.md
@@ -1,6 +1,9 @@
 # User module
 
 ## Queries
+
 ::: kili.queries.user.__init__.QueriesUser
+
 ## Mutations
+
 ::: kili.mutations.user.__init__.MutationsUser


### PR DESCRIPTION
I tried markdown formatting with mdformat: https://mdformat.readthedocs.io/en/stable/

Too many incompatibilities between markdown standards (commonmark, github markdown, mkdocs markdown). mdformat often breaks mkdocs related commands (!!! note, !!! warning). 

We can't disable formatting on some lines with mdformat, so I had to exclude some markdown files to not break the SDK doc.

It also doesn't work well with nbconvert. So we can't use it to format the notebook and markdown tutorials.

I also tried some markdown linters, but they are often too pedantic.

I'm not sure if we should merge this since markdown formatting is not exact science...