### PR TITLE
ci: do not run notebook tests for merge on master

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -7,7 +7,7 @@ on:
       - master
 jobs:
   recipes:
-    timeout-minutes: 15
+    timeout-minutes: 20
     name: Recipes test
     strategy:
       matrix:

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -7,7 +7,7 @@ on:
       - master
 jobs:
   recipes:
-    timeout-minutes: 20
+    timeout-minutes: 25
     name: Recipes test
     strategy:
       matrix:

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -5,20 +5,15 @@ on:
     branches:
       - "release/**"
       - master
+  schedule:
+    - cron: "0 7,15 * * *" # 8am and 4pm UTC+1
 jobs:
   recipes:
-    timeout-minutes: 25
     name: Recipes test
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    env:
-      KILI_API_CLOUD_VISION: ${{ secrets.KILI_API_CLOUD_VISION }}
-      KILI_API_ENDPOINT: https://staging.cloud.kili-technology.com/api/label/v2/graphql
-      KILI_API_KEY: ${{ secrets.KILI_USER_API_KEY }}
-      KILI_USER_EMAIL: ${{ secrets.KILI_USER_EMAIL }}
-      KILI_USER_ID: ${{ secrets.KILI_USER_ID }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -35,10 +30,25 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Integration tests
+        timeout-minutes: 10
         run: pytest -ra -sv --color yes --code-highlight yes --durations=15 -vv tests/e2e -k ".py"
+        env:
+          KILI_API_CLOUD_VISION: ${{ secrets.KILI_API_CLOUD_VISION }}
+          KILI_API_ENDPOINT: https://staging.cloud.kili-technology.com/api/label/v2/graphql
+          KILI_API_KEY: ${{ secrets.KILI_USER_API_KEY }}
+          KILI_USER_EMAIL: ${{ secrets.KILI_USER_EMAIL }}
+          KILI_USER_ID: ${{ secrets.KILI_USER_ID }}
 
       - name: Notebook tests
+        if: github.event_name != 'push' || github.ref_name != 'master' # doesn't run for push on master
+        timeout-minutes: 15
         run: pytest -ra -sv --color yes --code-highlight yes --durations=15 -vv tests/test_notebooks.py
+        env:
+          KILI_API_CLOUD_VISION: ${{ secrets.KILI_API_CLOUD_VISION }}
+          KILI_API_ENDPOINT: https://staging.cloud.kili-technology.com/api/label/v2/graphql
+          KILI_API_KEY: ${{ secrets.KILI_USER_API_KEY }}
+          KILI_USER_EMAIL: ${{ secrets.KILI_USER_EMAIL }}
+          KILI_USER_ID: ${{ secrets.KILI_USER_ID }}
 
       - name: Slack notification if failure
         if: failure()


### PR DESCRIPTION
we should consider removing some notebook tests maybe?  Or we can run them just once a day with a cron?

wdyt @kili-technology/ml ?

e2e tests: (~7min)
```
============================= slowest 15 durations =============================
114.50s setup    tests/e2e/test_query_assets_download_media.py::test_download_single_asset_big_image
63.05s call     tests/e2e/test_copy_project.py::test_copy_project_e2e
31.59s setup    tests/e2e/test_copy_project.py::test_copy_project_e2e
23.66s setup    tests/e2e/test_query_assets_download_media.py::test_download_single_asset_video_content_and_jsoncontent
22.15s setup    tests/e2e/test_mutations_asset.py::test_add_to_review
11.59s setup    tests/e2e/test_mutations_asset.py::test_send_back_to_queue
10.78s setup    tests/e2e/test_mutations_asset.py::test_change_asset_external_ids
10.54s setup    tests/e2e/test_mutations_asset.py::test_update_properties_in_assets_external_id
10.37s setup    tests/e2e/test_text_encoding_consistency.py::test_encoding_decoding_consistency
10.18s setup    tests/e2e/test_query_assets_download_media.py::test_download_assets_protected_content_images
8.70s call     tests/e2e/test_query_assets_download_media.py::test_download_single_asset_video_content_and_jsoncontent
7.58s call     tests/e2e/test_repository.py::test_get_content_stream_public_image[https://storage.googleapis.com/label-public-staging/car/car_2.jpg]
7.45s call     tests/e2e/test_repository.py::test_get_content_stream_public_image[https://storage.googleapis.com/label-public-staging/car/car_1.jpg]
6.60s setup    tests/e2e/test_mutations_project.py::test_update_properties_in_project
6.32s setup    tests/e2e/test_query_assets_download_media.py::test_download_single_asset_protected_content_videos
================== 16 passed, 2 warnings in 396.07s (0:06:36) ==================
```
notebooks: (~12min)
```
============================= slowest 15 durations =============================
156.85s call     tests/test_notebooks.py::test_all_recipes[recipes/plugins_example.ipynb]
102.50s call     tests/test_notebooks.py::test_all_recipes[recipes/frame_dicom_data.ipynb]
59.95s call     tests/test_notebooks.py::test_all_recipes[tests/e2e/paginated_calls_project_lifecycle.ipynb]
50.41s call     tests/test_notebooks.py::test_all_recipes[recipes/set_up_workflows.ipynb]
48.85s call     tests/test_notebooks.py::test_all_recipes[tests/e2e/import_predictions.ipynb]
41.27s call     tests/test_notebooks.py::test_all_recipes[recipes/inference_labels.ipynb]
38.16s call     tests/test_notebooks.py::test_all_recipes[recipes/webhooks.ipynb]
32.63s call     tests/test_notebooks.py::test_all_recipes[recipes/plugins_development.ipynb]
31.54s call     tests/test_notebooks.py::test_all_recipes[recipes/export_a_kili_project.ipynb]
28.33s call     tests/test_notebooks.py::test_all_recipes[recipes/query_methods.ipynb]
23.90s call     tests/test_notebooks.py::test_all_recipes[recipes/pixel_level_masks.ipynb]
19.66s call     tests/test_notebooks.py::test_all_recipes[recipes/medical_imaging.ipynb]
15.56s call     tests/test_notebooks.py::test_all_recipes[recipes/import_text_assets.ipynb]
14.69s call     tests/test_notebooks.py::test_all_recipes[recipes/ocr_pre_annotations.ipynb]
11.01s call     tests/test_notebooks.py::test_all_recipes[recipes/basic_project_setup.ipynb]
======================== 22 passed in 701.06s (0:11:41) ========================
```