### PR TITLE
ci: remove slack notification for e2e tests ran manually

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -51,7 +51,7 @@ jobs:
           KILI_USER_ID: ${{ secrets.KILI_USER_ID }}
 
       - name: Slack notification if failure
-        if: failure()
+        if: failure() && github.event_name != 'workflow_dispatch' # doesn't notify for manual runs
         id: slack
         uses: slackapi/slack-github-action@v1.18.0
         with:

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -51,7 +51,7 @@ jobs:
           KILI_USER_ID: ${{ secrets.KILI_USER_ID }}
 
       - name: Slack notification if failure
-        if: failure() && github.event_name != 'workflow_dispatch' # doesn't notify for manual runs
+        if: failure() && (github.event_name != 'workflow_dispatch') # doesn't notify for manual runs
         id: slack
         uses: slackapi/slack-github-action@v1.18.0
         with:


### PR DESCRIPTION
we expect the user to check if they passed or not