### PR TITLE
docs: stop forcing kili upgrade in notebooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,15 @@ repos:
           - --
   - repo: local
     hooks:
+      - id: clean-notebook-metadata
+        name: Clean notebook metadata
+        language: python
+        entry: jupyter nbconvert --ClearMetadataPreprocessor.enabled=True --ClearMetadataPreprocessor.preserve_cell_metadata_mask tags --inplace
+        files: .*\.ipynb$
+        stages: [commit, merge-commit]
+        always_run: false
+        pass_filenames: true
+        additional_dependencies: [nbconvert]
       - id: notebook-markdown-tutorials
         name: Checks for notebook and markdown tutorials
         language: python

--- a/docs/sdk/tutorials/export_a_kili_project.md
+++ b/docs/sdk/tutorials/export_a_kili_project.md
@@ -34,7 +34,7 @@ export KILI_API_KEY=<YOUR_API_KEY>
 
 
 ```python
-!pip install --upgrade kili
+!pip install  kili
 ```
 
 4) Import packages and instantiate `Kili`:

--- a/docs/sdk/tutorials/importing_assets_and_labels.md
+++ b/docs/sdk/tutorials/importing_assets_and_labels.md
@@ -21,7 +21,7 @@ First, let's install and import the required modules.
 
 
 ```python
-!pip install --upgrade kili
+!pip install  kili
 ```
 
 

--- a/docs/sdk/tutorials/importing_video_assets.md
+++ b/docs/sdk/tutorials/importing_video_assets.md
@@ -25,7 +25,7 @@ First, let's install and import the required modules.
 
 
 ```python
-!pip install --upgrade kili
+!pip install  kili
 ```
 
 

--- a/docs/sdk/tutorials/plugins_development.md
+++ b/docs/sdk/tutorials/plugins_development.md
@@ -53,7 +53,7 @@ Do not hesitate to reach out to us if you need more.
 
 
 ```python
-!pip install --upgrade kili
+!pip install  kili
 ```
 
 

--- a/docs/sdk/tutorials/plugins_example.md
+++ b/docs/sdk/tutorials/plugins_example.md
@@ -14,7 +14,7 @@ This notebook is an end-to-end example that you can follow to: create a project,
 
 
 ```python
-!pip install --upgrade kili
+!pip install  kili
 ```
 
 

--- a/docs/sdk/tutorials/set_up_workflows.md
+++ b/docs/sdk/tutorials/set_up_workflows.md
@@ -20,7 +20,7 @@ To work with this notebook, you will have to install and instantiate Kili.
 
 
 ```python
-!pip install --upgrade kili
+!pip install kili
 ```
 
 

--- a/recipes/counterfactual_data_augmentation.ipynb
+++ b/recipes/counterfactual_data_augmentation.ipynb
@@ -42,7 +42,7 @@
     "# Authentication\n",
     "import os\n",
     "\n",
-    "!pip install --upgrade kili\n",
+    "!pip install  kili\n",
     "from kili.client import Kili\n",
     "\n",
     "# Don't forget to set your 'KILI_API_KEY' environment variable with your API Key: os.environ['KILI_API_KEY'] = \"<YOUR_API_KEY>\"\n",

--- a/recipes/export_a_kili_project.ipynb
+++ b/recipes/export_a_kili_project.ipynb
@@ -85,7 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade kili"
+    "!pip install  kili"
    ]
   },
   {
@@ -861,8 +861,18 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "python37",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "name": "python"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "ebcc9ab275a0b8333d76f3c9007aff6798cc23ea07d3b4c53c0b1df0392e66fe"
+   }
   }
  },
  "nbformat": 4,

--- a/recipes/export_a_kili_project.ipynb
+++ b/recipes/export_a_kili_project.ipynb
@@ -861,18 +861,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "python37",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "name": "python"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "ebcc9ab275a0b8333d76f3c9007aff6798cc23ea07d3b4c53c0b1df0392e66fe"
-   }
   }
  },
  "nbformat": 4,

--- a/recipes/importing_assets_and_labels.ipynb
+++ b/recipes/importing_assets_and_labels.ipynb
@@ -56,7 +56,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade kili"
+    "!pip install  kili"
    ]
   },
   {

--- a/recipes/importing_video_assets.ipynb
+++ b/recipes/importing_video_assets.ipynb
@@ -60,7 +60,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade kili"
+    "!pip install  kili"
    ]
   },
   {
@@ -471,8 +471,18 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "python37",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "name": "python"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "ebcc9ab275a0b8333d76f3c9007aff6798cc23ea07d3b4c53c0b1df0392e66fe"
+   }
   }
  },
  "nbformat": 4,

--- a/recipes/importing_video_assets.ipynb
+++ b/recipes/importing_video_assets.ipynb
@@ -471,18 +471,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "python37",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "name": "python"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "ebcc9ab275a0b8333d76f3c9007aff6798cc23ea07d3b4c53c0b1df0392e66fe"
-   }
   }
  },
  "nbformat": 4,

--- a/recipes/medical_imaging.ipynb
+++ b/recipes/medical_imaging.ipynb
@@ -319,18 +319,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "python37",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "name": "python"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "ebcc9ab275a0b8333d76f3c9007aff6798cc23ea07d3b4c53c0b1df0392e66fe"
-   }
   }
  },
  "nbformat": 4,

--- a/recipes/medical_imaging.ipynb
+++ b/recipes/medical_imaging.ipynb
@@ -121,7 +121,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade kili\n",
+    "!pip install  kili\n",
     "from kili.client import Kili\n",
     "\n",
     "# Don't forget to set your 'KILI_API_KEY' environment variable with your API Key: os.environ['KILI_API_KEY'] = \"<YOUR_API_KEY>\"\n",
@@ -319,8 +319,18 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "python37",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "name": "python"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "ebcc9ab275a0b8333d76f3c9007aff6798cc23ea07d3b4c53c0b1df0392e66fe"
+   }
   }
  },
  "nbformat": 4,

--- a/recipes/plugins_development.ipynb
+++ b/recipes/plugins_development.ipynb
@@ -683,18 +683,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "python37",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "name": "python"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "ebcc9ab275a0b8333d76f3c9007aff6798cc23ea07d3b4c53c0b1df0392e66fe"
-   }
   }
  },
  "nbformat": 4,

--- a/recipes/plugins_development.ipynb
+++ b/recipes/plugins_development.ipynb
@@ -78,7 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade kili"
+    "!pip install  kili"
    ]
   },
   {
@@ -683,8 +683,18 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "python37",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "name": "python"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "ebcc9ab275a0b8333d76f3c9007aff6798cc23ea07d3b4c53c0b1df0392e66fe"
+   }
   }
  },
  "nbformat": 4,

--- a/recipes/plugins_example.ipynb
+++ b/recipes/plugins_example.ipynb
@@ -876,18 +876,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "python37",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "name": "python"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "ebcc9ab275a0b8333d76f3c9007aff6798cc23ea07d3b4c53c0b1df0392e66fe"
-   }
   }
  },
  "nbformat": 4,

--- a/recipes/plugins_example.ipynb
+++ b/recipes/plugins_example.ipynb
@@ -43,7 +43,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade kili"
+    "!pip install  kili"
    ]
   },
   {
@@ -876,8 +876,18 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "python37",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "name": "python"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "ebcc9ab275a0b8333d76f3c9007aff6798cc23ea07d3b4c53c0b1df0392e66fe"
+   }
   }
  },
  "nbformat": 4,

--- a/recipes/set_up_workflows.ipynb
+++ b/recipes/set_up_workflows.ipynb
@@ -648,18 +648,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "python37",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "name": "python"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "ebcc9ab275a0b8333d76f3c9007aff6798cc23ea07d3b4c53c0b1df0392e66fe"
-   }
   }
  },
  "nbformat": 4,

--- a/recipes/set_up_workflows.ipynb
+++ b/recipes/set_up_workflows.ipynb
@@ -46,7 +46,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade kili"
+    "!pip install kili"
    ]
   },
   {
@@ -649,7 +649,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "kili-python-sdk",
+   "display_name": "python37",
    "language": "python",
    "name": "python3"
   },
@@ -658,7 +658,7 @@
   },
   "vscode": {
    "interpreter": {
-    "hash": "d33841ec8232dd9499f6185d11ad4b869ae96fbec62e64101cd3d9c14f967e3c"
+    "hash": "ebcc9ab275a0b8333d76f3c9007aff6798cc23ea07d3b4c53c0b1df0392e66fe"
    }
   }
  },


### PR DESCRIPTION
force upgrading kili via pip breaks the test environment (if we want to test earlier version of kili sdk)

also add another precommit for cleaning notebooks, the precommit "nb-clean" does not clean everything unfortunately

e2e: https://github.com/kili-technology/kili-python-sdk/actions/runs/4026700002