### PR TITLE
ci: fix pre-commit ci

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -6,9 +6,9 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
           cache: "pip"
-      - uses: pre-commit/action@v2.0.3
+      - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,11 +10,17 @@ repos:
     hooks:
       - id: black
       - id: black-jupyter
-  - repo: https://github.com/pycqa/isort
-    rev: 5.11.4
+  - repo: local
     hooks:
       - id: isort
         name: isort (python)
+        language: python
+        entry: isort
+        files: .*\.py$
+        stages: [commit, merge-commit]
+        always_run: false
+        pass_filenames: true
+        additional_dependencies: [isort]
   - repo: https://github.com/pycqa/flake8
     rev: 5.0.4
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,17 +10,11 @@ repos:
     hooks:
       - id: black
       - id: black-jupyter
-  - repo: local
+  - repo: https://github.com/pycqa/isort
+    rev: 5.11.5
     hooks:
       - id: isort
         name: isort (python)
-        language: python
-        entry: isort
-        files: .*\.py$
-        stages: [commit, merge-commit]
-        always_run: false
-        pass_filenames: true
-        additional_dependencies: [isort]
   - repo: https://github.com/pycqa/flake8
     rev: 5.0.4
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,22 +1,22 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: detect-private-key
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.12.0
     hooks:
       - id: black
       - id: black-jupyter
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.11.4
     hooks:
       - id: isort
         name: isort (python)
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.0
+    rev: 5.0.4
     hooks:
       - id: flake8
         additional_dependencies:


### PR DESCRIPTION
isort pre-commit hook had some incompatibilities with python3.7: https://github.com/PyCQA/isort/issues/2083