### PR TITLE
fix: fix export bug when jsonContent is None

### DIFF
--- a/src/kili/queries/asset/media_downloader.py
+++ b/src/kili/queries/asset/media_downloader.py
@@ -75,7 +75,7 @@ class MediaDownloader:
         assets = list(assets_gen)
 
         if self.jsoncontent_field_added:
-            jsoncontent_not_empty = any(asset["jsonContent"] != "" for asset in assets)
+            jsoncontent_not_empty = any(bool(asset["jsonContent"]) for asset in assets)
             if jsoncontent_not_empty:
                 warnings.warn(
                     "Non empty jsonContent found in assets. Field was automatically added."
@@ -89,7 +89,7 @@ class MediaDownloader:
     def download_single_asset(self, asset: Dict) -> Dict[str, Any]:
         """Download single asset on disk and modify asset attributes"""
 
-        if "jsonContent" in asset and asset["jsonContent"] != "":
+        if "jsonContent" in asset and str(asset["jsonContent"]).startswith("http"):
             # richtext
             if self.project_input_type == "TEXT":
                 asset["jsonContent"] = download_file(
@@ -126,7 +126,7 @@ class MediaDownloader:
                     f"jsonContent download for type {self.project_input_type} not implemented yet."
                 )
 
-        if asset["content"] != "":
+        if str(asset["content"]).startswith("http"):
             asset["content"] = download_file(
                 asset["content"], asset["externalId"], self.local_dir_path
             )

--- a/src/kili/services/copy_project/__init__.py
+++ b/src/kili/services/copy_project/__init__.py
@@ -201,11 +201,11 @@ class ProjectCopier:  # pylint: disable=too-few-public-methods
     def _upload_assets(self, new_project_id, assets):
         assets = sorted(
             assets,
-            key=lambda asset: (asset["content"] != "", asset["jsonContent"] != ""),
+            key=lambda asset: (bool(asset["content"]), bool(asset["jsonContent"])),
         )
         assets_iterator = itertools.groupby(
             assets,
-            key=lambda asset: (asset["content"] != "", asset["jsonContent"] != ""),
+            key=lambda asset: (bool(asset["content"]), bool(asset["jsonContent"])),
         )
 
         for key, group in assets_iterator:

--- a/src/kili/services/export/format/kili/__init__.py
+++ b/src/kili/services/export/format/kili/__init__.py
@@ -67,7 +67,7 @@ class KiliExporter(AbstractExporter):
         Remove TemporaryDirectory() prefix from filepaths in "jsonContent" and "content" fields.
         """
         for asset in assets:
-            if asset["content"] != "" and os.path.isfile(asset["content"]):
+            if os.path.isfile(asset["content"]):
                 asset["content"] = str(Path(self.ASSETS_DIR_NAME) / Path(asset["content"]).name)
 
             json_content_list = []


### PR DESCRIPTION
```python
kili.export_labels(
    project_id=PROJECT_ID,
    filename="./kili_export.zip",
    fmt="coco",
    single_file=True,
)
```

```
Fetching assets...
  0%|                                                                                                                                                                                                                                               | 0/500 [00:02<?, ?it/s]
Traceback (most recent call last):
  File "/Users/brice/mltwist/testing/getAnnotations.py", line 50, in <module>
    kili.export_labels(
  File "/Users/brice/.asdf/installs/python/3.9.6/lib/python3.9/site-packages/kili/queries/label/__init__.py", line 312, in export_labels
    services.export_labels(
  File "/Users/brice/.asdf/installs/python/3.9.6/lib/python3.9/site-packages/kili/services/export/__init__.py", line 84, in export_labels
    exporter_class(
  File "/Users/brice/.asdf/installs/python/3.9.6/lib/python3.9/site-packages/kili/services/export/format/base.py", line 149, in export_project
    assets = fetch_assets(
  File "/Users/brice/.asdf/installs/python/3.9.6/lib/python3.9/site-packages/kili/services/export/tools.py", line 102, in fetch_assets
    assets = kili.assets(
  File "/Users/brice/.asdf/installs/python/3.9.6/lib/python3.9/site-packages/typeguard/__init__.py", line 1033, in wrapper
    retval = func(*args, **kwargs)
  File "/Users/brice/.asdf/installs/python/3.9.6/lib/python3.9/site-packages/kili/queries/asset/__init__.py", line 244, in assets
    return list(asset_generator)
  File "/Users/brice/.asdf/installs/python/3.9.6/lib/python3.9/site-packages/kili/utils/pagination.py", line 68, in row_generator_from_paginated_calls
    rows = post_call_process(rows)
  File "/Users/brice/.asdf/installs/python/3.9.6/lib/python3.9/site-packages/kili/queries/asset/helpers.py", line 86, in download_assets
    assets = list(assets_gen)
  File "/Users/brice/.asdf/installs/python/3.9.6/lib/python3.9/concurrent/futures/_base.py", line 608, in result_iterator
    yield fs.pop().result()
  File "/Users/brice/.asdf/installs/python/3.9.6/lib/python3.9/concurrent/futures/_base.py", line 438, in result
    return self.__get_result()
  File "/Users/brice/.asdf/installs/python/3.9.6/lib/python3.9/concurrent/futures/_base.py", line 390, in __get_result
    raise self._exception
  File "/Users/brice/.asdf/installs/python/3.9.6/lib/python3.9/concurrent/futures/thread.py", line 52, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/brice/.asdf/installs/python/3.9.6/lib/python3.9/site-packages/kili/queries/asset/helpers.py", line 131, in download_single_asset
    response = requests.get(asset["jsonContent"], timeout=20)
  File "/Users/brice/.asdf/installs/python/3.9.6/lib/python3.9/site-packages/requests/api.py", line 75, in get
    return request('get', url, params=params, **kwargs)
  File "/Users/brice/.asdf/installs/python/3.9.6/lib/python3.9/site-packages/requests/api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "/Users/brice/.asdf/installs/python/3.9.6/lib/python3.9/site-packages/requests/sessions.py", line 515, in request
    prep = self.prepare_request(req)
  File "/Users/brice/.asdf/installs/python/3.9.6/lib/python3.9/site-packages/requests/sessions.py", line 443, in prepare_request
    p.prepare(
  File "/Users/brice/.asdf/installs/python/3.9.6/lib/python3.9/site-packages/requests/models.py", line 318, in prepare
    self.prepare_url(url, params)
  File "/Users/brice/.asdf/installs/python/3.9.6/lib/python3.9/site-packages/requests/models.py", line 392, in prepare_url
    raise MissingSchema(error)
requests.exceptions.MissingSchema: Invalid URL 'None': No scheme supplied. Perhaps you meant http://none/?
```

export failed for an image project, with jsoncontent (big image?)

Our code assumed `asset["jsonContent"]` is either `""` or `"https://..."`. Seems like some `asset["jsonContent"]` can also be `None`.

I tested the same coco export on a big image project with this fix, it worked.

e2e tests: https://github.com/kili-technology/kili-python-sdk/actions/runs/4073123583

need to cherry pick on release/2.129.0