### PR TITLE
fix: fix GraphQL types for License

### DIFF
--- a/src/kili/types.py
+++ b/src/kili/types.py
@@ -34,13 +34,16 @@ class License(TypedDict):
     enableSmartTools: bool
     expiryDate: str
     inputType: InputType
+    maxNumberOfAnnotations: int
+    maxNumberOfAnnotationsPerMonth: int
     maxNumberOfLabeledAssets: int
+    maxNumberOfPredictionsPerMonth: int
+    organizationId: int
     seats: int
     startDate: str
     type: LicenseType
     uploadCloudData: bool
     uploadLocalData: bool
-    organizationId: int
 
 
 class OrganizationWithoutUser(TypedDict):


### PR DESCRIPTION
solves:

```bash
NonExistingFieldError: Cannot query field maxNumberOfAnnotationsPerMonth on object License. Admissible fields are: 
- api
- apiPriority
- canUsePlugins
- enableSmartTools
- expiryDate
- inputType
- maxNumberOfLabeledAssets
- seats
- startDate
- type
- uploadCloudData
- uploadLocalData
- organizationId
```

```graphql
type License {
  _: Boolean
  api: Boolean
  apiPriority: Boolean
  canUsePlugins: Boolean
  enableSmartTools: Boolean
  expiryDate: String
  inputType: [String!]
  maxNumberOfAnnotations: Int
  maxNumberOfAnnotationsPerMonth: Int
  maxNumberOfLabeledAssets: Int
  maxNumberOfLabeledAssetsPerMonth: Int @deprecated(reason: "This is not part of the billing")
  maxNumberOfPredictionsPerMonth: Int
  organizationId: String
  seats: Int
  startDate: String
  type: LicenseType
  uploadCloudData: Boolean
  uploadLocalData: Boolean
}
```