### PR TITLE
fix: fix bugs in ProjectCopier and MedialDownloader

### DIFF
--- a/src/kili/queries/asset/__init__.py
+++ b/src/kili/queries/asset/__init__.py
@@ -204,7 +204,7 @@ class QueriesAsset:
         )
         disable_tqdm = disable_tqdm_if_as_generator(as_generator, disable_tqdm)
         options = QueryOptions(disable_tqdm, first, skip)
-        post_call_function = get_download_assets_function(
+        post_call_function, fields = get_download_assets_function(
             self, download_media, fields, project_id, local_media_dir
         )
         assets_gen = AssetQuery(self.auth.client)(where, fields, options, post_call_function)

--- a/src/kili/queries/asset/media_downloader.py
+++ b/src/kili/queries/asset/media_downloader.py
@@ -30,7 +30,7 @@ def get_download_assets_function(
         return None
     projects = list(
         ProjectQuery(kili.auth.client)(
-            ProjectWhere(project_id=project_id), fields, QueryOptions(disable_tqdm=True)
+            ProjectWhere(project_id=project_id), ["inputType"], QueryOptions(disable_tqdm=True)
         )
     )
     if len(projects) == 0:

--- a/src/kili/queries/asset/media_downloader.py
+++ b/src/kili/queries/asset/media_downloader.py
@@ -21,13 +21,16 @@ from .exceptions import MissingPropertyError
 
 def get_download_assets_function(
     kili, download_media: bool, fields: List[str], project_id: str, local_media_dir: Optional[str]
-) -> Optional[Callable]:
-    """
-    Return the function to be called after each batch of asset query.
-    It is either None or MediaDownloader's download_assets.
+) -> Tuple[Optional[Callable], List[str]]:
+    """Get the function to be called after each batch of asset query.
+
+    The function is either None or MediaDownloader.download_assets().
+
+    Also returns the fields to be queried, which may be modified
+    if the jsonContent field is necessary.
     """
     if not download_media:
-        return None
+        return None, fields
     projects = list(
         ProjectQuery(kili.auth.client)(
             ProjectWhere(project_id=project_id), ["inputType"], QueryOptions(disable_tqdm=True)
@@ -41,14 +44,17 @@ def get_download_assets_function(
     input_type = projects[0]["inputType"]
     jsoncontent_field_added = False
     if input_type in ("TEXT", "VIDEO") and "jsonContent" not in fields:
-        fields.append("jsonContent")
+        fields = fields + ["jsonContent"]
         jsoncontent_field_added = True
-    return MediaDownloader(
-        local_media_dir,
-        project_id,
-        jsoncontent_field_added,
-        input_type,
-    ).download_assets
+    return (
+        MediaDownloader(
+            local_media_dir,
+            project_id,
+            jsoncontent_field_added,
+            input_type,
+        ).download_assets,
+        fields,
+    )
 
 
 class MediaDownloader:

--- a/src/kili/services/copy_project/__init__.py
+++ b/src/kili/services/copy_project/__init__.py
@@ -192,7 +192,7 @@ class ProjectCopier:  # pylint: disable=too-few-public-methods
             pass
 
     def _download_assets(self, from_project_id, fields, tmp_dir, assets):
-        download_function = get_download_assets_function(
+        download_function, _ = get_download_assets_function(
             self.kili,
             download_media=True,
             fields=fields,

--- a/src/kili/services/copy_project/__init__.py
+++ b/src/kili/services/copy_project/__init__.py
@@ -163,7 +163,6 @@ class ProjectCopier:  # pylint: disable=too-few-public-methods
             review_coverage=src_project["reviewCoverage"],
         )
 
-    # pylint: disable=too-many-locals
     def _copy_assets(self, from_project_id: str, new_project_id: str):
         """
         Copy assets from a project to another.
@@ -185,7 +184,12 @@ class ProjectCopier:  # pylint: disable=too-few-public-methods
                 downloaded_assets = self._download_assets(from_project_id, fields, tmp_dir, assets)
                 return self._upload_assets(new_project_id, downloaded_assets)
 
-        return AssetQuery(self.kili.auth.client)(where, fields, options, download_and_upload_assets)
+        asset_gen = AssetQuery(self.kili.auth.client)(
+            where, fields, options, download_and_upload_assets
+        )
+        # Generator needs to be iterated over to actually fetch assets
+        for _ in asset_gen:
+            pass
 
     def _download_assets(self, from_project_id, fields, tmp_dir, assets):
         download_function = get_download_assets_function(

--- a/src/kili/services/export/tools.py
+++ b/src/kili/services/export/tools.py
@@ -103,7 +103,7 @@ def fetch_assets(  # pylint: disable=too-many-arguments
             label_type_in=label_type_in,
         )
     options = QueryOptions(disable_tqdm=disable_tqdm)
-    post_call_function = get_download_assets_function(
+    post_call_function, fields = get_download_assets_function(
         kili, download_media, fields, project_id, local_media_dir
     )
     assets = list(AssetQuery(kili.auth.client)(where, fields, options, post_call_function))


### PR DESCRIPTION
the ProjectQuery was using fields for AssetsQuery

the assets copy in ProjectCopier was not done

e2e: https://github.com/kili-technology/kili-python-sdk/actions/runs/4075049946