### PR TITLE
fix: add delay after mutations

### DIFF
--- a/src/kili/mutations/asset/__init__.py
+++ b/src/kili/mutations/asset/__init__.py
@@ -5,6 +5,10 @@ Asset mutations
 import warnings
 from typing import Any, Dict, List, Optional, Union
 
+from tenacity import Retrying
+from tenacity.retry import retry_if_exception_type
+from tenacity.stop import stop_after_delay
+from tenacity.wait import wait_random
 from typeguard import typechecked
 
 from kili.authentication import KiliAuth
@@ -23,6 +27,7 @@ from kili.orm import Asset
 from kili.services.asset_import import import_assets
 from kili.utils.pagination import _mutate_from_paginated_call
 
+from ..exceptions import MutationError
 from .helpers import get_asset_ids_or_throw_error
 
 
@@ -336,8 +341,30 @@ class MutationsAsset:
         def generate_variables(batch):
             return {"where": {"idIn": batch["asset_ids"]}}
 
+        def verify_last_batch(last_batch: Dict, results: List):
+            """Check that all assets in the last batch have been deleted."""
+            for attempt in Retrying(
+                stop=stop_after_delay(5),
+                wait=wait_random(min=1, max=2),
+                retry=retry_if_exception_type(MutationError),
+            ):
+                with attempt:
+                    asset_ids = last_batch["asset_ids"]
+                    nb_assets_in_kili = AssetQuery(self.auth.client).count(
+                        AssetWhere(
+                            project_id=results[0]["data"]["data"]["id"],
+                            asset_id_in=asset_ids,
+                        )
+                    )
+                    if nb_assets_in_kili > 0:
+                        raise MutationError("Failed to delete some assets.")
+
         results = _mutate_from_paginated_call(
-            self, properties_to_batch, generate_variables, GQL_DELETE_MANY_FROM_DATASET
+            self,
+            properties_to_batch,
+            generate_variables,
+            GQL_DELETE_MANY_FROM_DATASET,
+            last_batch_callback=verify_last_batch,
         )
         return format_result("data", results[0], Asset)
 
@@ -378,11 +405,31 @@ class MutationsAsset:
         def generate_variables(batch):
             return {"where": {"idIn": batch["asset_ids"]}}
 
+        def verify_last_batch(last_batch: Dict, results: List):
+            """Check that all assets in the last batch have been sent to review."""
+            for attempt in Retrying(
+                stop=stop_after_delay(5),
+                wait=wait_random(min=1, max=2),
+                retry=retry_if_exception_type(MutationError),
+            ):
+                with attempt:
+                    asset_ids = last_batch["asset_ids"]
+                    nb_assets_in_review = AssetQuery(self.auth.client).count(
+                        AssetWhere(
+                            project_id=results[0]["data"]["data"]["id"],
+                            asset_id_in=asset_ids,
+                            status_in=["TO_REVIEW"],
+                        )
+                    )
+                    if len(asset_ids) != nb_assets_in_review:
+                        raise MutationError("Failed to send some assets to review")
+
         results = _mutate_from_paginated_call(
             self,
             properties_to_batch,
             generate_variables,
             GQL_ADD_ALL_LABELED_ASSETS_TO_REVIEW,
+            last_batch_callback=verify_last_batch,
         )
         result = format_result("data", results[0])
         if isinstance(result, dict) and "id" in result:
@@ -428,8 +475,31 @@ class MutationsAsset:
         def generate_variables(batch):
             return {"where": {"idIn": batch["asset_ids"]}}
 
+        def verify_last_batch(last_batch: Dict, results: List):
+            """Check that all assets in the last batch have been sent back to queue."""
+            for attempt in Retrying(
+                stop=stop_after_delay(5),
+                wait=wait_random(min=1, max=2),
+                retry=retry_if_exception_type(MutationError),
+            ):
+                with attempt:
+                    asset_ids = last_batch["asset_ids"]
+                    nb_assets_in_queue = AssetQuery(self.auth.client).count(
+                        AssetWhere(
+                            project_id=results[0]["data"]["data"]["id"],
+                            asset_id_in=asset_ids,
+                            status_in=["ONGOING"],
+                        )
+                    )
+                    if len(asset_ids) != nb_assets_in_queue:
+                        raise MutationError("Failed to send some assets back to queue")
+
         results = _mutate_from_paginated_call(
-            self, properties_to_batch, generate_variables, GQL_SEND_BACK_ASSETS_TO_QUEUE
+            self,
+            properties_to_batch,
+            generate_variables,
+            GQL_SEND_BACK_ASSETS_TO_QUEUE,
+            last_batch_callback=verify_last_batch,
         )
         result = format_result("data", results[0])
         assets_in_queue = AssetQuery(self.auth.client)(

--- a/src/kili/mutations/exceptions.py
+++ b/src/kili/mutations/exceptions.py
@@ -1,0 +1,7 @@
+"""
+Errors raised by the mutations module
+"""
+
+
+class MutationError(Exception):
+    """Errors raised when mutation fails."""

--- a/src/kili/mutations/project/__init__.py
+++ b/src/kili/mutations/project/__init__.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional, Union
 from tenacity import Retrying
 from tenacity.retry import retry_if_exception_type
 from tenacity.stop import stop_after_delay
-from tenacity.wait import wait_random
+from tenacity.wait import wait_fixed
 from typeguard import typechecked
 
 from kili import services
@@ -252,7 +252,7 @@ class MutationsProject:
         # We wait for the project to be created
         for attempt in Retrying(
             stop=stop_after_delay(5),
-            wait=wait_random(min=1, max=2),
+            wait=wait_fixed(1),
             retry=retry_if_exception_type(NotFound),
         ):
             with attempt:

--- a/src/kili/mutations/project/__init__.py
+++ b/src/kili/mutations/project/__init__.py
@@ -3,9 +3,14 @@
 from json import dumps
 from typing import Any, Dict, Optional, Union
 
+from tenacity import Retrying
+from tenacity.retry import retry_if_exception_type
+from tenacity.stop import stop_after_delay
+from tenacity.wait import wait_random
 from typeguard import typechecked
 
 from kili import services
+from kili.exceptions import NotFound
 
 from ...authentication import KiliAuth
 from ...helpers import format_result
@@ -242,7 +247,18 @@ class MutationsProject:
             }
         }
         result = self.auth.client.execute(GQL_CREATE_PROJECT, variables)
-        return format_result("data", result)
+        result = format_result("data", result)
+
+        # We wait for the project to be created
+        for attempt in Retrying(
+            stop=stop_after_delay(5),
+            wait=wait_random(min=1, max=2),
+            retry=retry_if_exception_type(NotFound),
+        ):
+            with attempt:
+                _ = services.get_project(self, project_id=result["id"], fields=["id"])
+
+        return result
 
     @typechecked
     def update_properties_in_role(self, role_id: str, project_id: str, user_id: str, role: str):

--- a/src/kili/services/asset_import/base.py
+++ b/src/kili/services/asset_import/base.py
@@ -119,7 +119,7 @@ class BaseBatchImporter:
         nb_assets_in_kili = AssetQuery(self.auth.client).count(where)
         if len(assets) != nb_assets_in_kili:
             raise BatchImportError(
-                "Number of assets imported is not equal to number of assets in Kili."
+                "Number of assets to upload is not equal to number of assets uploaded in Kili."
             )
 
     def add_ids(self, assets: List[AssetLike]):

--- a/src/kili/services/asset_import/base.py
+++ b/src/kili/services/asset_import/base.py
@@ -12,7 +12,7 @@ from uuid import uuid4
 from tenacity import retry
 from tenacity.retry import retry_if_exception_type
 from tenacity.stop import stop_after_delay
-from tenacity.wait import wait_random
+from tenacity.wait import wait_fixed
 
 from kili.authentication import KiliAuth
 from kili.graphql import QueryOptions
@@ -107,7 +107,7 @@ class BaseBatchImporter:
 
     @retry(
         retry=retry_if_exception_type(BatchImportError),
-        wait=wait_random(1, 2),
+        wait=wait_fixed(1),
         stop=stop_after_delay(5),
     )
     def verify_batch_imported(self, assets: List):

--- a/src/kili/services/asset_import/exceptions.py
+++ b/src/kili/services/asset_import/exceptions.py
@@ -20,3 +20,9 @@ class UploadFromLocalDataForbiddenError(Exception):
     """
     Raised when data given to import does not follow a right format
     """
+
+
+class BatchImportError(Exception):
+    """
+    Raised when an error occurs during the import a batch of assets
+    """

--- a/src/kili/services/asset_import/types.py
+++ b/src/kili/services/asset_import/types.py
@@ -7,7 +7,7 @@ from typing_extensions import TypedDict
 
 class AssetLike(TypedDict, total=False):
     """
-    General type of an asset obejct through the import functions
+    General type of an asset object through the import functions
     """
 
     content: Union[str, bytes]

--- a/src/kili/services/asset_import/video.py
+++ b/src/kili/services/asset_import/video.py
@@ -82,12 +82,12 @@ class VideoContentBatchImporter(ContentBatchImporter, VideoMixin):
         json_metadata = {**json_metadata, "processingParameters": processing_parameters}
         return AssetLike(**{**asset, "json_metadata": json_metadata})
 
-    def import_batch(self, assets: List[AssetLike]):
+    def import_batch(self, assets: List[AssetLike], verify: bool):
         """
         Import a batch of video assets from content into Kili.
         """
         assets = self.loop_on_batch(self.add_video_processing_parameters)(assets)
-        return super().import_batch(assets)
+        return super().import_batch(assets, verify)
 
 
 class FrameBatchImporter(JsonContentBatchImporter, VideoMixin):
@@ -104,7 +104,7 @@ class FrameBatchImporter(JsonContentBatchImporter, VideoMixin):
         json_metadata = {**json_metadata, "processingParameters": processing_parameters}
         return AssetLike(**{**asset, "json_metadata": json_metadata})
 
-    def import_batch(self, assets: List[AssetLike]):
+    def import_batch(self, assets: List[AssetLike], verify: bool):
         """
         Import a batch of video assets from frames
         """
@@ -113,7 +113,7 @@ class FrameBatchImporter(JsonContentBatchImporter, VideoMixin):
             assets = self.loop_on_batch(self.upload_frames_to_bucket)(assets)
         assets = self.loop_on_batch(self.map_frame_urls_to_index)(assets)
         assets = self.loop_on_batch(self.add_video_processing_parameters)(assets)
-        return super().import_batch(assets)
+        return super().import_batch(assets, verify)
 
     def upload_frames_to_bucket(self, asset: AssetLike):
         """

--- a/src/kili/services/label_import/importer/__init__.py
+++ b/src/kili/services/label_import/importer/__init__.py
@@ -111,7 +111,7 @@ class AbstractLabelImporter(ABC):
             }
             for label in labels
         ]
-        batch_generator = pagination.batch_iterator_builder(labels_data)
+        batch_generator = pagination.BatchIteratorBuilder(labels_data)
         result = []
         with tqdm.tqdm(total=len(labels_data), disable=self.logger_params.disable_tqdm) as pbar:
             for batch_labels in batch_generator:

--- a/src/kili/utils/pagination.py
+++ b/src/kili/utils/pagination.py
@@ -3,6 +3,7 @@ Utils
 """
 import functools
 import time
+from time import sleep
 from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, TypeVar
 
 from kili.constants import MUTATION_BATCH_SIZE, THROTTLING_DELAY
@@ -175,7 +176,7 @@ def _mutate_from_paginated_call(
                 properties_to_batch=properties_to_batch,
                 generate_variables=generate_variables
                 request= APPEND_MANY_TO_DATASET
-                )
+        )
         '''
     """
     results = []
@@ -185,4 +186,5 @@ def _mutate_from_paginated_call(
         results.append(result)
         if "errors" in result:
             raise GraphQLError(result["errors"], batch_number)
+    sleep(2)  # wait for the mutation to be processed
     return results

--- a/src/kili/utils/pagination.py
+++ b/src/kili/utils/pagination.py
@@ -3,6 +3,7 @@ Utils
 """
 import functools
 import time
+from time import sleep
 from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, TypeVar
 
 from kili.constants import MUTATION_BATCH_SIZE, THROTTLING_DELAY
@@ -190,6 +191,7 @@ def _mutate_from_paginated_call(
         if "errors" in result:
             raise GraphQLError(result["errors"], batch_number)
 
+    sleep(1)  # wait for the backend to process the mutations
     if batch and results and last_batch_callback:
         last_batch_callback(batch, results)
     return results

--- a/src/kili/utils/pagination.py
+++ b/src/kili/utils/pagination.py
@@ -186,5 +186,5 @@ def _mutate_from_paginated_call(
         results.append(result)
         if "errors" in result:
             raise GraphQLError(result["errors"], batch_number)
-    sleep(2)  # wait for the mutation to be processed
+    sleep(1)  # wait for the mutation to be processed
     return results

--- a/tests/e2e/test_mutations_asset.py
+++ b/tests/e2e/test_mutations_asset.py
@@ -91,6 +91,7 @@ def test_delete_many_from_dataset(kili, src_project):
     assert ret["id"] == src_project["id"]
 
     assets = kili.assets(src_project["id"], fields=["id"])
+    assert len(assets) == 1
     assert assets[0]["id"] == asset_ids[2]
 
 

--- a/tests/e2e/test_mutations_asset.py
+++ b/tests/e2e/test_mutations_asset.py
@@ -83,6 +83,17 @@ def src_project(kili):
     kili.delete_project(project["id"])
 
 
+def test_delete_many_from_dataset(kili, src_project):
+    assets = kili.assets(src_project["id"], fields=["id"])
+    asset_ids = [asset["id"] for asset in assets]
+    ret = kili.delete_many_from_dataset(asset_ids=asset_ids[:2])
+
+    assert ret["id"] == src_project["id"]
+
+    assets = kili.assets(src_project["id"], fields=["id"])
+    assert assets[0]["id"] == asset_ids[2]
+
+
 def test_add_to_review(kili, src_project):
     assets = kili.assets(src_project["id"], fields=["id"])
     asset_ids = [asset["id"] for asset in assets]

--- a/tests/services/asset_import/test_import_common.py
+++ b/tests/services/asset_import/test_import_common.py
@@ -31,6 +31,7 @@ from tests.services.asset_import.mocks import (
 )
 class TestContentType(ImportTestCase):
     @patch.object(ProjectQuery, "__call__", side_effect=mocked_project_input_type("VIDEO_LEGACY"))
+    @patch.object(AssetQuery, "count", return_value=1)
     def test_cannot_upload_an_image_to_video_project(self, *_):
         url = "https://storage.googleapis.com/label-public-staging/car/car_1.jpg"
         path_image = self.downloader(url)
@@ -39,6 +40,7 @@ class TestContentType(ImportTestCase):
             import_assets(self.auth, self.project_id, assets, disable_tqdm=True)
 
     @patch.object(ProjectQuery, "__call__", side_effect=mocked_project_input_type("IMAGE"))
+    @patch.object(AssetQuery, "count", return_value=1)
     def test_cannot_import_files_not_found_to_an_image_project(self, *_):
         path = "./doesnotexist.png"
         assets = [{"content": path, "external_id": "image"}]
@@ -46,6 +48,7 @@ class TestContentType(ImportTestCase):
             import_assets(self.auth, self.project_id, assets, disable_tqdm=True)
 
     @patch.object(ProjectQuery, "__call__", side_effect=mocked_project_input_type("PDF"))
+    @patch.object(AssetQuery, "count", return_value=1)
     def test_cannot_upload_raw_text_to_pdf_project(self, *_):
         path = "Hello world"
         assets = [{"content": path, "external_id": "image"}]
@@ -53,6 +56,7 @@ class TestContentType(ImportTestCase):
             import_assets(self.auth, self.project_id, assets, disable_tqdm=True)
 
     @patch.object(ProjectQuery, "__call__", side_effect=mocked_project_input_type("TEXT"))
+    @patch.object(AssetQuery, "count", return_value=3)
     def test_generate_different_uuid4_external_ids_if_not_given(self, *_):
         assets = [{"content": "One"}, {"content": "Two"}, {"content": "Three"}]
         import_assets(self.auth, self.project_id, assets, disable_tqdm=True)

--- a/tests/services/asset_import/test_import_image.py
+++ b/tests/services/asset_import/test_import_image.py
@@ -76,7 +76,7 @@ class ImageTestCase(ImportTestCase):
         )
         self.auth.client.execute.assert_called_with(*expected_parameters)
 
-    @patch.object(AssetQuery, "count", return_value=1)  # 2 images are uplaoded in different batches
+    @patch.object(AssetQuery, "count", return_value=1)  # 2 images are uploaded in different batches
     def test_upload_with_one_tiff_and_one_basic_image(self, *_):
         url_tiff = "https://storage.googleapis.com/label-public-staging/geotiffs/bogota.tif"
         url_basic = "https://storage.googleapis.com/label-public-staging/car/car_1.jpg"

--- a/tests/services/asset_import/test_import_image.py
+++ b/tests/services/asset_import/test_import_image.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
+from kili.graphql.operations.asset.queries import AssetQuery
 from kili.graphql.operations.organization.queries import OrganizationQuery
 from kili.graphql.operations.project.queries import ProjectQuery
 from kili.queries.asset import QueriesAsset
@@ -32,6 +33,7 @@ from tests.services.asset_import.mocks import (
     side_effect=mocked_organization_with_upload_from_local(upload_local_data=True),
 )
 class ImageTestCase(ImportTestCase):
+    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_from_one_local_image(self, *_):
         url = "https://storage.googleapis.com/label-public-staging/car/car_1.jpg"
         path_image = self.downloader(url)
@@ -48,6 +50,7 @@ class ImageTestCase(ImportTestCase):
         )
         self.auth.client.execute.assert_called_with(*expected_parameters)
 
+    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_from_one_hosted_image(self, *_):
         assets = [
             {"content": "https://hosted-data", "external_id": "hosted file", "id": "unique_id"}
@@ -58,6 +61,7 @@ class ImageTestCase(ImportTestCase):
         )
         self.auth.client.execute.assert_called_with(*expected_parameters)
 
+    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_from_one_local_tiff_image(self, *_):
         url = "https://storage.googleapis.com/label-public-staging/geotiffs/bogota.tif"
         path_image = self.downloader(url)
@@ -72,6 +76,7 @@ class ImageTestCase(ImportTestCase):
         )
         self.auth.client.execute.assert_called_with(*expected_parameters)
 
+    @patch.object(AssetQuery, "count", return_value=1)  # 2 images are uplaoded in different batches
     def test_upload_with_one_tiff_and_one_basic_image(self, *_):
         url_tiff = "https://storage.googleapis.com/label-public-staging/geotiffs/bogota.tif"
         url_basic = "https://storage.googleapis.com/label-public-staging/car/car_1.jpg"
@@ -101,9 +106,11 @@ class ImageTestCase(ImportTestCase):
         calls = [call(*expected_parameters_sync), call(*expected_parameters_async)]
         self.auth.client.execute.assert_has_calls(calls, any_order=True)
 
+    @patch.object(AssetQuery, "count", return_value=5)
     def test_upload_from_several_batches(self, *_):
         self.assert_upload_several_batches()
 
+    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_from_one_hosted_image_authorized_while_local_forbidden(self, *_):
         OrganizationQuery.__call__.side_effect = mocked_organization_with_upload_from_local(
             upload_local_data=False

--- a/tests/services/asset_import/test_import_pdf.py
+++ b/tests/services/asset_import/test_import_pdf.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from kili.graphql.operations.asset.queries import AssetQuery
 from kili.graphql.operations.organization.queries import OrganizationQuery
 from kili.graphql.operations.project.queries import ProjectQuery
 from kili.queries.asset import QueriesAsset
@@ -32,6 +33,7 @@ from tests.services.asset_import.mocks import (
     side_effect=mocked_organization_with_upload_from_local(upload_local_data=True),
 )
 class PDFTestCase(ImportTestCase):
+    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_from_one_local_pdf(self, *_):
         url = (
             "https://storage.googleapis.com/label-public-staging/asset-test-sample/pdfs/sample.pdf"
@@ -50,6 +52,7 @@ class PDFTestCase(ImportTestCase):
         )
         self.auth.client.execute.assert_called_with(*expected_parameters)
 
+    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_from_one_hosted_pdf(self, *_):
         assets = [
             {"content": "https://hosted-data", "external_id": "hosted file", "id": "unique_id"}
@@ -60,9 +63,11 @@ class PDFTestCase(ImportTestCase):
         )
         self.auth.client.execute.assert_called_with(*expected_parameters)
 
+    @patch.object(AssetQuery, "count", return_value=5)
     def test_upload_from_several_batches(self, *_):
         self.assert_upload_several_batches()
 
+    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_from_one_hosted_pdf_authorized_while_local_forbidden(self, *_):
         OrganizationQuery.__call__.side_effect = mocked_organization_with_upload_from_local(
             upload_local_data=False

--- a/tests/services/asset_import/test_import_text.py
+++ b/tests/services/asset_import/test_import_text.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from kili.graphql.operations.asset.queries import AssetQuery
 from kili.graphql.operations.organization.queries import OrganizationQuery
 from kili.graphql.operations.project.queries import ProjectQuery
 from kili.queries.asset import QueriesAsset
@@ -31,6 +32,7 @@ from tests.services.asset_import.mocks import (
     side_effect=mocked_organization_with_upload_from_local(upload_local_data=True),
 )
 class TextTestCase(ImportTestCase):
+    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_from_one_local_text_file(self, *_):
         url = "https://storage.googleapis.com/label-public-staging/asset-test-sample/texts/test_text_file.txt"
         path = self.downloader(url)
@@ -47,6 +49,7 @@ class TextTestCase(ImportTestCase):
         )
         self.auth.client.execute.assert_called_with(*expected_parameters)
 
+    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_from_one_hosted_text_file(self, *_):
         assets = [
             {"content": "https://hosted-data", "external_id": "hosted file", "id": "unique_id"}
@@ -57,6 +60,7 @@ class TextTestCase(ImportTestCase):
         )
         self.auth.client.execute.assert_called_with(*expected_parameters)
 
+    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_from_raw_text(self, *_):
         assets = [{"content": "this is raw text", "external_id": "raw text"}]
         import_assets(self.auth, self.project_id, assets)
@@ -71,6 +75,7 @@ class TextTestCase(ImportTestCase):
         )
         self.auth.client.execute.assert_called_with(*expected_parameters)
 
+    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_from_one_rich_text(self, *_):
         json_content = [
             {
@@ -96,9 +101,11 @@ class TextTestCase(ImportTestCase):
         )
         self.auth.client.execute.assert_called_with(*expected_parameters)
 
+    @patch.object(AssetQuery, "count", return_value=5)
     def test_upload_from_several_batches(self, *_):
         self.assert_upload_several_batches()
 
+    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_from_one_hosted_text_authorized_while_local_forbidden(self, *_):
         OrganizationQuery.__call__.side_effect = mocked_organization_with_upload_from_local(
             upload_local_data=False

--- a/tests/services/asset_import/test_import_video.py
+++ b/tests/services/asset_import/test_import_video.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from kili.graphql.operations.asset.queries import AssetQuery
 from kili.graphql.operations.organization.queries import OrganizationQuery
 from kili.graphql.operations.project.queries import ProjectQuery
 from kili.queries.asset import QueriesAsset
@@ -33,6 +34,7 @@ from tests.services.asset_import.mocks import (
     side_effect=mocked_organization_with_upload_from_local(upload_local_data=True),
 )
 class VideoTestCase(ImportTestCase):
+    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_from_one_local_video_file_to_native(self, *_):
         url = "https://storage.googleapis.com/label-public-staging/asset-test-sample/video/short_video.mp4"
         path = self.downloader(url)
@@ -58,6 +60,7 @@ class VideoTestCase(ImportTestCase):
         )
         self.auth.client.execute.assert_called_with(*expected_parameters)
 
+    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_from_one_hosted_video_file_to_native(self, *_):
         assets = [
             {"content": "https://hosted-data", "external_id": "hosted file", "id": "unique_id"}
@@ -83,6 +86,7 @@ class VideoTestCase(ImportTestCase):
         )
         self.auth.client.execute.assert_called_with(*expected_parameters)
 
+    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_from_one_hosted_video_authorized_while_local_forbidden(self, *_):
         OrganizationQuery.__call__.side_effect = mocked_organization_with_upload_from_local(
             upload_local_data=False
@@ -117,6 +121,7 @@ class VideoTestCase(ImportTestCase):
         with pytest.raises(UploadFromLocalDataForbiddenError):
             import_assets(self.auth, self.project_id, assets, disable_tqdm=True)
 
+    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_one_local_video_to_frames(self, *_):
         url = "https://storage.googleapis.com/label-public-staging/asset-test-sample/video/short_video.mp4"
         path = self.downloader(url)
@@ -151,6 +156,7 @@ class VideoTestCase(ImportTestCase):
         )
         self.auth.client.execute.assert_called_with(*expected_parameters)
 
+    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_one_hosted_video_to_frames(self, *_):
         assets = [
             {
@@ -184,6 +190,7 @@ class VideoTestCase(ImportTestCase):
         )
         self.auth.client.execute.assert_called_with(*expected_parameters)
 
+    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_one_video_from_local_frames(self, *_):
         hosted_frame_folder = (
             "https://storage.googleapis.com/label-public-staging/asset-test-sample/video/frames/"
@@ -219,6 +226,7 @@ class VideoTestCase(ImportTestCase):
         )
         self.auth.client.execute.assert_called_with(*expected_parameters)
 
+    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_one_video_from_hosted_frames(self, *_):
         url_frame1 = "https://frame1"
         url_frame2 = "https://frame2"
@@ -251,6 +259,7 @@ class VideoTestCase(ImportTestCase):
         )
         self.auth.client.execute.assert_called_with(*expected_parameters)
 
+    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_frames_call_from_label_import(self, *_):
         url_frame1 = "https://frame1"
         url_frame2 = "https://frame2"
@@ -284,6 +293,7 @@ class VideoTestCase(ImportTestCase):
         )
         self.auth.client.execute.assert_called_with(*expected_parameters)
 
+    @patch.object(AssetQuery, "count", return_value=1)
     def test_import_one_video_with_metadata(self, *_):
         assets = [
             {
@@ -327,6 +337,7 @@ class VideoTestCase(ImportTestCase):
     MagicMock(return_value=[]),
 )
 class VideoLegacyTestCase(ImportTestCase):
+    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_from_one_hosted_video_file_to_video_legacy_project(self, *_):
         assets = [
             {"content": "https://hosted-data", "external_id": "hosted file", "id": "unique_id"}

--- a/tests/services/asset_import/test_import_video.py
+++ b/tests/services/asset_import/test_import_video.py
@@ -33,8 +33,8 @@ from tests.services.asset_import.mocks import (
     "__call__",
     side_effect=mocked_organization_with_upload_from_local(upload_local_data=True),
 )
+@patch.object(AssetQuery, "count", return_value=1)
 class VideoTestCase(ImportTestCase):
-    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_from_one_local_video_file_to_native(self, *_):
         url = "https://storage.googleapis.com/label-public-staging/asset-test-sample/video/short_video.mp4"
         path = self.downloader(url)
@@ -60,7 +60,6 @@ class VideoTestCase(ImportTestCase):
         )
         self.auth.client.execute.assert_called_with(*expected_parameters)
 
-    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_from_one_hosted_video_file_to_native(self, *_):
         assets = [
             {"content": "https://hosted-data", "external_id": "hosted file", "id": "unique_id"}
@@ -86,7 +85,6 @@ class VideoTestCase(ImportTestCase):
         )
         self.auth.client.execute.assert_called_with(*expected_parameters)
 
-    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_from_one_hosted_video_authorized_while_local_forbidden(self, *_):
         OrganizationQuery.__call__.side_effect = mocked_organization_with_upload_from_local(
             upload_local_data=False
@@ -121,7 +119,6 @@ class VideoTestCase(ImportTestCase):
         with pytest.raises(UploadFromLocalDataForbiddenError):
             import_assets(self.auth, self.project_id, assets, disable_tqdm=True)
 
-    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_one_local_video_to_frames(self, *_):
         url = "https://storage.googleapis.com/label-public-staging/asset-test-sample/video/short_video.mp4"
         path = self.downloader(url)
@@ -156,7 +153,6 @@ class VideoTestCase(ImportTestCase):
         )
         self.auth.client.execute.assert_called_with(*expected_parameters)
 
-    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_one_hosted_video_to_frames(self, *_):
         assets = [
             {
@@ -190,7 +186,6 @@ class VideoTestCase(ImportTestCase):
         )
         self.auth.client.execute.assert_called_with(*expected_parameters)
 
-    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_one_video_from_local_frames(self, *_):
         hosted_frame_folder = (
             "https://storage.googleapis.com/label-public-staging/asset-test-sample/video/frames/"
@@ -226,7 +221,6 @@ class VideoTestCase(ImportTestCase):
         )
         self.auth.client.execute.assert_called_with(*expected_parameters)
 
-    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_one_video_from_hosted_frames(self, *_):
         url_frame1 = "https://frame1"
         url_frame2 = "https://frame2"
@@ -259,7 +253,6 @@ class VideoTestCase(ImportTestCase):
         )
         self.auth.client.execute.assert_called_with(*expected_parameters)
 
-    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_frames_call_from_label_import(self, *_):
         url_frame1 = "https://frame1"
         url_frame2 = "https://frame2"
@@ -293,7 +286,6 @@ class VideoTestCase(ImportTestCase):
         )
         self.auth.client.execute.assert_called_with(*expected_parameters)
 
-    @patch.object(AssetQuery, "count", return_value=1)
     def test_import_one_video_with_metadata(self, *_):
         assets = [
             {
@@ -336,8 +328,8 @@ class VideoTestCase(ImportTestCase):
     "assets",
     MagicMock(return_value=[]),
 )
+@patch.object(AssetQuery, "count", return_value=1)
 class VideoLegacyTestCase(ImportTestCase):
-    @patch.object(AssetQuery, "count", return_value=1)
     def test_upload_from_one_hosted_video_file_to_video_legacy_project(self, *_):
         assets = [
             {"content": "https://hosted-data", "external_id": "hosted file", "id": "unique_id"}

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,7 +1,7 @@
 """Tests for utils module"""
 
 from kili.utils.pagination import (
-    batch_iterator_builder,
+    BatchIteratorBuilder,
     batch_object_builder,
     row_generator_from_paginated_calls,
 )
@@ -101,7 +101,7 @@ def test_batch_iterator_builder():
         }
     ]
     for test_case in TEST_CASE:
-        actual = batch_iterator_builder(test_case["iterable"], batch_size=test_case["batch_size"])
+        actual = BatchIteratorBuilder(test_case["iterable"], batch_size=test_case["batch_size"])
         expected = test_case["expected_result"]
         case_name = test_case["case"]
         assert all(a == b for a, b in zip(actual, expected)), f'Test case "{case_name}" failed'


### PR DESCRIPTION
I looked at past failed e2e tests and added:

- `append_many_to_dataset`: verify that last batch is uploaded in `BaseBatchImporter.import_batch` by querying assets every second for 5s
- `create_project`: check that project is created every second during 5s
- `send_back_to_queue`, `add_to_review` and `delete_many_from_dataset`: add a callback in `_mutate_from_paginated_call` that checks the last batch

For other asset mutations, `update_properties_in_assets` and `change_asset_external_ids`, I cannot query the assets since the project id is not available in those methods, but required in `AssetWhere`. The simplest thing we can do is add a small delay at the end of `_mutate_from_paginated_call` I think