### PR TITLE
ci: fix bug in utils.sh script

### DIFF
--- a/.github/scripts/utils.sh
+++ b/.github/scripts/utils.sh
@@ -20,9 +20,11 @@ bump_version() {
 }
 
 # Takes the version to convert to int
-# 2.129.0 -> 21290
+# 2.129.1 -> 2129001
 version_to_int() {
-    echo "$@" | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }';
+    version=$1
+    as_int=$(echo "$version" | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }';)
+    echo "$((10#$as_int))"  # interpret as base 10
 }
 
 get_last_release_tag_github() {

--- a/.github/workflows/bump_commit_release_branch.yml
+++ b/.github/workflows/bump_commit_release_branch.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   create_bump_commit:
     runs-on: ubuntu-latest
-    name: create bump commit
+    name: create bump commit PR
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
version `002129001` will be interpreted as base 00. We force base 10 conversion

tests:
```bash
(python37) ➜  kili-python-sdk git:(ci/fix-ci-workflows) ✗ source ./.github/scripts/utils.sh
(python37) ➜  kili-python-sdk git:(ci/fix-ci-workflows) ✗ echo $(version_to_int 2.129.1)
2129001
(python37) ➜  kili-python-sdk git:(ci/fix-ci-workflows) ✗ echo $(version_to_int "2.129.1")
2129001
(python37) ➜  kili-python-sdk git:(ci/fix-ci-workflows) ✗ echo $(version_to_int "2.129.145")
2129145
(python37) ➜  kili-python-sdk git:(ci/fix-ci-workflows) ✗ echo $(version_to_int "442.129.145")
442129145
(python37) ➜  kili-python-sdk git:(ci/fix-ci-workflows) ✗ echo $(version_to_int "002.129.145")
2129145
(python37) ➜  kili-python-sdk git:(ci/fix-ci-workflows) ✗
```