### PR TITLE
ci: add CI to run tests from prev release against master

### DIFF
--- a/.github/workflows/e2e_tests_previous_release.yml
+++ b/.github/workflows/e2e_tests_previous_release.yml
@@ -1,0 +1,97 @@
+# This workflow runs e2e tests of previous release against master kili sdk
+# To make sure that we are not introducing breaking changes in the master branch
+
+name: E2E tests previous release against master
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 12 * * 1-5" # once everyday at 12:00 UTC
+jobs:
+  recipes:
+    name: Recipes test
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Get latest release branch
+        shell: bash
+        run: |
+          last_version=$(curl --silent "https://api.github.com/repos/kili-technology/kili-python-sdk/releases/latest" | jq -r .tag_name)
+          echo "Last version: $last_version"
+
+          IFS=. read -r major minor patch <<< "$last_version"
+          last_minor_version="$major.$minor.0"
+          echo "REF=release/$last_minor_version" >> $GITHUB_ENV
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.REF }} # checked out branch
+
+      - name: Delete kili src from checkout repo
+        shell: bash
+        run: |
+          rm -rf src
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+          cache: "pip"
+
+      - name: Upgrade pip
+        run: |
+          python -m pip install --upgrade pip
+
+      - name: Install kili from master branch
+        run: |
+          pip install "kili[dev] @ git+https://github.com/kili-technology/kili-python-sdk.git@master"
+
+      - name: Set proper test server
+        shell: bash
+        run: |
+          echo "TEST_AGAINST=STAGING" >> $GITHUB_ENV
+          echo "KILI_API_ENDPOINT=https://staging.cloud.kili-technology.com/api/label/v2/graphql" >> $GITHUB_ENV
+
+      - name: Integration tests
+        timeout-minutes: 10
+        run: pytest -ra -sv --color yes --code-highlight yes --durations=15 -vv tests/e2e -k ".py"
+        env:
+          KILI_API_CLOUD_VISION: ${{ secrets.KILI_API_CLOUD_VISION }}
+          KILI_API_ENDPOINT: ${{ env.KILI_API_ENDPOINT }}
+          KILI_API_KEY: ${{ secrets[format('KILI_USER_API_KEY_{0}', env.TEST_AGAINST)] }}
+          KILI_USER_EMAIL: ${{ secrets[format('KILI_USER_EMAIL_{0}', env.TEST_AGAINST)] }}
+          KILI_USER_ID: ${{ secrets[format('KILI_USER_ID_{0}', env.TEST_AGAINST)] }}
+
+      - name: Notebook tests
+        timeout-minutes: 15
+        run: pytest -ra -sv --color yes --code-highlight yes --durations=15 -vv tests/test_notebooks.py
+        env:
+          KILI_API_CLOUD_VISION: ${{ secrets.KILI_API_CLOUD_VISION }}
+          KILI_API_ENDPOINT: ${{ env.KILI_API_ENDPOINT }}
+          KILI_API_KEY: ${{ secrets[format('KILI_USER_API_KEY_{0}', env.TEST_AGAINST)] }}
+          KILI_USER_EMAIL: ${{ secrets[format('KILI_USER_EMAIL_{0}', env.TEST_AGAINST)] }}
+          KILI_USER_ID: ${{ secrets[format('KILI_USER_ID_{0}', env.TEST_AGAINST)] }}
+
+      - name: Slack notification if failure
+        if: failure() && (github.event_name != 'workflow_dispatch') # doesn't notify for manual runs
+        id: slack
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload: |
+            {
+              "text": "E2E tests previous release against master failed: ${{ job.status }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "E2E tests previous release against master failed: ${{ job.status }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_PYTHON_SDK_ALARMING }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
ML-971

pip install kili from git master

then checkout repo from latest release branch and run tests

useful to make sure we don't introduce BC in master branch compared to the lastest release

not tested yet