### PR TITLE
ci: make sure bump commit PR branch has unique name

### DIFF
--- a/.github/workflows/bump_commit_release_branch.yml
+++ b/.github/workflows/bump_commit_release_branch.yml
@@ -52,7 +52,7 @@ jobs:
           source ./.github/scripts/utils.sh   # to get the bump_version function
 
           # create PR branch
-          git checkout -b workflow/create-bump-commit-release-branch-${{ inputs.releaseBranchVersion }}
+          git checkout -b workflow-${{ github.run_id }}/create-bump-commit-release-branch-${{ inputs.releaseBranchVersion }}
 
           # create bump commit
           new_version=$(bump_version commit ${{ inputs.bumpCommitType }})

--- a/.github/workflows/bump_commit_release_branch.yml
+++ b/.github/workflows/bump_commit_release_branch.yml
@@ -59,7 +59,7 @@ jobs:
           echo "New version (bump_version): $new_version"
 
           # create PR
-          git push --quiet --set-upstream origin workflow/create-bump-commit-release-branch-${{ inputs.releaseBranchVersion }}
+          git push --quiet --set-upstream origin workflow-${{ github.run_id }}/create-bump-commit-release-branch-${{ inputs.releaseBranchVersion }}
           gh pr create --base release/${{ inputs.releaseBranchVersion }} --title "chore: bump version to $new_version" --body "Bump version to $new_version on branch release/${{ inputs.releaseBranchVersion }}"
 
         env:

--- a/.github/workflows/bump_commit_release_branch.yml
+++ b/.github/workflows/bump_commit_release_branch.yml
@@ -52,14 +52,14 @@ jobs:
           source ./.github/scripts/utils.sh   # to get the bump_version function
 
           # create PR branch
-          git checkout -b workflow-${{ github.run_id }}/create-bump-commit-release-branch-${{ inputs.releaseBranchVersion }}
+          git checkout -b workflow/create-bump-commit-release-branch-${{ inputs.releaseBranchVersion }}-${{ github.run_id }}
 
           # create bump commit
           new_version=$(bump_version commit ${{ inputs.bumpCommitType }})
           echo "New version (bump_version): $new_version"
 
           # create PR
-          git push --quiet --set-upstream origin workflow-${{ github.run_id }}/create-bump-commit-release-branch-${{ inputs.releaseBranchVersion }}
+          git push --quiet --set-upstream origin workflow/create-bump-commit-release-branch-${{ inputs.releaseBranchVersion }}-${{ github.run_id }}
           gh pr create --base release/${{ inputs.releaseBranchVersion }} --title "chore: bump version to $new_version" --body "Bump version to $new_version on branch release/${{ inputs.releaseBranchVersion }}"
 
         env:


### PR DESCRIPTION
in case we forget to delete the previous branch or in case we run the workflow several times, it's safer to create a new branch

tested here: https://github.com/kili-technology/kili-python-sdk/pull/1020