### PR TITLE
feat: add `kili.data_integrations`

### DIFF
--- a/docs/sdk/cloud_storage.md
+++ b/docs/sdk/cloud_storage.md
@@ -1,4 +1,4 @@
-# Remote storage module
+# Cloud storage module
 
 ## Queries
 

--- a/docs/sdk/remote_storage.md
+++ b/docs/sdk/remote_storage.md
@@ -1,0 +1,5 @@
+# Remote storage module
+
+## Queries
+
+::: kili.queries.data_integration.__init__.QueriesDataIntegration

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
       - Reference:
           - API Key: sdk/api_key.md
           - Asset: sdk/asset.md
+          - Cloud Storage: sdk/cloud_storage.md
           - Issue: sdk/issue.md
           - Label: sdk/label.md
           - Notification: sdk/notification.md
@@ -32,7 +33,6 @@ nav:
           - Project: sdk/project.md
           - Project User: sdk/project_user.md
           - Project Version: sdk/project_version.md
-          - Cloud storage: sdk/cloud_storage.md
           - User: sdk/user.md
   - Command line interface:
       - Getting Started: cli/index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,33 +6,34 @@ site_url: https://python-sdk-docs.kili-technology.com/
 ## Repository
 repo_url: https://github.com/kili-technology/kili-python-sdk
 repo_name: Kili Python SDK
-edit_uri: '' #disables edit button
+edit_uri: "" #disables edit button
 
 ## Site Architecture
 nav:
   - Python SDK:
       - Getting Started: index.md
       - Tutorials:
-        - Basic project setup: sdk/tutorials/basic_project_setup.md
-        - Importing assets and labels: sdk/tutorials/importing_assets_and_labels.md
-        - Importing video assets: sdk/tutorials/importing_video_assets.md
-        - Managing workflows: sdk/tutorials/set_up_workflows.md
-        - Exporting project data: sdk/tutorials/export_a_kili_project.md
-        - Developing plugins - overview: sdk/tutorials/plugins_development.md
-        - Developing plugins - example: sdk/tutorials/plugins_example.md
-        - Plugins library: sdk/tutorials/plugins_library.md
+          - Basic project setup: sdk/tutorials/basic_project_setup.md
+          - Importing assets and labels: sdk/tutorials/importing_assets_and_labels.md
+          - Importing video assets: sdk/tutorials/importing_video_assets.md
+          - Managing workflows: sdk/tutorials/set_up_workflows.md
+          - Exporting project data: sdk/tutorials/export_a_kili_project.md
+          - Developing plugins - overview: sdk/tutorials/plugins_development.md
+          - Developing plugins - example: sdk/tutorials/plugins_example.md
+          - Plugins library: sdk/tutorials/plugins_library.md
       - Reference:
-        - API Key: sdk/api_key.md
-        - Asset: sdk/asset.md
-        - Issue: sdk/issue.md
-        - Label: sdk/label.md
-        - Notification: sdk/notification.md
-        - Organization: sdk/organization.md
-        - Plugins: sdk/plugins.md
-        - Project: sdk/project.md
-        - Project User: sdk/project_user.md
-        - Project Version: sdk/project_version.md
-        - User: sdk/user.md
+          - API Key: sdk/api_key.md
+          - Asset: sdk/asset.md
+          - Issue: sdk/issue.md
+          - Label: sdk/label.md
+          - Notification: sdk/notification.md
+          - Organization: sdk/organization.md
+          - Plugins: sdk/plugins.md
+          - Project: sdk/project.md
+          - Project User: sdk/project_user.md
+          - Project Version: sdk/project_version.md
+          - Remote storage: sdk/remote_storage.md
+          - User: sdk/user.md
   - Command line interface:
       - Getting Started: cli/index.md
       - Reference: cli/reference.md
@@ -53,7 +54,7 @@ plugins:
           selection:
             docstring_style: google
             filters:
-              - '!^__' # exclude all members starting with __
+              - "!^__" # exclude all members starting with __
             docstring_options:
               replace_admonitions: yes
       watch:
@@ -82,7 +83,7 @@ extra:
 
 ## Theme and Design
 theme:
-  name: 'material'
+  name: "material"
   palette:
     scheme: kili
   logo: assets/kili_logo.png

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,7 +32,7 @@ nav:
           - Project: sdk/project.md
           - Project User: sdk/project_user.md
           - Project Version: sdk/project_version.md
-          - Remote storage: sdk/remote_storage.md
+          - Cloud storage: sdk/cloud_storage.md
           - User: sdk/user.md
   - Command line interface:
       - Getting Started: cli/index.md

--- a/src/kili/client.py
+++ b/src/kili/client.py
@@ -18,6 +18,7 @@ from kili.mutations.user import MutationsUser
 from kili.project import Project
 from kili.queries.api_key import QueriesApiKey
 from kili.queries.asset import QueriesAsset
+from kili.queries.data_integration import QueriesDataIntegration
 from kili.queries.issue import QueriesIssue
 from kili.queries.label import QueriesLabel
 from kili.queries.notification import QueriesNotification
@@ -45,6 +46,7 @@ class Kili(  # pylint: disable=too-many-ancestors
     MutationsUser,
     QueriesApiKey,
     QueriesAsset,
+    QueriesDataIntegration,
     QueriesIssue,
     QueriesLabel,
     QueriesNotification,

--- a/src/kili/graphql/__init__.py
+++ b/src/kili/graphql/__init__.py
@@ -52,7 +52,7 @@ class GraphQLQuery(ABC):
     def __init__(
         self,
         client: GraphQLClient,
-    ):
+    ) -> None:
         self.client = client
 
     @staticmethod

--- a/src/kili/graphql/operations/api_key/queries.py
+++ b/src/kili/graphql/operations/api_key/queries.py
@@ -34,7 +34,7 @@ class APIKeyWhere(BaseQueryWhere):
 
 
 class APIKeyQuery(GraphQLQuery):
-    """ProjectUser query."""
+    """APIKey query."""
 
     @staticmethod
     def query(fragment):

--- a/src/kili/graphql/operations/data_integration/queries.py
+++ b/src/kili/graphql/operations/data_integration/queries.py
@@ -1,0 +1,63 @@
+"""
+GraphQL Queries of data integrations
+"""
+
+
+from typing import Optional
+
+from kili.graphql import BaseQueryWhere, GraphQLQuery
+
+
+class DataIntegrationWhere(BaseQueryWhere):
+    """
+    Tuple to be passed to the DataIntegrationQuery to restrict the query
+    """
+
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self,
+        data_integration_id: Optional[str] = None,
+        name: Optional[str] = None,
+        platform: Optional[str] = None,
+        status: Optional[str] = None,
+        organization_id: Optional[str] = None,
+    ) -> None:
+        self.data_integration_id = data_integration_id
+        self.name = name
+        self.platform = platform
+        self.status = status
+        self.organization_id = organization_id
+        super().__init__()
+
+    def graphql_where_builder(self):
+        """Build the GraphQL Where payload sent in the resolver from the SDK DataIntegrationWhere"""
+        return {
+            "id": self.data_integration_id,
+            "name": self.name,
+            "platform": self.platform,
+            "status": self.status,
+            "organizationId": self.organization_id,
+        }
+
+
+class DataIntegrationQuery(GraphQLQuery):
+    """DataIntegration query."""
+
+    @staticmethod
+    def query(fragment):
+        """
+        Return the GraphQL dataIntegrations query
+        """
+        return f"""
+        query dataIntegrations($where: DataIntegrationWhere!, $first: PageSize!, $skip: Int!) {{
+          data: dataIntegrations(where: $where, skip: $skip, first: $first) {{
+            {fragment}
+          }}
+        }}
+        """
+
+    COUNT_QUERY = """
+    query countDataIntegrations($where: DataIntegrationWhere!) {
+      data: countDataIntegrations(where: $where)
+    }
+    """

--- a/src/kili/queries/data_integration/__init__.py
+++ b/src/kili/queries/data_integration/__init__.py
@@ -3,6 +3,7 @@
 from typing import Dict, Iterable, List, Optional
 
 from typeguard import typechecked
+from typing_extensions import Literal
 
 from kili.authentication import KiliAuth
 from kili.graphql import QueryOptions
@@ -33,8 +34,8 @@ class QueriesDataIntegration:
         self,
         data_integration_id: Optional[str] = None,
         name: Optional[str] = None,
-        platform: Optional[str] = None,
-        status: Optional[str] = None,
+        platform: Optional[Literal["AWS", "Azure", "GCP"]] = None,
+        status: Optional[Literal["CONNECTED", "DISCONNECTED", "CHECKING"]] = None,
         organization_id: Optional[str] = None,
         fields: List[str] = ["name", "id", "platform", "status"],
         first: Optional[int] = None,
@@ -50,9 +51,9 @@ class QueriesDataIntegration:
             data_integration_id: ID of the data integration.
             name: Name of the data integration.
             platform: Platform of the data integration.
-                Possible choices : `AWS`, `Azure` or `GCP`.
+                Possible choices: `AWS`, `Azure` or `GCP`.
             status: Status of the data integration.
-                Possible choices : `CONNECTED`, `DISCONNECTED` or `CHECKING`.
+                Possible choices: `CONNECTED`, `DISCONNECTED` or `CHECKING`.
             organization_id: ID of the organization.
             fields: All the fields to request among the possible fields for the data integrations.
                 See [the documentation](https://docs.kili-technology.com/reference/graphql-api#dataintegration) for all possible fields.
@@ -88,8 +89,8 @@ class QueriesDataIntegration:
         self,
         data_integration_id: Optional[str] = None,
         name: Optional[str] = None,
-        platform: Optional[str] = None,
-        status: Optional[str] = None,
+        platform: Optional[Literal["AWS", "Azure", "GCP"]] = None,
+        status: Optional[Literal["CONNECTED", "DISCONNECTED", "CHECKING"]] = None,
         organization_id: Optional[str] = None,
     ) -> int:
         """Count and return the number of data integrations that match a set of criteria.
@@ -98,9 +99,9 @@ class QueriesDataIntegration:
             data_integration_id: ID of the data integration.
             name: Name of the data integration.
             platform: Platform of the data integration.
-                Possible choices : `AWS`, `Azure` or `GCP`.
+                Possible choices: `AWS`, `Azure` or `GCP`.
             status: Status of the data integration.
-                Possible choices : `CONNECTED`, `DISCONNECTED` or `CHECKING`.
+                Possible choices: `CONNECTED`, `DISCONNECTED` or `CHECKING`.
             organization_id: ID of the organization.
 
         Returns:

--- a/src/kili/queries/data_integration/__init__.py
+++ b/src/kili/queries/data_integration/__init__.py
@@ -19,7 +19,7 @@ class QueriesDataIntegration:
     Set of data integration queries
     """
 
-    # pylint: disable=too-many-arguments,dangerous-default-value,too-few-public-methods
+    # pylint: disable=too-many-arguments,dangerous-default-value
 
     def __init__(self, auth: KiliAuth):
         """Initialize the subclass.

--- a/src/kili/queries/data_integration/__init__.py
+++ b/src/kili/queries/data_integration/__init__.py
@@ -98,7 +98,6 @@ class QueriesDataIntegration:
             name: Name of the data integration.
             platform: Platform of the data integration.
             status: Status of the data integration.
-                Possible choices: `CONNECTED`, `DISCONNECTED` or `CHECKING`.
             organization_id: ID of the organization.
 
         Returns:

--- a/src/kili/queries/data_integration/__init__.py
+++ b/src/kili/queries/data_integration/__init__.py
@@ -52,7 +52,6 @@ class QueriesDataIntegration:
             name: Name of the data integration.
             platform: Platform of the data integration.
             status: Status of the data integration.
-                Possible choices: `CONNECTED`, `DISCONNECTED` or `CHECKING`.
             organization_id: ID of the organization.
             fields: All the fields to request among the possible fields for the data integrations.
                 See [the documentation](https://docs.kili-technology.com/reference/graphql-api#dataintegration) for all possible fields.

--- a/src/kili/queries/data_integration/__init__.py
+++ b/src/kili/queries/data_integration/__init__.py
@@ -51,7 +51,6 @@ class QueriesDataIntegration:
             data_integration_id: ID of the data integration.
             name: Name of the data integration.
             platform: Platform of the data integration.
-                Possible choices: `AWS`, `Azure` or `GCP`.
             status: Status of the data integration.
                 Possible choices: `CONNECTED`, `DISCONNECTED` or `CHECKING`.
             organization_id: ID of the organization.

--- a/src/kili/queries/data_integration/__init__.py
+++ b/src/kili/queries/data_integration/__init__.py
@@ -1,0 +1,116 @@
+"""Data integration queries."""
+
+from typing import Dict, Iterable, List, Optional
+
+from typeguard import typechecked
+
+from kili.authentication import KiliAuth
+from kili.graphql import QueryOptions
+from kili.graphql.operations.data_integration.queries import (
+    DataIntegrationQuery,
+    DataIntegrationWhere,
+)
+from kili.helpers import disable_tqdm_if_as_generator
+
+
+class QueriesDataIntegration:
+    """
+    Set of data integration queries
+    """
+
+    # pylint: disable=too-many-arguments,dangerous-default-value,too-few-public-methods
+
+    def __init__(self, auth: KiliAuth):
+        """Initialize the subclass.
+
+        Args:
+            auth: KiliAuth object
+        """
+        self.auth = auth
+
+    @typechecked
+    def data_integrations(
+        self,
+        data_integration_id: Optional[str] = None,
+        name: Optional[str] = None,
+        platform: Optional[str] = None,
+        status: Optional[str] = None,
+        organization_id: Optional[str] = None,
+        fields: List[str] = ["name", "id", "platform", "status"],
+        first: Optional[int] = None,
+        skip: int = 0,
+        disable_tqdm: bool = False,
+        *,
+        as_generator: bool = False,
+    ) -> Iterable[Dict]:
+        # pylint: disable=line-too-long
+        """Get a generator or a list of data integretations that match a set of criteria.
+
+        Args:
+            data_integration_id: ID of the data integration.
+            name: Name of the data integration.
+            platform: Platform of the data integration.
+                Possible choices : `AWS`, `Azure` or `GCP`.
+            status: Status of the data integration.
+                Possible choices : `CONNECTED`, `DISCONNECTED` or `CHECKING`.
+            organization_id: ID of the organization.
+            fields: All the fields to request among the possible fields for the data integrations.
+                See [the documentation](https://docs.kili-technology.com/reference/graphql-api#dataintegration) for all possible fields.
+            first: Maximum number of data integrations to return.
+            skip: Number of skipped data integrations.
+            disable_tqdm: If `True`, the progress bar will be disabled.
+            as_generator: If `True`, a generator on the data integrations is returned.
+
+        Returns:
+            A list or a generator of the data integrations that match the criteria.
+
+        Examples:
+            >>> kili.data_integrations()
+            [{'name': 'My bucket', 'id': '123456789', 'platform': 'AWS', 'status': 'CONNECTED'}]
+        """
+        where = DataIntegrationWhere(
+            data_integration_id=data_integration_id,
+            name=name,
+            platform=platform,
+            status=status,
+            organization_id=organization_id,
+        )
+        disable_tqdm = disable_tqdm_if_as_generator(as_generator, disable_tqdm)
+        options = QueryOptions(disable_tqdm, first, skip)
+        data_integrations_gen = DataIntegrationQuery(self.auth.client)(where, fields, options)
+
+        if as_generator:
+            return data_integrations_gen
+        return list(data_integrations_gen)
+
+    @typechecked
+    def count_data_integrations(
+        self,
+        data_integration_id: Optional[str] = None,
+        name: Optional[str] = None,
+        platform: Optional[str] = None,
+        status: Optional[str] = None,
+        organization_id: Optional[str] = None,
+    ) -> int:
+        """Count and return the number of data integrations that match a set of criteria.
+
+        Args:
+            data_integration_id: ID of the data integration.
+            name: Name of the data integration.
+            platform: Platform of the data integration.
+                Possible choices : `AWS`, `Azure` or `GCP`.
+            status: Status of the data integration.
+                Possible choices : `CONNECTED`, `DISCONNECTED` or `CHECKING`.
+            organization_id: ID of the organization.
+
+        Returns:
+            The number of data integrations that match the criteria.
+        """
+        where = DataIntegrationWhere(
+            data_integration_id=data_integration_id,
+            name=name,
+            platform=platform,
+            status=status,
+            organization_id=organization_id,
+        )
+        return DataIntegrationQuery(self.auth.client).count(where)

--- a/src/kili/queries/data_integration/__init__.py
+++ b/src/kili/queries/data_integration/__init__.py
@@ -97,7 +97,6 @@ class QueriesDataIntegration:
             data_integration_id: ID of the data integration.
             name: Name of the data integration.
             platform: Platform of the data integration.
-                Possible choices: `AWS`, `Azure` or `GCP`.
             status: Status of the data integration.
                 Possible choices: `CONNECTED`, `DISCONNECTED` or `CHECKING`.
             organization_id: ID of the organization.


### PR DESCRIPTION
doc rendering is ok

also tested:

```python
kili.data_integrations(platform="Azure", fields=["name", "platform", "status"])
```

returns:

```python
[{'name': 'Test Azure Token based ', 'platform': 'Azure', 'status': 'CONNECTED'}, {'name': 'Test Azure', 'platform': 'Azure', 'status': 'CONNECTED'}, {'name': 'Azure integration for tests', 'platform': 'Azure', 'status': 'DISCONNECTED'}, {'name': 'Test Datalake', 'platform': 'Azure', 'status': 'DISCONNECTED'}, {'name': 'Test demo-container-delegated-access', 'platform': 'Azure', 'status': 'CONNECTED'}, {'name': 'StorageClientAppSample', 'platform': 'Azure', 'status': 'DISCONNECTED'}, {'name': 'test 2', 'platform': 'Azure', 'status': 'CONNECTED'}, {'name': 'test-integration', 'platform': 'Azure', 'status': 'DISCONNECTED'}, {'name': 'test integ 1', 'platform': 'Azure', 'status': 'CHECKING'}]
```



schema:

```graphql
enum DataIntegrationStatus {
  CONNECTED
  DISCONNECTED
  CHECKING
}

enum DataIntegrationPlatform {
  AWS  Azure  GCP
}

input DataIntegrationWhere {
  status: DataIntegrationStatus
  id: ID
  name: String
  organizationId: ID
  platform: DataIntegrationPlatform
}


"""
  Retrieves page by page all dataIntegrations who verify where input parameters.
"""
dataIntegrations(where: DataIntegrationWhere!, first: PageSize!, skip: Int!): [DataIntegration!]

"""Count all dataIntegrations who verify where input parameters."""
countDataIntegrations(where: DataIntegrationWhere!): Int!
  
  
"""Get the dataIntegration's data"""
dataIntegration(where: DataIntegrationWhere!): DataIntegration
```