### PR TITLE
refactor: keep naming consistent with graphql schema

### DIFF
--- a/src/kili/graphql/operations/data_connection/queries.py
+++ b/src/kili/graphql/operations/data_connection/queries.py
@@ -16,17 +16,17 @@ class DataConnectionsWhere(BaseQueryWhere):
     def __init__(
         self,
         project_id: Optional[str] = None,
-        integration_id: Optional[str] = None,
+        data_integration_id: Optional[str] = None,
     ) -> None:
         self.project_id = project_id
-        self.integration_id = integration_id
+        self.data_integration_id = data_integration_id
         super().__init__()
 
     def graphql_where_builder(self):
         """Build the GraphQL Where payload sent in the resolver from the SDK DataConnectionsWhere"""
         return {
             "projectId": self.project_id,
-            "integrationId": self.integration_id,
+            "integrationId": self.data_integration_id,
         }
 
 

--- a/src/kili/graphql/operations/data_integration/queries.py
+++ b/src/kili/graphql/operations/data_integration/queries.py
@@ -10,7 +10,7 @@ from kili.graphql import BaseQueryWhere, GraphQLQuery
 
 class DataIntegrationWhere(BaseQueryWhere):
     """
-    Tuple to be passed to the DataIntegrationQuery to restrict the query
+    Tuple to be passed to the DataIntegrationsQuery to restrict the query
     """
 
     # pylint: disable=too-many-arguments
@@ -40,8 +40,8 @@ class DataIntegrationWhere(BaseQueryWhere):
         }
 
 
-class DataIntegrationQuery(GraphQLQuery):
-    """DataIntegration query."""
+class DataIntegrationsQuery(GraphQLQuery):
+    """DataIntegrations query."""
 
     @staticmethod
     def query(fragment):

--- a/src/kili/mutations/data_connection/__init__.py
+++ b/src/kili/mutations/data_connection/__init__.py
@@ -28,8 +28,8 @@ class MutationsDataConnection:
         """Connect a remote storage to a project.
 
         Args:
-            project_id : ID of the project
-            data_integration_id : ID of the data integration
+            project_id: ID of the project
+            data_integration_id: ID of the data integration
 
         Returns:
             A dict with the DataConnection ID.

--- a/src/kili/queries/data_connection/__init__.py
+++ b/src/kili/queries/data_connection/__init__.py
@@ -34,7 +34,7 @@ class QueriesDataConnection:
     def data_connections(
         self,
         project_id: Optional[str] = None,
-        integration_id: Optional[str] = None,
+        data_integration_id: Optional[str] = None,
         fields: List[str] = [
             "id",
             "lastChecked",
@@ -54,7 +54,7 @@ class QueriesDataConnection:
     def data_connections(
         self,
         project_id: Optional[str] = None,
-        integration_id: Optional[str] = None,
+        data_integration_id: Optional[str] = None,
         fields: List[str] = [
             "id",
             "lastChecked",
@@ -74,7 +74,7 @@ class QueriesDataConnection:
     def data_connections(
         self,
         project_id: Optional[str] = None,
-        integration_id: Optional[str] = None,
+        data_integration_id: Optional[str] = None,
         fields: List[str] = [
             "id",
             "lastChecked",
@@ -93,7 +93,7 @@ class QueriesDataConnection:
 
         Args:
             project_id: ID of the project.
-            integration_id: ID of the data integration.
+            data_integration_id: ID of the data integration.
             fields: All the fields to request among the possible fields for the data connections.
                 See [the documentation](https://docs.kili-technology.com/reference/graphql-api#dataconnection) for all possible fields.
             first: Maximum number of data connections to return.
@@ -108,7 +108,7 @@ class QueriesDataConnection:
             >>> kili.data_connections(project_id="789465123")
             [{'id': '123456789', 'lastChecked': '2023-02-21T14:49:35.606Z', 'numberOfAssets': 42, 'isApplyingDataDifferences': False, 'isChecking': False}]
         """
-        where = DataConnectionsWhere(project_id=project_id, integration_id=integration_id)
+        where = DataConnectionsWhere(project_id=project_id, data_integration_id=data_integration_id)
         disable_tqdm = disable_tqdm_if_as_generator(as_generator, disable_tqdm)
         options = QueryOptions(disable_tqdm, first, skip)
         data_connections_gen = DataConnectionsQuery(self.auth.client)(where, fields, options)

--- a/src/kili/queries/data_integration/__init__.py
+++ b/src/kili/queries/data_integration/__init__.py
@@ -8,7 +8,7 @@ from typing_extensions import Literal
 from kili.authentication import KiliAuth
 from kili.graphql import QueryOptions
 from kili.graphql.operations.data_integration.queries import (
-    DataIntegrationQuery,
+    DataIntegrationsQuery,
     DataIntegrationWhere,
 )
 from kili.helpers import disable_tqdm_if_as_generator
@@ -76,7 +76,7 @@ class QueriesDataIntegration:
         )
         disable_tqdm = disable_tqdm_if_as_generator(as_generator, disable_tqdm)
         options = QueryOptions(disable_tqdm, first, skip)
-        data_integrations_gen = DataIntegrationQuery(self.auth.client)(where, fields, options)
+        data_integrations_gen = DataIntegrationsQuery(self.auth.client)(where, fields, options)
 
         if as_generator:
             return data_integrations_gen
@@ -110,4 +110,4 @@ class QueriesDataIntegration:
             status=status,
             organization_id=organization_id,
         )
-        return DataIntegrationQuery(self.auth.client).count(where)
+        return DataIntegrationsQuery(self.auth.client).count(where)


### PR DESCRIPTION
I changed integration_id for data_integration_id, since we use data_connection_id 

better include that before release