### PR TITLE
refactor: rename cloud storage methods and update doc

### DIFF
--- a/docs/sdk/cloud_storage.md
+++ b/docs/sdk/cloud_storage.md
@@ -1,7 +1,7 @@
 # Cloud storage module
 
-!!! warning "Beta feature"
-    The cloud storage feature is currently in beta. If you encounter any issue, do not hesitate to contact [Kili support](mailto:support@kili-technology.com) or create an issue on [GitHub](https://github.com/kili-technology/kili-python-sdk/issues).
+!!! warning "Alpha feature"
+    The cloud storage feature is currently in alpha. It is still under active development: methods and behaviors can still evolve until the feature is complete.
 
 !!! info "Cloud Storage Integration and Connection"
     A cloud storage integration is a connection between a Kili organization and a cloud storage (AWS, GCP or Azure).

--- a/docs/sdk/cloud_storage.md
+++ b/docs/sdk/cloud_storage.md
@@ -1,13 +1,17 @@
 # Cloud storage module
 
-## Data Integration versus Data Connection
+!!! warning "Beta feature"
+    The cloud storage feature is currently in beta. If you encounter any issue, do not hesitate to contact [Kili support](mailto:support@kili-technology.com) or create an issue on [GitHub](https://github.com/kili-technology/kili-python-sdk/issues).
 
-A data integration is a connection between a Kili organization and a remote/cloud storage (AWS, GCP or Azure).
-Once a data integration is created, it can be used in any project of the organization.
-Adding a data integration from the API is currently not supported. More information about how to create a data integration can be found [here](https://docs.kili-technology.com/docs/adding-assets-to-project#creating-a-remote-storage-integration).
+!!! info "Cloud Storage Integration and Connection"
+    A cloud storage integration is a connection between a Kili organization and a cloud storage (AWS, GCP or Azure).
+    Once a cloud storage integration is created, it can be used in any project of the organization.
+    Adding a cloud storage integration from the SDK is currently not supported.
+    More information about how to create a cloud storage integration can be found [here](https://docs.kili-technology.com/docs/adding-assets-to-project#creating-a-remote-storage-integration).
 
-A data connection is a data integration used in a Kili project. It is used to import data from a remote storage to a project.
-More information about how to use a data integration in a project can be found [here](https://docs.kili-technology.com/docs/adding-assets-to-project#adding-assets-located-in-remote-storage-integration).
+    A cloud storage connection is a cloud storage integration used in a Kili project.
+    It is used to import data from a cloud storage to a project.
+    More information about how to use a cloud storage integration in a project can be found [here](https://docs.kili-technology.com/docs/adding-assets-to-project#adding-assets-located-in-remote-storage-integration).
 
 ## Queries
 

--- a/src/kili/mutations/data_connection/__init__.py
+++ b/src/kili/mutations/data_connection/__init__.py
@@ -24,12 +24,14 @@ class MutationsDataConnection:
         self.auth = auth
 
     @typechecked
-    def add_data_connection(self, project_id: str, data_integration_id: str) -> Dict:
-        """Connect a remote storage to a project.
+    def add_cloud_storage_connection(
+        self, project_id: str, cloud_storage_integration_id: str
+    ) -> Dict:
+        """Connect a cloud storage to a project.
 
         Args:
             project_id: ID of the project
-            data_integration_id: ID of the data integration
+            cloud_storage_integration_id: ID of the cloud storage integration
 
         Returns:
             A dict with the DataConnection ID.
@@ -37,7 +39,7 @@ class MutationsDataConnection:
         variables = {
             "data": {
                 "projectId": project_id,
-                "integrationId": data_integration_id,
+                "integrationId": cloud_storage_integration_id,
                 "isChecking": False,
                 "lastChecked": datetime.now().isoformat(sep="T", timespec="milliseconds") + "Z",
             }

--- a/src/kili/queries/data_connection/__init__.py
+++ b/src/kili/queries/data_connection/__init__.py
@@ -17,7 +17,7 @@ from kili.helpers import disable_tqdm_if_as_generator
 # pylint: disable=too-few-public-methods
 class QueriesDataConnection:
     """
-    Set of data connection queries
+    Set of cloud storage connection queries
     """
 
     # pylint: disable=too-many-arguments,dangerous-default-value
@@ -31,10 +31,10 @@ class QueriesDataConnection:
         self.auth = auth
 
     @overload
-    def data_connections(
+    def cloud_storage_connections(
         self,
         project_id: Optional[str] = None,
-        data_integration_id: Optional[str] = None,
+        cloud_storage_integration_id: Optional[str] = None,
         fields: List[str] = [
             "id",
             "lastChecked",
@@ -51,10 +51,10 @@ class QueriesDataConnection:
         ...
 
     @overload
-    def data_connections(
+    def cloud_storage_connections(
         self,
         project_id: Optional[str] = None,
-        data_integration_id: Optional[str] = None,
+        cloud_storage_integration_id: Optional[str] = None,
         fields: List[str] = [
             "id",
             "lastChecked",
@@ -71,10 +71,10 @@ class QueriesDataConnection:
         ...
 
     @typechecked
-    def data_connections(
+    def cloud_storage_connections(
         self,
         project_id: Optional[str] = None,
-        data_integration_id: Optional[str] = None,
+        cloud_storage_integration_id: Optional[str] = None,
         fields: List[str] = [
             "id",
             "lastChecked",
@@ -89,26 +89,28 @@ class QueriesDataConnection:
         as_generator: bool = False,
     ) -> Iterable[Dict]:
         # pylint: disable=line-too-long
-        """Get a generator or a list of data connections that match a set of criteria.
+        """Get a generator or a list of cloud storage connections that match a set of criteria.
 
         Args:
             project_id: ID of the project.
-            data_integration_id: ID of the data integration.
-            fields: All the fields to request among the possible fields for the data connections.
+            cloud_storage_integration_id: ID of the cloud storage integration.
+            fields: All the fields to request among the possible fields for the cloud storage connections.
                 See [the documentation](https://docs.kili-technology.com/reference/graphql-api#dataconnection) for all possible fields.
-            first: Maximum number of data connections to return.
-            skip: Number of skipped data connections.
+            first: Maximum number of cloud storage connections to return.
+            skip: Number of skipped cloud storage connections.
             disable_tqdm: If `True`, the progress bar will be disabled.
-            as_generator: If `True`, a generator on the data connections is returned.
+            as_generator: If `True`, a generator on the cloud storage connections is returned.
 
         Returns:
-            A list or a generator of the data connections that match the criteria.
+            A list or a generator of the cloud storage connections that match the criteria.
 
         Examples:
-            >>> kili.data_connections(project_id="789465123")
+            >>> kili.cloud_storage_connections(project_id="789465123")
             [{'id': '123456789', 'lastChecked': '2023-02-21T14:49:35.606Z', 'numberOfAssets': 42, 'isApplyingDataDifferences': False, 'isChecking': False}]
         """
-        where = DataConnectionsWhere(project_id=project_id, data_integration_id=data_integration_id)
+        where = DataConnectionsWhere(
+            project_id=project_id, data_integration_id=cloud_storage_integration_id
+        )
         disable_tqdm = disable_tqdm_if_as_generator(as_generator, disable_tqdm)
         options = QueryOptions(disable_tqdm, first, skip)
         data_connections_gen = DataConnectionsQuery(self.auth.client)(where, fields, options)

--- a/src/kili/queries/data_integration/__init__.py
+++ b/src/kili/queries/data_integration/__init__.py
@@ -1,6 +1,6 @@
 """Data integration queries."""
 
-from typing import Dict, Iterable, List, Optional
+from typing import Dict, Generator, Iterable, List, Optional, overload
 
 from typeguard import typechecked
 from typing_extensions import Literal
@@ -28,6 +28,40 @@ class QueriesDataIntegration:
             auth: KiliAuth object
         """
         self.auth = auth
+
+    @overload
+    def cloud_storage_integrations(
+        self,
+        cloud_storage_integration_id: Optional[str] = None,
+        name: Optional[str] = None,
+        platform: Optional[Literal["AWS", "Azure", "GCP"]] = None,
+        status: Optional[Literal["CONNECTED", "DISCONNECTED", "CHECKING"]] = None,
+        organization_id: Optional[str] = None,
+        fields: List[str] = ["name", "id", "platform", "status"],
+        first: Optional[int] = None,
+        skip: int = 0,
+        disable_tqdm: bool = False,
+        *,
+        as_generator: Literal[True],
+    ) -> Generator[Dict, None, None]:
+        ...
+
+    @overload
+    def cloud_storage_integrations(
+        self,
+        cloud_storage_integration_id: Optional[str] = None,
+        name: Optional[str] = None,
+        platform: Optional[Literal["AWS", "Azure", "GCP"]] = None,
+        status: Optional[Literal["CONNECTED", "DISCONNECTED", "CHECKING"]] = None,
+        organization_id: Optional[str] = None,
+        fields: List[str] = ["name", "id", "platform", "status"],
+        first: Optional[int] = None,
+        skip: int = 0,
+        disable_tqdm: bool = False,
+        *,
+        as_generator: Literal[False] = False,
+    ) -> List[Dict]:
+        ...
 
     @typechecked
     def cloud_storage_integrations(

--- a/src/kili/queries/data_integration/__init__.py
+++ b/src/kili/queries/data_integration/__init__.py
@@ -16,7 +16,7 @@ from kili.helpers import disable_tqdm_if_as_generator
 
 class QueriesDataIntegration:
     """
-    Set of data integration queries
+    Set of cloud storage integration queries
     """
 
     # pylint: disable=too-many-arguments,dangerous-default-value
@@ -30,9 +30,9 @@ class QueriesDataIntegration:
         self.auth = auth
 
     @typechecked
-    def data_integrations(
+    def cloud_storage_integrations(
         self,
-        data_integration_id: Optional[str] = None,
+        cloud_storage_integration_id: Optional[str] = None,
         name: Optional[str] = None,
         platform: Optional[Literal["AWS", "Azure", "GCP"]] = None,
         status: Optional[Literal["CONNECTED", "DISCONNECTED", "CHECKING"]] = None,
@@ -45,30 +45,30 @@ class QueriesDataIntegration:
         as_generator: bool = False,
     ) -> Iterable[Dict]:
         # pylint: disable=line-too-long
-        """Get a generator or a list of data integretations that match a set of criteria.
+        """Get a generator or a list of cloud storage integrations that match a set of criteria.
 
         Args:
-            data_integration_id: ID of the data integration.
-            name: Name of the data integration.
-            platform: Platform of the data integration.
-            status: Status of the data integration.
+            cloud_storage_integration_id: ID of the cloud storage integration.
+            name: Name of the cloud storage integration.
+            platform: Platform of the cloud storage integration.
+            status: Status of the cloud storage integration.
             organization_id: ID of the organization.
-            fields: All the fields to request among the possible fields for the data integrations.
+            fields: All the fields to request among the possible fields for the cloud storage integrations.
                 See [the documentation](https://docs.kili-technology.com/reference/graphql-api#dataintegration) for all possible fields.
-            first: Maximum number of data integrations to return.
-            skip: Number of skipped data integrations.
+            first: Maximum number of cloud storage integrations to return.
+            skip: Number of skipped cloud storage integrations.
             disable_tqdm: If `True`, the progress bar will be disabled.
-            as_generator: If `True`, a generator on the data integrations is returned.
+            as_generator: If `True`, a generator on the cloud storage integrations is returned.
 
         Returns:
-            A list or a generator of the data integrations that match the criteria.
+            A list or a generator of the cloud storage integrations that match the criteria.
 
         Examples:
-            >>> kili.data_integrations()
+            >>> kili.cloud_storage_integrations()
             [{'name': 'My bucket', 'id': '123456789', 'platform': 'AWS', 'status': 'CONNECTED'}]
         """
         where = DataIntegrationWhere(
-            data_integration_id=data_integration_id,
+            data_integration_id=cloud_storage_integration_id,
             name=name,
             platform=platform,
             status=status,
@@ -83,28 +83,28 @@ class QueriesDataIntegration:
         return list(data_integrations_gen)
 
     @typechecked
-    def count_data_integrations(
+    def count_cloud_storage_integrations(
         self,
-        data_integration_id: Optional[str] = None,
+        cloud_storage_integration_id: Optional[str] = None,
         name: Optional[str] = None,
         platform: Optional[Literal["AWS", "Azure", "GCP"]] = None,
         status: Optional[Literal["CONNECTED", "DISCONNECTED", "CHECKING"]] = None,
         organization_id: Optional[str] = None,
     ) -> int:
-        """Count and return the number of data integrations that match a set of criteria.
+        """Count and return the number of cloud storage integrations that match a set of criteria.
 
         Args:
-            data_integration_id: ID of the data integration.
-            name: Name of the data integration.
-            platform: Platform of the data integration.
-            status: Status of the data integration.
+            cloud_storage_integration_id: ID of the cloud storage integration.
+            name: Name of the cloud storage integration.
+            platform: Platform of the cloud storage integration.
+            status: Status of the cloud storage integration.
             organization_id: ID of the organization.
 
         Returns:
-            The number of data integrations that match the criteria.
+            The number of cloud storage integrations that match the criteria.
         """
         where = DataIntegrationWhere(
-            data_integration_id=data_integration_id,
+            data_integration_id=cloud_storage_integration_id,
             name=name,
             platform=platform,
             status=status,

--- a/src/kili/services/copy_project/__init__.py
+++ b/src/kili/services/copy_project/__init__.py
@@ -88,7 +88,7 @@ class ProjectCopier:  # pylint: disable=too-few-public-methods
         src_project = services.get_project(self.kili.auth, from_project_id, fields)
 
         if len(src_project["dataConnections"]) > 0 and copy_assets:
-            raise NotImplementedError("Copying projects with remote storage is not supported.")
+            raise NotImplementedError("Copying projects with cloud storage is not supported.")
 
         new_project_title = title or self._generate_project_title(src_title=src_project["title"])
 

--- a/src/kili/utils/pagination.py
+++ b/src/kili/utils/pagination.py
@@ -4,77 +4,12 @@ Utils
 import functools
 import time
 from time import sleep
-from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, TypeVar
+from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from kili.constants import MUTATION_BATCH_SIZE, THROTTLING_DELAY
 from kili.exceptions import GraphQLError
-from kili.utils.tqdm import tqdm
 
-# pylint: disable=too-many-arguments,too-many-locals
-
-T = TypeVar("T")
-
-
-def row_generator_from_paginated_calls(
-    skip: int,
-    first: Optional[int],
-    count_method: Callable[..., int],
-    count_kwargs: dict,
-    paged_call_method: Callable[..., Iterable[T]],
-    paged_call_payload: dict,
-    fields: List[str],
-    disable_tqdm: bool,
-    post_call_process: Optional[Callable[[List[T]], List[T]]] = None,
-):
-    """
-    Builds a row generator from paginated calls.
-
-    Args:
-        skip: Number of assets to skip (they are ordered by their date of creation, first to last).
-        first: Maximum number of assets to return.
-        count_method: Callable returning the number of available assets given `count_args`.
-        count_kwargs: Keyword arguments passed to the `count_method`.
-        paged_call_method: Callable returning the list of samples.
-        paged_call_payload: Payload for the GraphQL query.
-        fields: The list of strings to retrieved.
-        disable_tqdm: If `True`, disables tqdm.
-    """
-    count_rows_retrieved = 0
-    if not disable_tqdm:
-        count_rows_available = count_method(**count_kwargs)
-        count_rows_queried_total = (
-            min(count_rows_available, first) if first is not None else count_rows_available
-        )
-    else:
-        # dummy value that won't have any impact since tqdm is disabled
-        count_rows_queried_total = 1 if first != 0 else 0
-    count_rows_query_default = min(100, first or 100)
-
-    if count_rows_queried_total == 0:
-        yield from ()
-    else:
-        with tqdm(total=count_rows_queried_total, disable=disable_tqdm) as pbar:
-            while True:
-                rows = api_throttle(paged_call_method)(
-                    count_rows_retrieved + skip,
-                    count_rows_query_default,
-                    paged_call_payload,
-                    fields,
-                )
-
-                if rows is None or len(rows) == 0:
-                    break
-
-                if post_call_process is not None:
-                    rows = post_call_process(rows)
-
-                for row in rows:
-                    yield row
-
-                count_rows_retrieved += len(rows)
-                pbar.update(len(rows))
-                if first is not None and count_rows_retrieved >= first:
-                    break
+# pylint: disable=too-many-arguments
 
 
 class BatchIteratorBuilder:

--- a/tests/queries/data_connection/test_data_connection.py
+++ b/tests/queries/data_connection/test_data_connection.py
@@ -6,7 +6,7 @@ from kili.queries.data_connection import QueriesDataConnection
 @patch("kili.graphql.GraphQLClient")
 def test_data_connections(mocked_graphql_client):
     kili = QueriesDataConnection(auth=MagicMock(client=mocked_graphql_client))
-    kili.data_connections(project_id="789465123")
+    kili.cloud_storage_connections(project_id="789465123")
     mocked_graphql_client.execute.assert_called_once()
     query_sent = mocked_graphql_client.execute.call_args[0][0]
     variables = mocked_graphql_client.execute.call_args[0][1]

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,122 +1,133 @@
 """Tests for utils module"""
 
-from kili.utils.pagination import (
-    BatchIteratorBuilder,
-    batch_object_builder,
-    row_generator_from_paginated_calls,
-)
+from typing import Dict
+from unittest.mock import MagicMock
+
+import pytest
+
+from kili.graphql import BaseQueryWhere, GraphQLQuery, QueryOptions
+from kili.utils.pagination import BatchIteratorBuilder, batch_object_builder
 
 from .utils import mocked_count_method, mocked_query_method
 
-TEST_CASES = [
-    {
-        "case": "AAU, When I query objects with first=50, I get the first 50 objects",
-        "args": {"first": 50},
-        "expected_result": ({"id": i} for i in range(50)),
-    },
-    {
-        "case": "AAU, When I query objects with first=200, I get the first 200 objects",
-        "args": {"first": 200},
-        "expected_result": ({"id": i} for i in range(200)),
-    },
-    {
-        "case": (
-            "AAU, When I query objects with first=50 and skip=20, I skip the 20"
-            " first objects I get the 50 objects following"
-        ),
-        "args": {"first": 50, "skip": 20},
-        "expected_result": ({"id": i} for i in range(20, 70)),
-    },
-    {
-        "case": (
-            "AAU, When I query objects with first=50 and skip=20, I skip the 20"
-            "first objects I get the 200 following objects"
-        ),
-        "args": {"first": 200, "skip": 20},
-        "expected_result": ({"id": i} for i in range(20, 220)),
-    },
-    {
-        "case": "AAU, When I query objects with first=25100, I get the first 1100 objects",
-        "args": {"first": 25100},
-        "expected_result": ({"id": i} for i in range(25100)),
-    },
-    {
-        "case": (
-            "AAU, When I query objects with first=20 and disable_tqdm, I get the first 2O objects"
-        ),
-        "args": {"first": 20, "disable_tqdm": True},
-        "expected_result": ({"id": i} for i in range(20)),
-    },
-    {
-        "case": (
-            "AAU, When I query objects with first=20, skip=20 and disable_tqdm, I  skip the 20"
-            "first objects and I get the 20 following objects"
-        ),
-        "args": {"first": 20, "skip": 20, "disable_tqdm": True},
-        "expected_result": ({"id": i} for i in range(20, 40)),
-    },
-    {
-        "case": "AAU, When I query objects with first=0, I get no objects",
-        "args": {"first": 0},
-        "expected_result": iter(()),
-    },
-]
 
-
-def test_row_generator_from_paginated_calls():
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        {
+            "case": "AAU, When I query objects with first=50, I get the first 50 objects",
+            "args": {"first": 50},
+            "expected_result": ({"id": i} for i in range(50)),
+        },
+        {
+            "case": "AAU, When I query objects with first=200, I get the first 200 objects",
+            "args": {"first": 200},
+            "expected_result": ({"id": i} for i in range(200)),
+        },
+        {
+            "case": (
+                "AAU, When I query objects with first=50 and skip=20, I skip the 20"
+                " first objects I get the 50 objects following"
+            ),
+            "args": {"first": 50, "skip": 20},
+            "expected_result": ({"id": i} for i in range(20, 70)),
+        },
+        {
+            "case": (
+                "AAU, When I query objects with first=50 and skip=20, I skip the 20"
+                "first objects I get the 200 following objects"
+            ),
+            "args": {"first": 200, "skip": 20},
+            "expected_result": ({"id": i} for i in range(20, 220)),
+        },
+        {
+            "case": "AAU, When I query objects with first=25100, I get the first 1100 objects",
+            "args": {"first": 25100},
+            "expected_result": ({"id": i} for i in range(25100)),
+        },
+        {
+            "case": (
+                "AAU, When I query objects with first=20 and disable_tqdm, I get the first 2O"
+                " objects"
+            ),
+            "args": {"first": 20, "disable_tqdm": True},
+            "expected_result": ({"id": i} for i in range(20)),
+        },
+        {
+            "case": (
+                "AAU, When I query objects with first=20, skip=20 and disable_tqdm, I  skip the 20"
+                "first objects and I get the 20 following objects"
+            ),
+            "args": {"first": 20, "skip": 20, "disable_tqdm": True},
+            "expected_result": ({"id": i} for i in range(20, 40)),
+        },
+        {
+            "case": "AAU, When I query objects with first=0, I get no objects",
+            "args": {"first": 0},
+            "expected_result": iter(()),
+        },
+    ],
+)
+def test_row_generator_from_paginated_calls(test_case):
     """
     Simulates a count query result by returning a list of ids
     """
-    for test_case in TEST_CASES:
-        case_name = test_case["case"]
-        expected = test_case["expected_result"]
-        skip = test_case["args"].get("skip", 0)
-        first = test_case["args"].get("first")
-        disable_tqdm = test_case["args"].get("disable_tqdm", False)
 
-        actual = row_generator_from_paginated_calls(
-            skip,
-            first,
-            mocked_count_method,
-            {},
-            mocked_query_method,
-            {first, skip},  # type:ignore X
-            [],
-            disable_tqdm,
-        )
-        assert all(a == b for a, b in zip(actual, expected)), f'Test case "{case_name}" failed'
-        assert type(actual).__name__ == "generator", f'Test case "{case_name}" failed'
+    class MyGraphQLQuery(GraphQLQuery):
+        @staticmethod
+        def query(fragment: str) -> str:
+            return f"not_implemented_query with fragment {fragment}"
+
+    class MyGraphQLWhere(BaseQueryWhere):
+        def graphql_where_builder(self) -> Dict:
+            return {"where": "not_implemented_where"}
+
+    case_name = test_case["case"]
+    expected = test_case["expected_result"]
+    skip = test_case["args"].get("skip", 0)
+    first = test_case["args"].get("first")
+    disable_tqdm = test_case["args"].get("disable_tqdm", False)
+
+    options = QueryOptions(first=first, skip=skip, disable_tqdm=disable_tqdm)
+    where = MyGraphQLWhere()
+    actual = MyGraphQLQuery(
+        client=MagicMock(execute=mocked_query_method)
+    ).execute_query_from_paginated_call(
+        query="", where=where, options=options, post_call_function=None
+    )
+
+    assert all(a == b for a, b in zip(actual, expected)), f'Test case "{case_name}" failed'
+    assert type(actual).__name__ == "generator", f'Test case "{case_name}" failed'
 
 
-def test_batch_iterator_builder():
-    """Test batch iterator builder."""
-    TEST_CASE = [
+@pytest.mark.parametrize(
+    "test_case",
+    [
         {
             "case": (
                 "When the size of the iterable is not a multiple of the batch_size, I see a success"
             ),
             "batch_size": 3,
-            "iterable": [i for i in range(7)],
+            "iterable": list(range(7)),
             "expected_result": (i for i in [[0, 1, 2], [3, 4, 5], [6]]),
         }
-    ]
-    for test_case in TEST_CASE:
-        actual = BatchIteratorBuilder(test_case["iterable"], batch_size=test_case["batch_size"])
-        expected = test_case["expected_result"]
-        case_name = test_case["case"]
-        assert all(a == b for a, b in zip(actual, expected)), f'Test case "{case_name}" failed'
+    ],
+)
+def test_batch_iterator_builder(test_case):
+    """Test batch iterator builder."""
+    actual = BatchIteratorBuilder(test_case["iterable"], batch_size=test_case["batch_size"])
+    expected = test_case["expected_result"]
+    case_name = test_case["case"]
+    assert all(a == b for a, b in zip(actual, expected)), f'Test case "{case_name}" failed'
 
 
-def test_batch_object_builder():
-    """Test batch iterator builder for several arrays in the same time."""
-    array1 = [i for i in range(10)]
-    array2 = [i for i in range(10, 20)]
-    array3 = [i for i in range(20, 30)]
-    TEST_CASE = [
+@pytest.mark.parametrize(
+    "test_case",
+    [
         {
             "case": "When I have one property I see that it returns paginated batches",
             "batch_size": 3,
-            "properties_to_batch": {"a1": array1},
+            "properties_to_batch": {"a1": list(range(10))},
             "expected_result": (
                 i
                 for i in [
@@ -130,7 +141,11 @@ def test_batch_object_builder():
         {
             "case": "When I have several iterables I see it creates a common batch",
             "batch_size": 4,
-            "properties_to_batch": {"a1": array1, "a2": array2, "a3": array3},
+            "properties_to_batch": {
+                "a1": list(range(10)),
+                "a2": list(range(10, 20)),
+                "a3": list(range(20, 30)),
+            },
             "expected_result": (
                 i
                 for i in [
@@ -151,7 +166,12 @@ def test_batch_object_builder():
         {
             "case": "When I have None arrays, I see that it stays None in the batches",
             "batch_size": 4,
-            "properties_to_batch": {"a1": array1, "a2": None, "a3": array2, "a4": None},
+            "properties_to_batch": {
+                "a1": list(range(10)),
+                "a2": None,
+                "a3": list(range(10, 20)),
+                "a4": None,
+            },
             "expected_result": (
                 i
                 for i in [
@@ -177,9 +197,11 @@ def test_batch_object_builder():
             "properties_to_batch": {"a1": None, "a2": None, "a3": None},
             "expected_result": (i for i in [{"a1": None, "a2": None, "a3": None}]),
         },
-    ]
-    for test_case in TEST_CASE:
-        actual = batch_object_builder(test_case["properties_to_batch"], test_case["batch_size"])
-        expected = test_case["expected_result"]
-        case_name = test_case["case"]
-        assert all(a == b for a, b in zip(actual, expected)), f'Test case "{case_name}" failed'
+    ],
+)
+def test_batch_object_builder(test_case):
+    """Test batch iterator builder for several arrays in the same time."""
+    actual = batch_object_builder(test_case["properties_to_batch"], test_case["batch_size"])
+    expected = test_case["expected_result"]
+    case_name = test_case["case"]
+    assert all(a == b for a, b in zip(actual, expected)), f'Test case "{case_name}" failed'

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -50,12 +50,14 @@ class burstthrottle(object):
 
 
 @burstthrottle(max_hits=250, minutes=1)
-def mocked_query_method(skip, first, *_):
+def mocked_query_method(query, payload):
     """
     Simulates a query result by returning a list of ids
     """
+    skip = payload["skip"]
+    first = payload["first"]
     max_range = min(COUNT_SAMPLE_MAX, skip + first)
-    res = [{"id": i} for i in range(skip, max_range)]
+    res = {"data": [{"id": i} for i in range(skip, max_range)]}
     return res
 
 


### PR DESCRIPTION
I had to rework test_pagination.py because pyright CI was not passing because of row_generator_from_paginated_calls method