### PR TITLE
feat: warn and return if argument of type list is empty

### DIFF
--- a/src/kili/helpers.py
+++ b/src/kili/helpers.py
@@ -400,7 +400,7 @@ def skip_if_empty_arguments(
 
     Args:
         all_non_empty: sequence of argument names that must be all non-empty.
-        any_non_empty: sequence of argument names that must be at least one non-empty.
+        any_non_empty: sequence of argument names that must have at least one non-empty value.
     """
 
     def is_empty_sequence(arg_value) -> bool:
@@ -408,7 +408,7 @@ def skip_if_empty_arguments(
 
     def get_arg_value(arg_name: str, args: Tuple[Any, ...], kwargs: Dict[str, Any], func: Callable):
         """
-        Get the value of an argument `arg_name` from args and kwargs.
+        Get the value of an argument `arg_name` from the args and kwargs of the decorated function.
         """
         if arg_name in kwargs:
             return kwargs[arg_name]
@@ -419,7 +419,7 @@ def skip_if_empty_arguments(
         except IndexError:
             return None
 
-    def get_args_dict(
+    def get_args_as_dict(
         arg_names: Sequence[str], args: Tuple[Any, ...], kwargs: Dict[str, Any], func: Callable
     ) -> Dict[str, Any]:
         args_dict = {}
@@ -436,7 +436,7 @@ def skip_if_empty_arguments(
 
             # we want all arguments to be non-empty
             if all_non_empty:
-                args_dict = get_args_dict(all_non_empty, args, kwargs, func)
+                args_dict = get_args_as_dict(all_non_empty, args, kwargs, func)
 
                 empty_args = [
                     arg_name
@@ -456,7 +456,7 @@ def skip_if_empty_arguments(
 
             # we need at least one argument to be non-empty
             if any_non_empty:
-                args_dict = get_args_dict(any_non_empty, args, kwargs, func)
+                args_dict = get_args_as_dict(any_non_empty, args, kwargs, func)
 
                 if args_dict and all(
                     is_empty_sequence(arg_value) for arg_value in args_dict.values()

--- a/src/kili/helpers.py
+++ b/src/kili/helpers.py
@@ -447,8 +447,8 @@ def skip_if_empty_arguments(
                 if empty_args:
                     warnings.warn(
                         (
-                            f"Skipping '{func.__name__}' because the following arguments are"
-                            f" empty: {', '.join(empty_args)}."
+                            f"Method '{func.__name__}' did nothing because the following arguments"
+                            f" are empty: {', '.join(empty_args)}."
                         ),
                         stacklevel=4,
                     )
@@ -463,8 +463,8 @@ def skip_if_empty_arguments(
                 ):
                     warnings.warn(
                         (
-                            f"Skipping '{func.__name__}' because the following arguments are"
-                            f" empty: {', '.join(args_dict.keys())}."
+                            f"Method '{func.__name__}' did nothing because the following arguments"
+                            f" are empty: {', '.join(args_dict.keys())}."
                         ),
                         stacklevel=4,
                     )

--- a/src/kili/helpers.py
+++ b/src/kili/helpers.py
@@ -447,7 +447,7 @@ def skip_if_empty_arguments(
                 if empty_args:
                     warnings.warn(
                         (
-                            f"Skipping '{func.__name__}' because the following inputs are"
+                            f"Skipping '{func.__name__}' because the following arguments are"
                             f" empty: {', '.join(empty_args)}."
                         ),
                         stacklevel=4,
@@ -463,7 +463,7 @@ def skip_if_empty_arguments(
                 ):
                     warnings.warn(
                         (
-                            f"Skipping '{func.__name__}' because the following inputs are"
+                            f"Skipping '{func.__name__}' because the following arguments are"
                             f" empty: {', '.join(args_dict.keys())}."
                         ),
                         stacklevel=4,

--- a/src/kili/helpers.py
+++ b/src/kili/helpers.py
@@ -388,7 +388,7 @@ def is_empty_list_with_warning(method_name: str, argument_name: str, argument_va
                 f"Method '{method_name}' did nothing because the following argument"
                 f" is empty: {argument_name}."
             ),
-            stacklevel=3,
+            stacklevel=5,
         )
         return True
     return False

--- a/src/kili/helpers.py
+++ b/src/kili/helpers.py
@@ -376,7 +376,7 @@ class RetryLongWaitWarner:  # pylint: disable=too-few-public-methods
             self.warned = True
 
 
-def check_warn_empty_list(method_name: str, argument_name: str, argument_value: Any) -> bool:
+def is_empty_list_with_warning(method_name: str, argument_name: str, argument_value: Any) -> bool:
     """
     Check if an input list argument is empty and warn the user if it is
 

--- a/src/kili/mutations/asset/__init__.py
+++ b/src/kili/mutations/asset/__init__.py
@@ -49,6 +49,7 @@ class MutationsAsset:
         self.auth = auth
 
     @typechecked
+    @skip_if_empty_arguments(any_non_empty=["content_array", "json_content_array"])
     def append_many_to_dataset(
         self,
         project_id: str,
@@ -125,6 +126,7 @@ class MutationsAsset:
 
         if content_array is None and json_content_array is None:
             raise ValueError("Variables content_array and json_content_array cannot be both None.")
+
         nb_data = (
             len(content_array)
             if content_array is not None

--- a/src/kili/mutations/asset/__init__.py
+++ b/src/kili/mutations/asset/__init__.py
@@ -27,7 +27,7 @@ from kili.services.asset_import import import_assets
 from kili.utils.logcontext import for_all_methods, log_call
 from kili.utils.pagination import _mutate_from_paginated_call
 
-from ...helpers import check_warn_empty_list
+from ...helpers import is_empty_list_with_warning
 from ..exceptions import MutationError
 from .helpers import get_asset_ids_or_throw_error
 
@@ -113,9 +113,9 @@ class MutationsAsset:
             - For more detailed examples on how to import text assets,
                 see [the recipe](https://github.com/kili-technology/kili-python-sdk/blob/master/recipes/import_text_assets.ipynb).
         """
-        if check_warn_empty_list(
+        if is_empty_list_with_warning(
             "append_many_to_dataset", "content_array", content_array
-        ) or check_warn_empty_list(
+        ) or is_empty_list_with_warning(
             "append_many_to_dataset", "json_content_array", json_content_array
         ):
             return None
@@ -223,9 +223,11 @@ class MutationsAsset:
                     to_be_labeled_by_array=[['test+pierre@kili-technology.com'], None],
                 )
         """
-        if check_warn_empty_list(
+        if is_empty_list_with_warning(
             "update_properties_in_assets", "asset_ids", asset_ids
-        ) or check_warn_empty_list("update_properties_in_assets", "external_ids", external_ids):
+        ) or is_empty_list_with_warning(
+            "update_properties_in_assets", "external_ids", external_ids
+        ):
             return None
 
         if status_array is not None:
@@ -329,7 +331,9 @@ class MutationsAsset:
                     asset_ids=["ckg22d81r0jrg0885unmuswj8", "ckg22d81s0jrh0885pdxfd03n"],
                 )
         """
-        if check_warn_empty_list("change_asset_external_ids", "new_external_ids", new_external_ids):
+        if is_empty_list_with_warning(
+            "change_asset_external_ids", "new_external_ids", new_external_ids
+        ):
             return None
 
         asset_ids = get_asset_ids_or_throw_error(self.auth, asset_ids, external_ids, project_id)
@@ -382,9 +386,9 @@ class MutationsAsset:
             A result object which indicates if the mutation was successful,
                 or an error message.
         """
-        if check_warn_empty_list(
+        if is_empty_list_with_warning(
             "delete_many_from_dataset", "asset_ids", asset_ids
-        ) or check_warn_empty_list("delete_many_from_dataset", "external_ids", external_ids):
+        ) or is_empty_list_with_warning("delete_many_from_dataset", "external_ids", external_ids):
             return None
 
         asset_ids = get_asset_ids_or_throw_error(self.auth, asset_ids, external_ids, project_id)
@@ -450,9 +454,9 @@ class MutationsAsset:
                     ],
                 )
         """
-        if check_warn_empty_list("add_to_review", "asset_ids", asset_ids) or check_warn_empty_list(
-            "add_to_review", "external_ids", external_ids
-        ):
+        if is_empty_list_with_warning(
+            "add_to_review", "asset_ids", asset_ids
+        ) or is_empty_list_with_warning("add_to_review", "external_ids", external_ids):
             return None
 
         asset_ids = get_asset_ids_or_throw_error(self.auth, asset_ids, external_ids, project_id)
@@ -530,9 +534,9 @@ class MutationsAsset:
                         ],
                 )
         """
-        if check_warn_empty_list(
+        if is_empty_list_with_warning(
             "send_back_to_queue", "asset_ids", asset_ids
-        ) or check_warn_empty_list("send_back_to_queue", "external_ids", external_ids):
+        ) or is_empty_list_with_warning("send_back_to_queue", "external_ids", external_ids):
             return None
 
         asset_ids = get_asset_ids_or_throw_error(self.auth, asset_ids, external_ids, project_id)

--- a/src/kili/mutations/asset/__init__.py
+++ b/src/kili/mutations/asset/__init__.py
@@ -154,6 +154,7 @@ class MutationsAsset:
         return result
 
     @typechecked
+    @skip_if_empty_arguments(any_non_empty=["asset_ids", "external_ids"])
     # pylint: disable=unused-argument
     def update_properties_in_assets(
         self,
@@ -170,7 +171,7 @@ class MutationsAsset:
         is_used_for_consensus_array: Optional[List[bool]] = None,
         is_honeypot_array: Optional[List[bool]] = None,
         project_id: Optional[str] = None,
-    ) -> List[Dict]:
+    ) -> Optional[List[Dict]]:
         """Update the properties of one or more assets.
 
         Args:
@@ -291,13 +292,14 @@ class MutationsAsset:
         return [item for batch_list in formated_results for item in batch_list]
 
     @typechecked
+    @skip_if_empty_arguments(all_non_empty=["new_external_ids"])
     def change_asset_external_ids(
         self,
         new_external_ids: List[str],
         asset_ids: Optional[List[str]] = None,
         external_ids: Optional[List[str]] = None,
         project_id: Optional[str] = None,
-    ) -> List[Dict]:
+    ) -> Optional[List[Dict]]:
         """Update the external IDs of one or more assets.
 
         Args:
@@ -349,12 +351,13 @@ class MutationsAsset:
         return [item for batch_list in formated_results for item in batch_list]
 
     @typechecked
+    @skip_if_empty_arguments(any_non_empty=["asset_ids", "external_ids"])
     def delete_many_from_dataset(
         self,
         asset_ids: Optional[List[str]] = None,
         external_ids: Optional[List[str]] = None,
         project_id: Optional[str] = None,
-    ) -> Asset:
+    ) -> Optional[Asset]:
         """Delete assets from a project.
 
         Args:
@@ -480,12 +483,13 @@ class MutationsAsset:
         return result
 
     @typechecked
+    @skip_if_empty_arguments(any_non_empty=["asset_ids", "external_ids"])
     def send_back_to_queue(
         self,
         asset_ids: Optional[List[str]] = None,
         external_ids: Optional[List[str]] = None,
         project_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
+    ) -> Optional[Dict[str, Any]]:
         """Send assets back to queue.
 
         Args:

--- a/src/kili/mutations/asset/__init__.py
+++ b/src/kili/mutations/asset/__init__.py
@@ -27,6 +27,7 @@ from kili.services.asset_import import import_assets
 from kili.utils.logcontext import for_all_methods, log_call
 from kili.utils.pagination import _mutate_from_paginated_call
 
+from ...helpers import skip_if_empty_arguments
 from ..exceptions import MutationError
 from .helpers import get_asset_ids_or_throw_error
 
@@ -60,7 +61,7 @@ class MutationsAsset:
         json_metadata_array: Optional[List[dict]] = None,
         disable_tqdm: bool = False,
         wait_until_availability: bool = True,
-    ) -> Dict[str, str]:
+    ) -> Optional[Dict[str, str]]:
         # pylint: disable=line-too-long
         """Append assets to a project.
 
@@ -399,6 +400,7 @@ class MutationsAsset:
         return format_result("data", results[0], Asset)
 
     @typechecked
+    @skip_if_empty_arguments(any_non_empty=["asset_ids", "external_ids"])
     def add_to_review(
         self,
         asset_ids: Optional[List[str]] = None,

--- a/src/kili/mutations/asset/__init__.py
+++ b/src/kili/mutations/asset/__init__.py
@@ -27,7 +27,7 @@ from kili.services.asset_import import import_assets
 from kili.utils.logcontext import for_all_methods, log_call
 from kili.utils.pagination import _mutate_from_paginated_call
 
-from ...helpers import skip_if_empty_arguments
+from ...helpers import check_warn_empty_list
 from ..exceptions import MutationError
 from .helpers import get_asset_ids_or_throw_error
 
@@ -49,7 +49,6 @@ class MutationsAsset:
         self.auth = auth
 
     @typechecked
-    @skip_if_empty_arguments(any_non_empty=["content_array", "json_content_array"])
     def append_many_to_dataset(
         self,
         project_id: str,
@@ -62,7 +61,7 @@ class MutationsAsset:
         json_metadata_array: Optional[List[dict]] = None,
         disable_tqdm: bool = False,
         wait_until_availability: bool = True,
-    ) -> Dict[str, str]:
+    ) -> Optional[Dict[str, str]]:
         # pylint: disable=line-too-long
         """Append assets to a project.
 
@@ -114,6 +113,13 @@ class MutationsAsset:
             - For more detailed examples on how to import text assets,
                 see [the recipe](https://github.com/kili-technology/kili-python-sdk/blob/master/recipes/import_text_assets.ipynb).
         """
+        if check_warn_empty_list(
+            "append_many_to_dataset", "content_array", content_array
+        ) or check_warn_empty_list(
+            "append_many_to_dataset", "json_content_array", json_content_array
+        ):
+            return None
+
         if status_array is not None:
             warnings.warn(
                 (
@@ -156,7 +162,6 @@ class MutationsAsset:
         return result
 
     @typechecked
-    @skip_if_empty_arguments(any_non_empty=["asset_ids", "external_ids"])
     # pylint: disable=unused-argument
     def update_properties_in_assets(
         self,
@@ -218,6 +223,11 @@ class MutationsAsset:
                     to_be_labeled_by_array=[['test+pierre@kili-technology.com'], None],
                 )
         """
+        if check_warn_empty_list(
+            "update_properties_in_assets", "asset_ids", asset_ids
+        ) or check_warn_empty_list("update_properties_in_assets", "external_ids", external_ids):
+            return None
+
         if status_array is not None:
             warnings.warn(
                 (
@@ -294,7 +304,6 @@ class MutationsAsset:
         return [item for batch_list in formated_results for item in batch_list]
 
     @typechecked
-    @skip_if_empty_arguments(all_non_empty=["new_external_ids"])
     def change_asset_external_ids(
         self,
         new_external_ids: List[str],
@@ -320,6 +329,9 @@ class MutationsAsset:
                     asset_ids=["ckg22d81r0jrg0885unmuswj8", "ckg22d81s0jrh0885pdxfd03n"],
                 )
         """
+        if check_warn_empty_list("change_asset_external_ids", "new_external_ids", new_external_ids):
+            return None
+
         asset_ids = get_asset_ids_or_throw_error(self.auth, asset_ids, external_ids, project_id)
 
         parameters = {
@@ -353,7 +365,6 @@ class MutationsAsset:
         return [item for batch_list in formated_results for item in batch_list]
 
     @typechecked
-    @skip_if_empty_arguments(any_non_empty=["asset_ids", "external_ids"])
     def delete_many_from_dataset(
         self,
         asset_ids: Optional[List[str]] = None,
@@ -371,6 +382,11 @@ class MutationsAsset:
             A result object which indicates if the mutation was successful,
                 or an error message.
         """
+        if check_warn_empty_list(
+            "delete_many_from_dataset", "asset_ids", asset_ids
+        ) or check_warn_empty_list("delete_many_from_dataset", "external_ids", external_ids):
+            return None
+
         asset_ids = get_asset_ids_or_throw_error(self.auth, asset_ids, external_ids, project_id)
 
         properties_to_batch: Dict[str, Optional[List[Any]]] = {"asset_ids": asset_ids}
@@ -405,7 +421,6 @@ class MutationsAsset:
         return format_result("data", results[0], Asset)
 
     @typechecked
-    @skip_if_empty_arguments(any_non_empty=["asset_ids", "external_ids"])
     def add_to_review(
         self,
         asset_ids: Optional[List[str]] = None,
@@ -435,6 +450,11 @@ class MutationsAsset:
                     ],
                 )
         """
+        if check_warn_empty_list("add_to_review", "asset_ids", asset_ids) or check_warn_empty_list(
+            "add_to_review", "external_ids", external_ids
+        ):
+            return None
+
         asset_ids = get_asset_ids_or_throw_error(self.auth, asset_ids, external_ids, project_id)
 
         properties_to_batch: Dict[str, Optional[List[Any]]] = {"asset_ids": asset_ids}
@@ -485,7 +505,6 @@ class MutationsAsset:
         return result
 
     @typechecked
-    @skip_if_empty_arguments(any_non_empty=["asset_ids", "external_ids"])
     def send_back_to_queue(
         self,
         asset_ids: Optional[List[str]] = None,
@@ -511,6 +530,11 @@ class MutationsAsset:
                         ],
                 )
         """
+        if check_warn_empty_list(
+            "send_back_to_queue", "asset_ids", asset_ids
+        ) or check_warn_empty_list("send_back_to_queue", "external_ids", external_ids):
+            return None
+
         asset_ids = get_asset_ids_or_throw_error(self.auth, asset_ids, external_ids, project_id)
 
         properties_to_batch: Dict[str, Optional[List[Any]]] = {"asset_ids": asset_ids}

--- a/src/kili/mutations/asset/__init__.py
+++ b/src/kili/mutations/asset/__init__.py
@@ -61,7 +61,7 @@ class MutationsAsset:
         json_metadata_array: Optional[List[dict]] = None,
         disable_tqdm: bool = False,
         wait_until_availability: bool = True,
-    ) -> Dict[str, str]:
+    ) -> Optional[Dict[str, str]]:
         # pylint: disable=line-too-long
         """Append assets to a project.
 
@@ -118,7 +118,7 @@ class MutationsAsset:
         ) or is_empty_list_with_warning(
             "append_many_to_dataset", "json_content_array", json_content_array
         ):
-            return {}
+            return None
 
         if status_array is not None:
             warnings.warn(
@@ -514,7 +514,7 @@ class MutationsAsset:
         asset_ids: Optional[List[str]] = None,
         external_ids: Optional[List[str]] = None,
         project_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
+    ) -> Optional[Dict[str, Any]]:
         """Send assets back to queue.
 
         Args:
@@ -537,7 +537,7 @@ class MutationsAsset:
         if is_empty_list_with_warning(
             "send_back_to_queue", "asset_ids", asset_ids
         ) or is_empty_list_with_warning("send_back_to_queue", "external_ids", external_ids):
-            return {}
+            return None
 
         asset_ids = get_asset_ids_or_throw_error(self.auth, asset_ids, external_ids, project_id)
 

--- a/src/kili/mutations/asset/__init__.py
+++ b/src/kili/mutations/asset/__init__.py
@@ -61,7 +61,7 @@ class MutationsAsset:
         json_metadata_array: Optional[List[dict]] = None,
         disable_tqdm: bool = False,
         wait_until_availability: bool = True,
-    ) -> Optional[Dict[str, str]]:
+    ) -> Dict[str, str]:
         # pylint: disable=line-too-long
         """Append assets to a project.
 
@@ -118,7 +118,7 @@ class MutationsAsset:
         ) or is_empty_list_with_warning(
             "append_many_to_dataset", "json_content_array", json_content_array
         ):
-            return None
+            return {}
 
         if status_array is not None:
             warnings.warn(
@@ -178,7 +178,7 @@ class MutationsAsset:
         is_used_for_consensus_array: Optional[List[bool]] = None,
         is_honeypot_array: Optional[List[bool]] = None,
         project_id: Optional[str] = None,
-    ) -> Optional[List[Dict]]:
+    ) -> List[Dict]:
         """Update the properties of one or more assets.
 
         Args:
@@ -228,7 +228,7 @@ class MutationsAsset:
         ) or is_empty_list_with_warning(
             "update_properties_in_assets", "external_ids", external_ids
         ):
-            return None
+            return []
 
         if status_array is not None:
             warnings.warn(
@@ -312,7 +312,7 @@ class MutationsAsset:
         asset_ids: Optional[List[str]] = None,
         external_ids: Optional[List[str]] = None,
         project_id: Optional[str] = None,
-    ) -> Optional[List[Dict]]:
+    ) -> List[Dict]:
         """Update the external IDs of one or more assets.
 
         Args:
@@ -334,7 +334,7 @@ class MutationsAsset:
         if is_empty_list_with_warning(
             "change_asset_external_ids", "new_external_ids", new_external_ids
         ):
-            return None
+            return []
 
         asset_ids = get_asset_ids_or_throw_error(self.auth, asset_ids, external_ids, project_id)
 
@@ -374,7 +374,7 @@ class MutationsAsset:
         asset_ids: Optional[List[str]] = None,
         external_ids: Optional[List[str]] = None,
         project_id: Optional[str] = None,
-    ) -> Optional[Asset]:
+    ) -> Asset:
         """Delete assets from a project.
 
         Args:
@@ -389,7 +389,7 @@ class MutationsAsset:
         if is_empty_list_with_warning(
             "delete_many_from_dataset", "asset_ids", asset_ids
         ) or is_empty_list_with_warning("delete_many_from_dataset", "external_ids", external_ids):
-            return None
+            return Asset()
 
         asset_ids = get_asset_ids_or_throw_error(self.auth, asset_ids, external_ids, project_id)
 
@@ -514,7 +514,7 @@ class MutationsAsset:
         asset_ids: Optional[List[str]] = None,
         external_ids: Optional[List[str]] = None,
         project_id: Optional[str] = None,
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Dict[str, Any]:
         """Send assets back to queue.
 
         Args:
@@ -537,7 +537,7 @@ class MutationsAsset:
         if is_empty_list_with_warning(
             "send_back_to_queue", "asset_ids", asset_ids
         ) or is_empty_list_with_warning("send_back_to_queue", "external_ids", external_ids):
-            return None
+            return {}
 
         asset_ids = get_asset_ids_or_throw_error(self.auth, asset_ids, external_ids, project_id)
 

--- a/src/kili/mutations/asset/__init__.py
+++ b/src/kili/mutations/asset/__init__.py
@@ -61,7 +61,7 @@ class MutationsAsset:
         json_metadata_array: Optional[List[dict]] = None,
         disable_tqdm: bool = False,
         wait_until_availability: bool = True,
-    ) -> Optional[Dict[str, str]]:
+    ) -> Dict[str, str]:
         # pylint: disable=line-too-long
         """Append assets to a project.
 

--- a/src/kili/mutations/label/__init__.py
+++ b/src/kili/mutations/label/__init__.py
@@ -49,7 +49,7 @@ class MutationsLabel:
         json_response_array: Optional[List[dict]] = None,
         model_name: Optional[str] = None,
         asset_id_array: Optional[List[str]] = None,
-    ) -> dict:
+    ) -> Dict:
         # pylint: disable=line-too-long
         """Create predictions for specific assets.
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -198,3 +198,17 @@ class TestSkipIfEmptyDecorator(TestCase):
             warnings.simplefilter("error")
             kili.add_to_review(["asset_id"], None)
         mocked__mutate_from_paginated_call.assert_called_once()
+
+    def test_all_non_empty(self, mocked__mutate_from_paginated_call):
+        """test the all_non_empty argument of the skip_if_empty_arguments decorator"""
+        kili = MutationsAsset(auth=MagicMock())
+        with pytest.warns(
+            UserWarning,
+            match=(
+                "Skipping 'change_asset_external_ids' because the following arguments are empty:"
+                " new_external_ids"
+            ),
+        ):
+            ret = kili.change_asset_external_ids(new_external_ids=[], asset_ids=[])
+        assert ret is None
+        mocked__mutate_from_paginated_call.assert_not_called()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -2,14 +2,17 @@ import json
 import time
 import warnings
 from typing import List
-from unittest.mock import patch
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
 
 import pytest
 from tenacity import TryAgain, retry
 from tenacity.wait import wait_fixed
 
+from kili.exceptions import MissingArgumentError
 from kili.graphql.operations.label.queries import LabelQuery
 from kili.helpers import RetryLongWaitWarner, format_result
+from kili.mutations.asset import MutationsAsset
 from kili.mutations.issue.helpers import get_labels_asset_ids_map
 from kili.orm import Asset
 from tests.services.export.fakes.fake_kili import FakeAuth
@@ -117,3 +120,79 @@ def test_get_labels_asset_ids_map():
             "label_id_1": "asset_id_1",
             "label_id_2": "asset_id_1",
         }
+
+
+@patch("kili.mutations.asset._mutate_from_paginated_call", return_value=[{"data": None}])
+class TestSkipIfEmptyDecorator(TestCase):
+    """
+    tests for the skip_if_empty_input decorator
+    """
+
+    def test_kwargs_empty(self, mocked__mutate_from_paginated_call):
+        kili = MutationsAsset(auth=MagicMock())
+        with pytest.warns(
+            UserWarning,
+            match=(
+                "Skipping 'add_to_review' because the following inputs are empty: asset_ids,"
+                " external_ids."
+            ),
+        ):
+            ret = kili.add_to_review(asset_ids=[], external_ids=[])
+        assert ret is None
+        mocked__mutate_from_paginated_call.assert_not_called()
+
+    def test_args_empty(self, mocked__mutate_from_paginated_call):
+        kili = MutationsAsset(auth=MagicMock())
+        with pytest.warns(
+            UserWarning,
+            match=(
+                "Skipping 'add_to_review' because the following inputs are empty: asset_ids,"
+                " external_ids."
+            ),
+        ):
+            ret = kili.add_to_review([], [])
+        assert ret is None
+        mocked__mutate_from_paginated_call.assert_not_called()
+
+    def test_none(self, mocked__mutate_from_paginated_call):
+        """test that the decorator does not raise a warning if the input is None"""
+        kili = MutationsAsset(auth=MagicMock())
+        with pytest.raises(MissingArgumentError):
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                kili.add_to_review()
+        mocked__mutate_from_paginated_call.assert_not_called()
+
+    def test_kwargs_one_empty(self, mocked__mutate_from_paginated_call):
+        kili = MutationsAsset(auth=MagicMock())
+        with pytest.warns(
+            UserWarning,
+            match="Skipping 'add_to_review' because the following inputs are empty: external_ids.",
+        ):
+            ret = kili.add_to_review(asset_ids=None, external_ids=[], project_id="project_id")
+        assert ret is None
+        mocked__mutate_from_paginated_call.assert_not_called()
+
+    def test_kwargs_one_empty_2(self, mocked__mutate_from_paginated_call):
+        kili = MutationsAsset(auth=MagicMock())
+        with pytest.warns(
+            UserWarning,
+            match="Skipping 'add_to_review' because the following inputs are empty: asset_ids",
+        ):
+            ret = kili.add_to_review(asset_ids=[], external_ids=None)
+        assert ret is None
+        mocked__mutate_from_paginated_call.assert_not_called()
+
+    def test_kwargs_no_skip(self, mocked__mutate_from_paginated_call):
+        kili = MutationsAsset(auth=MagicMock())
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            kili.add_to_review(asset_ids=["asset_id"], external_ids=None)
+        mocked__mutate_from_paginated_call.assert_called_once()
+
+    def test_args_skip(self, mocked__mutate_from_paginated_call):
+        kili = MutationsAsset(auth=MagicMock())
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            kili.add_to_review(["asset_id"], None)
+        mocked__mutate_from_paginated_call.assert_called_once()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -123,9 +123,9 @@ def test_get_labels_asset_ids_map():
 
 
 @patch("kili.mutations.asset._mutate_from_paginated_call", return_value=[{"data": None}])
-class TestSkipIfEmptyDecorator(TestCase):
+class TestCheckWarnEmptyList(TestCase):
     """
-    tests for the skip_if_empty_input decorator
+    tests for the check_warn_empty_list helper
     """
 
     def test_kwargs_empty(self, mocked__mutate_from_paginated_call):
@@ -155,7 +155,7 @@ class TestSkipIfEmptyDecorator(TestCase):
         mocked__mutate_from_paginated_call.assert_not_called()
 
     def test_none(self, mocked__mutate_from_paginated_call):
-        """test that the decorator does not raise a warning if args are None"""
+        """test that the helper does not raise a warning if args are None"""
         kili = MutationsAsset(auth=MagicMock())
         with pytest.raises(MissingArgumentError):
             with warnings.catch_warnings():
@@ -189,22 +189,21 @@ class TestSkipIfEmptyDecorator(TestCase):
         assert ret is None
         mocked__mutate_from_paginated_call.assert_not_called()
 
-    def test_kwargs_no_warning(self, mocked__mutate_from_paginated_call):
+    def test_kwargs_no_warning_correct_input(self, mocked__mutate_from_paginated_call):
         kili = MutationsAsset(auth=MagicMock())
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             kili.add_to_review(asset_ids=["asset_id"], external_ids=None)
         mocked__mutate_from_paginated_call.assert_called_once()
 
-    def test_args_no_warning(self, mocked__mutate_from_paginated_call):
+    def test_args_no_warning_correct_input(self, mocked__mutate_from_paginated_call):
         kili = MutationsAsset(auth=MagicMock())
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             kili.add_to_review(["asset_id"], None)
         mocked__mutate_from_paginated_call.assert_called_once()
 
-    def test_all_non_empty(self, mocked__mutate_from_paginated_call):
-        """test the all_non_empty argument of the skip_if_empty_arguments decorator"""
+    def test_warn_change_asset_external_ids(self, mocked__mutate_from_paginated_call):
         kili = MutationsAsset(auth=MagicMock())
         with pytest.warns(
             UserWarning,

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -133,8 +133,8 @@ class TestSkipIfEmptyDecorator(TestCase):
         with pytest.warns(
             UserWarning,
             match=(
-                "Method 'add_to_review' did nothing because the following arguments are empty:"
-                " asset_ids, external_ids."
+                "Method 'add_to_review' did nothing because the following argument is empty:"
+                " asset_ids."
             ),
         ):
             ret = kili.add_to_review(asset_ids=[], external_ids=[])
@@ -146,8 +146,8 @@ class TestSkipIfEmptyDecorator(TestCase):
         with pytest.warns(
             UserWarning,
             match=(
-                "Method 'add_to_review' did nothing because the following arguments are empty:"
-                " asset_ids, external_ids."
+                "Method 'add_to_review' did nothing because the following argument is empty:"
+                " asset_ids."
             ),
         ):
             ret = kili.add_to_review([], [])
@@ -168,7 +168,7 @@ class TestSkipIfEmptyDecorator(TestCase):
         with pytest.warns(
             UserWarning,
             match=(
-                "Method 'add_to_review' did nothing because the following arguments are empty:"
+                "Method 'add_to_review' did nothing because the following argument is empty:"
                 " external_ids."
             ),
         ):
@@ -181,7 +181,7 @@ class TestSkipIfEmptyDecorator(TestCase):
         with pytest.warns(
             UserWarning,
             match=(
-                "Method 'add_to_review' did nothing because the following arguments are empty:"
+                "Method 'add_to_review' did nothing because the following argument is empty:"
                 " asset_ids"
             ),
         ):
@@ -209,7 +209,7 @@ class TestSkipIfEmptyDecorator(TestCase):
         with pytest.warns(
             UserWarning,
             match=(
-                "Method 'change_asset_external_ids' did nothing because the following arguments are"
+                "Method 'change_asset_external_ids' did nothing because the following argument is"
                 " empty: new_external_ids"
             ),
         ):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -133,8 +133,8 @@ class TestSkipIfEmptyDecorator(TestCase):
         with pytest.warns(
             UserWarning,
             match=(
-                "Skipping 'add_to_review' because the following arguments are empty: asset_ids,"
-                " external_ids."
+                "Method 'add_to_review' did nothing because the following arguments are empty:"
+                " asset_ids, external_ids."
             ),
         ):
             ret = kili.add_to_review(asset_ids=[], external_ids=[])
@@ -146,8 +146,8 @@ class TestSkipIfEmptyDecorator(TestCase):
         with pytest.warns(
             UserWarning,
             match=(
-                "Skipping 'add_to_review' because the following arguments are empty: asset_ids,"
-                " external_ids."
+                "Method 'add_to_review' did nothing because the following arguments are empty:"
+                " asset_ids, external_ids."
             ),
         ):
             ret = kili.add_to_review([], [])
@@ -168,7 +168,8 @@ class TestSkipIfEmptyDecorator(TestCase):
         with pytest.warns(
             UserWarning,
             match=(
-                "Skipping 'add_to_review' because the following arguments are empty: external_ids."
+                "Method 'add_to_review' did nothing because the following arguments are empty:"
+                " external_ids."
             ),
         ):
             ret = kili.add_to_review(asset_ids=None, external_ids=[], project_id="project_id")
@@ -179,7 +180,10 @@ class TestSkipIfEmptyDecorator(TestCase):
         kili = MutationsAsset(auth=MagicMock())
         with pytest.warns(
             UserWarning,
-            match="Skipping 'add_to_review' because the following arguments are empty: asset_ids",
+            match=(
+                "Method 'add_to_review' did nothing because the following arguments are empty:"
+                " asset_ids"
+            ),
         ):
             ret = kili.add_to_review(asset_ids=[], external_ids=None)
         assert ret is None
@@ -205,8 +209,8 @@ class TestSkipIfEmptyDecorator(TestCase):
         with pytest.warns(
             UserWarning,
             match=(
-                "Skipping 'change_asset_external_ids' because the following arguments are empty:"
-                " new_external_ids"
+                "Method 'change_asset_external_ids' did nothing because the following arguments are"
+                " empty: new_external_ids"
             ),
         ):
             ret = kili.change_asset_external_ids(new_external_ids=[], asset_ids=[])

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -133,7 +133,7 @@ class TestSkipIfEmptyDecorator(TestCase):
         with pytest.warns(
             UserWarning,
             match=(
-                "Skipping 'add_to_review' because the following inputs are empty: asset_ids,"
+                "Skipping 'add_to_review' because the following arguments are empty: asset_ids,"
                 " external_ids."
             ),
         ):
@@ -146,7 +146,7 @@ class TestSkipIfEmptyDecorator(TestCase):
         with pytest.warns(
             UserWarning,
             match=(
-                "Skipping 'add_to_review' because the following inputs are empty: asset_ids,"
+                "Skipping 'add_to_review' because the following arguments are empty: asset_ids,"
                 " external_ids."
             ),
         ):
@@ -167,7 +167,9 @@ class TestSkipIfEmptyDecorator(TestCase):
         kili = MutationsAsset(auth=MagicMock())
         with pytest.warns(
             UserWarning,
-            match="Skipping 'add_to_review' because the following inputs are empty: external_ids.",
+            match=(
+                "Skipping 'add_to_review' because the following arguments are empty: external_ids."
+            ),
         ):
             ret = kili.add_to_review(asset_ids=None, external_ids=[], project_id="project_id")
         assert ret is None
@@ -177,7 +179,7 @@ class TestSkipIfEmptyDecorator(TestCase):
         kili = MutationsAsset(auth=MagicMock())
         with pytest.warns(
             UserWarning,
-            match="Skipping 'add_to_review' because the following inputs are empty: asset_ids",
+            match="Skipping 'add_to_review' because the following arguments are empty: asset_ids",
         ):
             ret = kili.add_to_review(asset_ids=[], external_ids=None)
         assert ret is None

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -213,5 +213,5 @@ class TestCheckWarnEmptyList(TestCase):
             ),
         ):
             ret = kili.change_asset_external_ids(new_external_ids=[], asset_ids=[])
-        assert ret is None
+        assert ret == []
         mocked__mutate_from_paginated_call.assert_not_called()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -155,7 +155,7 @@ class TestSkipIfEmptyDecorator(TestCase):
         mocked__mutate_from_paginated_call.assert_not_called()
 
     def test_none(self, mocked__mutate_from_paginated_call):
-        """test that the decorator does not raise a warning if the input is None"""
+        """test that the decorator does not raise a warning if args are None"""
         kili = MutationsAsset(auth=MagicMock())
         with pytest.raises(MissingArgumentError):
             with warnings.catch_warnings():
@@ -183,14 +183,14 @@ class TestSkipIfEmptyDecorator(TestCase):
         assert ret is None
         mocked__mutate_from_paginated_call.assert_not_called()
 
-    def test_kwargs_no_skip(self, mocked__mutate_from_paginated_call):
+    def test_kwargs_no_warning(self, mocked__mutate_from_paginated_call):
         kili = MutationsAsset(auth=MagicMock())
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             kili.add_to_review(asset_ids=["asset_id"], external_ids=None)
         mocked__mutate_from_paginated_call.assert_called_once()
 
-    def test_args_skip(self, mocked__mutate_from_paginated_call):
+    def test_args_no_warning(self, mocked__mutate_from_paginated_call):
         kili = MutationsAsset(auth=MagicMock())
         with warnings.catch_warnings():
             warnings.simplefilter("error")


### PR DESCRIPTION
add a helperthat raises warning and return bool if the provided input list is empty 

Some methods already check for the len(input_array), so I didn't modify them

e2e: https://github.com/kili-technology/kili-python-sdk/actions/runs/4382202318
