### PR TITLE
test: disable tests for plugin notebooks on LTS

### DIFF
--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -1,6 +1,8 @@
 """
 Test notebooks with pytest
 """
+import os
+
 import nbformat
 import pytest
 from nbconvert.preprocessors.execute import ExecutePreprocessor
@@ -25,7 +27,13 @@ def process_notebook(notebook_filename):
         "tests/e2e/import_assets.ipynb",
         "tests/e2e/import_predictions.ipynb",
         "tests/e2e/paginated_calls_project_lifecycle.ipynb",
-        "tests/e2e/plugin_workflow.ipynb",
+        pytest.param(
+            "tests/e2e/plugin_workflow.ipynb",
+            marks=pytest.mark.skipif(
+                "lts.cloud" in os.environ["KILI_API_ENDPOINT"],
+                reason="Feature not available on premise",
+            ),
+        ),
         "recipes/basic_project_setup.ipynb",
         "recipes/export_a_kili_project.ipynb",
         "recipes/frame_dicom_data.ipynb",
@@ -36,7 +44,13 @@ def process_notebook(notebook_filename):
         "recipes/medical_imaging.ipynb",
         "recipes/ocr_pre_annotations.ipynb",
         "recipes/pixel_level_masks.ipynb",
-        "recipes/plugins_example.ipynb",
+        pytest.param(
+            "recipes/plugins_example.ipynb",
+            marks=pytest.mark.skipif(
+                "lts.cloud" in os.environ["KILI_API_ENDPOINT"],
+                reason="Feature not available on premise",
+            ),
+        ),
         "recipes/set_up_workflows.ipynb",
         "recipes/webhooks_example.ipynb",
     ],


### PR DESCRIPTION
e2e: https://github.com/kili-technology/kili-python-sdk/actions/runs/4374421316/jobs/7653828732

```shell
============================= test session starts ==============================
platform linux -- Python 3.7.15, pytest-7.2.2, pluggy-1.0.0 -- /opt/hostedtoolcache/Python/3.7.15/x64/bin/python
cachedir: .pytest_cache
rootdir: /home/runner/work/kili-python-sdk/kili-python-sdk
plugins: mock-3.10.0, cov-4.0.0, typeguard-2.13.3
collecting ... collected 19 items
tests/test_notebooks.py::test_all_recipes[tests/e2e/create_project.ipynb] PASSED
tests/test_notebooks.py::test_all_recipes[tests/e2e/export_labels.ipynb] PASSED
tests/test_notebooks.py::test_all_recipes[tests/e2e/import_assets.ipynb] PASSED
tests/test_notebooks.py::test_all_recipes[tests/e2e/import_predictions.ipynb] PASSED
tests/test_notebooks.py::test_all_recipes[tests/e2e/paginated_calls_project_lifecycle.ipynb] PASSED
tests/test_notebooks.py::test_all_recipes[tests/e2e/plugin_workflow.ipynb] SKIPPED (Feature not available on premise)
tests/test_notebooks.py::test_all_recipes[recipes/basic_project_setup.ipynb] PASSED
```