### PR TITLE
fix: refetch local graphql schema when outdated

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ install_requires = [
     "tabulate",
     "tenacity",
     "tqdm",
-    "typeguard",
+    "typeguard<3.0.0",
     "typing_extensions>=4.1.0",
     "pyparsing",
     "websocket-client",

--- a/src/kili/graphql/graphql_client.py
+++ b/src/kili/graphql/graphql_client.py
@@ -63,15 +63,12 @@ class GraphQLClient:
             method="POST",
         )
 
-        self._gql_client = self._initizalize_graphql_client(use_cached_schema=True)
+        self._gql_client = self._initizalize_graphql_client()
 
-    def _initizalize_graphql_client(self, use_cached_schema: bool) -> Client:
+    def _initizalize_graphql_client(self) -> Client:
         """
         Initialize the GraphQL client
         """
-        if not use_cached_schema:
-            return Client(transport=self._gql_transport, fetch_schema_from_transport=True)
-
         graphql_schema_path = self._get_graphql_schema_path()
 
         if graphql_schema_path is None:
@@ -178,7 +175,8 @@ class GraphQLClient:
             # if error is due do parsing, local validation of the query (graphql.GraphQLError)
             # we refresh the schema and retry
             if isinstance(err.__cause__, graphql.GraphQLError):
-                self._gql_client = self._initizalize_graphql_client(use_cached_schema=False)
+                self._purge_graphql_schema_cache_dir()
+                self._gql_client = self._initizalize_graphql_client()
                 ret = _execute(document, variables)
             else:
                 raise err

--- a/src/kili/graphql/graphql_client.py
+++ b/src/kili/graphql/graphql_client.py
@@ -40,17 +40,11 @@ class GraphQLClient:
     ) -> None:
         self.endpoint = endpoint
         self.api_key = api_key
+        self.client_name = client_name
         self.verify = verify
 
         self.ws_endpoint = self.endpoint.replace("http", "ws")
 
-        self.headers = {
-            "Authorization": f"X-API-Key: {api_key}",
-            "Accept": "application/json",
-            "Content-Type": "application/json",
-            "apollographql-client-name": client_name.value,
-            "apollographql-client-version": __version__,
-        }
         self._gql_transport = RequestsHTTPTransport(
             url=endpoint,
             headers=self.headers,
@@ -64,6 +58,19 @@ class GraphQLClient:
         )
 
         self._gql_client = self._initizalize_graphql_client()
+
+    @property
+    def headers(self) -> Dict[str, str]:
+        """
+        Get the headers
+        """
+        return {
+            "Authorization": f"X-API-Key: {self.api_key}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "apollographql-client-name": self.client_name.value,
+            "apollographql-client-version": __version__,
+        }
 
     def _initizalize_graphql_client(self) -> Client:
         """

--- a/src/kili/graphql/graphql_client.py
+++ b/src/kili/graphql/graphql_client.py
@@ -9,7 +9,7 @@ import threading
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Optional, Union
 from urllib.parse import urlparse
 
 import graphql
@@ -26,7 +26,6 @@ from kili.graphql.clientnames import GraphQLClientName
 from kili.utils.logcontext import LogContext
 
 
-# pylint: disable=too-few-public-methods
 class GraphQLClient:
     """
     GraphQL client
@@ -43,6 +42,8 @@ class GraphQLClient:
         self.api_key = api_key
         self.verify = verify
 
+        self.ws_endpoint = self.endpoint.replace("http", "ws")
+
         self.headers = {
             "Authorization": f"X-API-Key: {api_key}",
             "Accept": "application/json",
@@ -58,41 +59,37 @@ class GraphQLClient:
             use_json=True,
             timeout=30,
             verify=verify,
-            retries=20,  # requests.Session retries
+            retries=20,
             method="POST",
-            # can add other requests kwargs here
         )
 
-        try:
-            graphql_schema_path = self._get_graphql_schema_path()
-            self._cache_graphql_schema(graphql_schema_path)
-        except (requests.exceptions.JSONDecodeError, json.decoder.JSONDecodeError):
-            self._gql_client = Client(
-                transport=self._gql_transport, fetch_schema_from_transport=True
-            )
-        else:
-            self._gql_client = Client(
-                schema=graphql_schema_path.read_text(encoding="utf-8"),
-                transport=self._gql_transport,
-            )
+        self._gql_client = self._initizalize_graphql_client(use_cached_schema=True)
 
-        self.ws_endpoint = self.endpoint.replace("http", "ws")
+    def _initizalize_graphql_client(self, use_cached_schema: bool) -> Client:
+        """
+        Initialize the GraphQL client
+        """
+        if not use_cached_schema:
+            return Client(transport=self._gql_transport, fetch_schema_from_transport=True)
+
+        graphql_schema_path = self._get_graphql_schema_path()
+
+        if graphql_schema_path is None:
+            return Client(transport=self._gql_transport, fetch_schema_from_transport=True)
+
+        if not (graphql_schema_path.is_file() and graphql_schema_path.stat().st_size > 0):
+            self._purge_graphql_schema_cache_dir()
+            self._cache_graphql_schema(graphql_schema_path)
+
+        return Client(
+            schema=graphql_schema_path.read_text(encoding="utf-8"),
+            transport=self._gql_transport,
+        )
 
     def _cache_graphql_schema(self, graphql_schema_path: Path) -> None:
         """
-        Cache the graphql schema (if not already in cache).
-
-        If the schema is not in cache, it will be fetched from the server.
-
-        Also deletes old cache files.
+        Cache the graphql schema on disk.
         """
-        for old_cache_file in graphql_schema_path.parent.glob("*.graphql"):
-            if old_cache_file.name != graphql_schema_path.name:
-                old_cache_file.unlink()
-
-        if graphql_schema_path.is_file() and graphql_schema_path.stat().st_size > 0:
-            return
-
         with Client(transport=self._gql_transport, fetch_schema_from_transport=True) as session:
             schema_str = print_schema(session.client.schema)  # type: ignore
 
@@ -101,28 +98,50 @@ class GraphQLClient:
         with graphql_schema_path.open("w", encoding="utf-8") as file:
             file.write(schema_str)
 
-    def _get_graphql_schema_path(self) -> Path:
+    @property
+    def graphql_schema_cache_dir(self) -> Path:
+        """
+        Get the path of the GraphQL schema cache directory
+        """
+        return Path.home() / ".cache" / "kili" / "graphql"
+
+    def _purge_graphql_schema_cache_dir(self) -> None:
+        """
+        Purge the schema cache directory
+        """
+        for file in self.graphql_schema_cache_dir.glob("*.graphql"):
+            file.unlink()
+
+    def _get_graphql_schema_path(self) -> Optional[Path]:
         """
         Get the path of the GraphQL schema
+
+        Will return None if we cannot get the version of the Kili app server.
         """
         endpoint_netloc = urlparse(self.endpoint).netloc
         version = self._get_kili_app_version()
-
+        if version is None:
+            return None
         filename = f"{endpoint_netloc}_{version}.graphql"
-        dir_ = Path.home() / ".cache" / "kili" / "graphql"
+        return self.graphql_schema_cache_dir / filename
 
-        return dir_ / filename
-
-    def _get_kili_app_version(self) -> str:
+    def _get_kili_app_version(self) -> Optional[str]:
         """
         Get the version of the Kili app server
+
+        Returns None if the version cannot be retrieved.
         """
         url = self.endpoint.replace("/graphql", "/version")
-        response = requests.get(url, verify=self.verify, timeout=30).json()
-        version = response["version"]
-        return version
+        response = requests.get(url, verify=self.verify, timeout=30)
+        if response.status_code == 200 and '"version":' in response.text:
+            response_json = response.json()
+            version = response_json["version"]
+            return version
+        return None
 
-    def execute(self, query: Union[str, DocumentNode], variables: Optional[Dict] = None) -> Dict:
+    def execute(
+        self, query: Union[str, DocumentNode], variables: Optional[Dict] = None
+    ) -> Dict[str, Any]:
         """
         Execute a query
 
@@ -130,26 +149,40 @@ class GraphQLClient:
             query: the GraphQL query
             variables: the payload of the query
         """
+
+        def _execute(document: DocumentNode, variables: Optional[Dict] = None) -> Dict[str, Any]:
+            try:
+                assert self._gql_transport.headers, "Transport headers must be defined"
+                result = self._gql_client.execute(
+                    document=document,
+                    variable_values=variables,
+                    extra_args={
+                        "headers": {
+                            **self._gql_transport.headers,
+                            **LogContext(),
+                        }
+                    },
+                )
+            except (exceptions.TransportQueryError, graphql.GraphQLError) as err:
+                if isinstance(err, exceptions.TransportQueryError):
+                    raise GraphQLError(error=err.errors) from err
+                if isinstance(err, graphql.GraphQLError):
+                    raise GraphQLError(error=err.message) from err
+            return result  # type: ignore
+
         document = query if isinstance(query, DocumentNode) else gql(query)
 
         try:
-            assert self._gql_transport.headers, "Transport headers must be defined"
-            result = self._gql_client.execute(
-                document=document,
-                variable_values=variables,
-                extra_args={
-                    "headers": {
-                        **self._gql_transport.headers,
-                        **LogContext(),
-                    }
-                },
-            )
-        except (exceptions.TransportQueryError, graphql.GraphQLError) as err:
-            if isinstance(err, exceptions.TransportQueryError):
-                raise GraphQLError(error=err.errors) from err
-            if isinstance(err, graphql.GraphQLError):
-                raise GraphQLError(error=err.message) from err
-        return result  # type: ignore
+            ret = _execute(document, variables)
+        except GraphQLError as err:
+            # if error is due do parsing, local validation of the query (graphql.GraphQLError)
+            # we refresh the schema and retry
+            if isinstance(err.__cause__, graphql.GraphQLError):
+                self._gql_client = self._initizalize_graphql_client(use_cached_schema=False)
+                ret = _execute(document, variables)
+            else:
+                raise err
+        return ret
 
 
 GQL_WS_SUBPROTOCOL = "graphql-ws"

--- a/src/kili/graphql/graphql_client.py
+++ b/src/kili/graphql/graphql_client.py
@@ -47,7 +47,7 @@ class GraphQLClient:
 
         self._gql_transport = RequestsHTTPTransport(
             url=endpoint,
-            headers=self.headers,
+            headers=self._get_headers(),
             cookies=None,
             auth=None,
             use_json=True,
@@ -59,8 +59,7 @@ class GraphQLClient:
 
         self._gql_client = self._initizalize_graphql_client()
 
-    @property
-    def headers(self) -> Dict[str, str]:
+    def _get_headers(self) -> Dict[str, str]:
         """
         Get the headers
         """
@@ -156,13 +155,12 @@ class GraphQLClient:
 
         def _execute(document: DocumentNode, variables: Optional[Dict] = None) -> Dict[str, Any]:
             try:
-                assert self._gql_transport.headers, "Transport headers must be defined"
                 result = self._gql_client.execute(
                     document=document,
                     variable_values=variables,
                     extra_args={
                         "headers": {
-                            **self._gql_transport.headers,
+                            **self._gql_transport.headers,  # type: ignore
                             **LogContext(),
                         }
                     },

--- a/tests/e2e/test_graphql_client.py
+++ b/tests/e2e/test_graphql_client.py
@@ -126,13 +126,13 @@ def test_outdated_cached_schema(mocker):
 
     client._gql_client.schema = build_ast_schema(parse(fake_schema))
 
-    assert "email" not in client._gql_client.schema.type_map["User"].fields
+    assert "email" not in client._gql_client.schema.type_map["User"].fields  # type: ignore
 
     # the query below will fail since the schema is outdated
     # but the client should fetch an up-to-date schema and retry
     result = client.execute("query MyQuery { me { email id } }")
 
-    assert "email" in client._gql_client.schema.type_map["User"].fields
+    assert "email" in client._gql_client.schema.type_map["User"].fields  # type: ignore
 
     assert result["me"]["id"]  # pylint: disable=unsubscriptable-object
     assert result["me"]["email"]  # pylint: disable=unsubscriptable-object

--- a/tests/e2e/test_graphql_client.py
+++ b/tests/e2e/test_graphql_client.py
@@ -5,36 +5,25 @@ import os
 from pathlib import Path
 from unittest import mock
 
-import graphql
 import pytest
 from gql.transport import exceptions
 from graphql import build_ast_schema, parse
 
-from kili.client import Kili
 from kili.exceptions import GraphQLError
 from kili.graphql.graphql_client import GraphQLClient, GraphQLClientName
 
 
-@pytest.mark.parametrize(
-    "query",
-    [
-        "query MyQuery { my_query_is_clearly_not_valid_according_to_the_kili_schema { id } }",
-        "query { projects { this_field_does_not_exist } }",
-    ],
-)
-def test_gql_bad_query_local_validation(query):
-    """test gql validation against local schema"""
-    kili = Kili()  # fetch schema from kili server
-
-    with pytest.raises(GraphQLError) as exc_info:
-        kili.auth.client.execute(query)
-
-    assert isinstance(exc_info.value.__cause__, graphql.GraphQLError)
-
-
 def test_gql_bad_query_remote_validation():
     """test validation by the server no local schema"""
-    kili = Kili()
+    api_endpoint = os.getenv("KILI_API_ENDPOINT")
+    api_key = os.getenv("KILI_API_KEY")
+
+    client = GraphQLClient(
+        endpoint=api_endpoint,  # type: ignore
+        api_key=api_key,  # type: ignore
+        client_name=GraphQLClientName.SDK,
+        verify=True,
+    )
 
     query = """
     query MyQuery {
@@ -44,50 +33,18 @@ def test_gql_bad_query_remote_validation():
     }
     """
 
-    kili.auth.client._gql_client.schema = None
-    kili.auth.client._gql_client.fetch_schema_from_transport = False
+    client._gql_client.schema = None
+    client._gql_client.fetch_schema_from_transport = False
     mocked_validate = mock.MagicMock()
-    kili.auth.client._gql_client.validate = mocked_validate
+    client._gql_client.validate = mocked_validate
 
     with pytest.raises(GraphQLError) as exc_info:
-        kili.auth.client.execute(query)
+        client.execute(query)
 
     assert isinstance(exc_info.value.__cause__, exceptions.TransportQueryError)
     assert "Cannot query field" in str(exc_info.value.__cause__)
 
     mocked_validate.assert_not_called()
-
-
-def test_graphql_client_cache(mocker):
-    SCHEMA_PATH = Path.home() / ".cache" / "kili" / "graphql" / "schema.graphql"
-    mocker.patch.object(GraphQLClient, "_get_graphql_schema_path", return_value=SCHEMA_PATH)
-
-    api_endpoint = os.getenv("KILI_API_ENDPOINT")
-    api_key = os.getenv("KILI_API_KEY")
-
-    if SCHEMA_PATH.is_file():
-        SCHEMA_PATH.unlink()
-
-    _ = GraphQLClient(
-        endpoint=api_endpoint,  # type: ignore
-        api_key=api_key,  # type: ignore
-        client_name=GraphQLClientName.SDK,
-        verify=True,
-    )
-    assert SCHEMA_PATH.is_file()  # schema cached
-    assert SCHEMA_PATH.stat().st_size > 0  # schema not empty
-
-    with mock.patch("kili.graphql.graphql_client.print_schema") as mocked_print_schema:
-        _ = GraphQLClient(
-            endpoint=api_endpoint,  # type: ignore
-            api_key=api_key,  # type: ignore
-            client_name=GraphQLClientName.SDK,
-            verify=True,
-        )
-        mocked_print_schema.assert_not_called()
-
-    if SCHEMA_PATH.is_file():
-        SCHEMA_PATH.unlink()
 
 
 def test_outdated_cached_schema(mocker):

--- a/tests/graphql/test_graphql_client.py
+++ b/tests/graphql/test_graphql_client.py
@@ -38,7 +38,7 @@ def test_gql_bad_query_local_validation(query, mocker):
 
     # we need to remove "Authorization" api key from the header
     # if not, the backend will refuse the introspection query
-    mocker.patch.object(GraphQLClient, "headers", return_value={})
+    mocker.patch.object(GraphQLClient, "_get_headers", return_value={})
 
     client = GraphQLClient(
         endpoint=api_endpoint,
@@ -63,7 +63,7 @@ def test_graphql_client_cache(mocker):
 
     # we need to remove "Authorization" api key from the header
     # if not, the backend will refuse the introspection query
-    mocker.patch.object(GraphQLClient, "headers", return_value={})
+    mocker.patch.object(GraphQLClient, "_get_headers", return_value={})
 
     if SCHEMA_PATH.is_file():
         SCHEMA_PATH.unlink()

--- a/tests/graphql/test_graphql_client.py
+++ b/tests/graphql/test_graphql_client.py
@@ -1,3 +1,11 @@
+import os
+from pathlib import Path
+from unittest import mock
+
+import graphql
+import pytest
+
+from kili.exceptions import GraphQLError
 from kili.graphql.graphql_client import GraphQLClient, GraphQLClientName
 
 
@@ -13,3 +21,64 @@ def test_graphql_client_cache_cant_get_kili_version(mocker):
         client_name=GraphQLClientName.SDK,
         verify=True,
     )
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "query MyQuery { my_query_is_clearly_not_valid_according_to_the_kili_schema { id } }",
+        "query { projects { this_field_does_not_exist } }",
+    ],
+)
+def test_gql_bad_query_local_validation(query):
+    """test gql validation against local schema"""
+    api_endpoint = os.getenv(
+        "KILI_API_ENDPOINT", "https://cloud.kili-technology.com/api/label/v2/graphql"
+    )
+    api_key = os.getenv("KILI_API_KEY")
+
+    client = GraphQLClient(
+        endpoint=api_endpoint,  # type: ignore
+        api_key=api_key,  # type: ignore
+        client_name=GraphQLClientName.SDK,
+        verify=True,
+    )
+
+    with pytest.raises(GraphQLError) as exc_info:
+        client.execute(query)
+
+    assert isinstance(exc_info.value.__cause__, graphql.GraphQLError)
+
+
+def test_graphql_client_cache(mocker):
+    SCHEMA_PATH = Path.home() / ".cache" / "kili" / "graphql" / "schema.graphql"
+    mocker.patch.object(GraphQLClient, "_get_graphql_schema_path", return_value=SCHEMA_PATH)
+
+    api_endpoint = os.getenv(
+        "KILI_API_ENDPOINT", "https://cloud.kili-technology.com/api/label/v2/graphql"
+    )
+    api_key = os.getenv("KILI_API_KEY")
+
+    if SCHEMA_PATH.is_file():
+        SCHEMA_PATH.unlink()
+
+    _ = GraphQLClient(
+        endpoint=api_endpoint,  # type: ignore
+        api_key=api_key,  # type: ignore
+        client_name=GraphQLClientName.SDK,
+        verify=True,
+    )
+    assert SCHEMA_PATH.is_file()  # schema cached
+    assert SCHEMA_PATH.stat().st_size > 0  # schema not empty
+
+    with mock.patch("kili.graphql.graphql_client.print_schema") as mocked_print_schema:
+        _ = GraphQLClient(
+            endpoint=api_endpoint,  # type: ignore
+            api_key=api_key,  # type: ignore
+            client_name=GraphQLClientName.SDK,
+            verify=True,
+        )
+        mocked_print_schema.assert_not_called()
+
+    if SCHEMA_PATH.is_file():
+        SCHEMA_PATH.unlink()

--- a/tests/graphql/test_graphql_client.py
+++ b/tests/graphql/test_graphql_client.py
@@ -1,18 +1,12 @@
-from unittest import mock
-
-import requests
-
 from kili.graphql.graphql_client import GraphQLClient, GraphQLClientName
 
 
-@mock.patch.object(
-    GraphQLClient,
-    "_get_kili_app_version",
-    side_effect=requests.exceptions.JSONDecodeError("", "", 0),
-)
-@mock.patch("kili.graphql.graphql_client.Client", return_value=None)
-def test_graphql_client_cache_cant_get_kili_version(mocked_client, mocked_get_kili_app_version):
+def test_graphql_client_cache_cant_get_kili_version(mocker):
     """test when we can't get the kili version from the backend"""
+
+    mocker.patch("kili.graphql.graphql_client.Client", return_value=None)
+    mocker.patch.object(GraphQLClient, "_get_kili_app_version", return_value=None)
+
     _ = GraphQLClient(
         endpoint="https://",
         api_key="nokey",

--- a/tests/graphql/test_graphql_client.py
+++ b/tests/graphql/test_graphql_client.py
@@ -30,16 +30,19 @@ def test_graphql_client_cache_cant_get_kili_version(mocker):
         "query { projects { this_field_does_not_exist } }",
     ],
 )
-def test_gql_bad_query_local_validation(query):
+def test_gql_bad_query_local_validation(query, mocker):
     """test gql validation against local schema"""
     api_endpoint = os.getenv(
         "KILI_API_ENDPOINT", "https://cloud.kili-technology.com/api/label/v2/graphql"
     )
-    api_key = os.getenv("KILI_API_KEY")
+
+    # we need to remove "Authorization" api key from the header
+    # if not, the backend will refuse the introspection query
+    mocker.patch.object(GraphQLClient, "headers", return_value={})
 
     client = GraphQLClient(
-        endpoint=api_endpoint,  # type: ignore
-        api_key=api_key,  # type: ignore
+        endpoint=api_endpoint,
+        api_key="",
         client_name=GraphQLClientName.SDK,
         verify=True,
     )
@@ -57,14 +60,17 @@ def test_graphql_client_cache(mocker):
     api_endpoint = os.getenv(
         "KILI_API_ENDPOINT", "https://cloud.kili-technology.com/api/label/v2/graphql"
     )
-    api_key = os.getenv("KILI_API_KEY")
+
+    # we need to remove "Authorization" api key from the header
+    # if not, the backend will refuse the introspection query
+    mocker.patch.object(GraphQLClient, "headers", return_value={})
 
     if SCHEMA_PATH.is_file():
         SCHEMA_PATH.unlink()
 
     _ = GraphQLClient(
-        endpoint=api_endpoint,  # type: ignore
-        api_key=api_key,  # type: ignore
+        endpoint=api_endpoint,
+        api_key="",
         client_name=GraphQLClientName.SDK,
         verify=True,
     )
@@ -73,8 +79,8 @@ def test_graphql_client_cache(mocker):
 
     with mock.patch("kili.graphql.graphql_client.print_schema") as mocked_print_schema:
         _ = GraphQLClient(
-            endpoint=api_endpoint,  # type: ignore
-            api_key=api_key,  # type: ignore
+            endpoint=api_endpoint,
+            api_key="",
             client_name=GraphQLClientName.SDK,
             verify=True,
         )


### PR DESCRIPTION
if the local schema validation fails, we fetch a fresh schema from backend, and retry the query

e2e: https://github.com/kili-technology/kili-python-sdk/actions/runs/4425003433