### PR TITLE
fix: restrict typeguard version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ install_requires = [
     "tabulate",
     "tenacity",
     "tqdm",
-    "typeguard",
+    "typeguard<3.0.0",
     "typing_extensions>=4.1.0",
     "pyparsing",
     "websocket-client",


### PR DESCRIPTION
should fix e2e: https://github.com/kili-technology/kili-python-sdk/actions/runs/4424619034