### PR TITLE
ci: use all cpu cores for pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Unit tests
-        run: pytest -ra -sv --color yes --code-highlight yes --durations=15 -vv --ignore tests/test_notebooks.py --ignore tests/e2e/ --cov=src/kili --cov-report=term-missing --cov-config=.coveragerc --cov-fail-under=77
+        run: pytest -n auto -ra -sv --color yes --code-highlight yes --durations=15 -vv --ignore tests/test_notebooks.py --ignore tests/e2e/ --cov=src/kili --cov-report=term-missing --cov-config=.coveragerc --cov-fail-under=77
 
   markdown-link-check:
     timeout-minutes: 2

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -234,7 +234,7 @@ jobs:
       - name: E2E tests
         if: github.event.inputs.runE2ETests != 'false'
         timeout-minutes: 10
-        run: pytest -ra -sv --color yes --code-highlight yes --durations=15 -vv tests/e2e -k ".py"
+        run: pytest -n auto -ra -sv --color yes --code-highlight yes --durations=15 -vv tests/e2e -k ".py"
         env:
           KILI_API_CLOUD_VISION: ${{ secrets.KILI_API_CLOUD_VISION }}
           KILI_API_ENDPOINT: ${{ env.KILI_API_ENDPOINT }}
@@ -246,7 +246,7 @@ jobs:
       - name: Notebook tests
         if: github.event.inputs.runNotebookTests != 'false' && (github.event_name != 'push' || github.ref_name != 'master') # Do not run notebook tests after merging to master
         timeout-minutes: 18
-        run: pytest -ra -sv --color yes --code-highlight yes --durations=15 -vv tests/test_notebooks.py
+        run: pytest -n auto -ra -sv --color yes --code-highlight yes --durations=15 -vv tests/test_notebooks.py
         env:
           KILI_API_CLOUD_VISION: ${{ secrets.KILI_API_CLOUD_VISION }}
           KILI_API_ENDPOINT: ${{ env.KILI_API_ENDPOINT }}

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ dev_extra = [
     "pytest",
     "pytest-mock",
     "pytest-cov",
+    "pytest-xdist[psutil]",
     # documentation
     "mkdocs",
     "mkdocs-material",


### PR DESCRIPTION
use all cpu cores for running tests

2 cores cpus on github infra usually

unit tests:
- windows: 6m54s -> 2m11s
- ubuntu: 5m44s -> 3m40s

e2e (e2e tests + notebooks):
- windows: 22m -> 10m30s
- ubuntu: 24m -> 12m


