### PR TITLE
ci: fix bug when fetching last release branch

### DIFF
--- a/.github/scripts/add_latest_release_branch_to_github_env.py
+++ b/.github/scripts/add_latest_release_branch_to_github_env.py
@@ -1,0 +1,42 @@
+"""This script adds the latest release branch to the github env file."""
+import json
+import os
+import urllib.request
+
+from packaging.version import InvalidVersion, parse
+
+
+def parse_version(version: str):
+    try:
+        return parse(version)
+    except InvalidVersion:
+        return parse("0.0.0")
+
+
+BRANCH_PREFIX = "release/"
+per_page = 100
+page = 1
+
+branch_versions = []
+while True:
+    url = f"https://api.github.com/repos/kili-technology/kili-python-sdk/branches?page={page}&per_page={per_page}&protected=true"
+    response = urllib.request.urlopen(url).read()
+    response = json.loads(response)
+    batch_branch_versions = [
+        branch["name"].replace(BRANCH_PREFIX, "")
+        for branch in response
+        if branch["name"].startswith(BRANCH_PREFIX)
+    ]
+    branch_versions.extend(batch_branch_versions)
+    if len(response) < per_page:
+        break
+    page += 1
+
+release_versions = sorted(branch_versions, key=parse_version)
+print(f"Release branches sorted: {release_versions}")
+
+last_version = release_versions[-1]
+print(f"Latest release branch is {BRANCH_PREFIX}{last_version}")
+
+with open(os.environ["GITHUB_ENV"], "a") as f:
+    f.write(f"LASTEST_RELEASE_BRANCH={BRANCH_PREFIX}{last_version}")

--- a/.github/scripts/utils.sh
+++ b/.github/scripts/utils.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-get_sdk_version() {
+get_sdk_version_from_setup_cfg() {
     sdk_version=$(cat setup.cfg | grep current_version | cut -d ' ' -f 3)
     echo "$sdk_version"
 }
@@ -11,7 +11,7 @@ bump_version() {
     new_version=$(bump2version \
         --list \
         --"$1" \
-        --current-version "$(get_sdk_version)" \
+        --current-version "$(get_sdk_version_from_setup_cfg)" \
         "$2" \
         src/kili/__init__.py \
         | grep new_version | sed -r s,"^.*=",,)

--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -47,7 +47,7 @@ jobs:
           source ./.github/scripts/utils.sh   # to load the utils functions
 
           # Get release version
-          release_version=$(get_sdk_version)
+          release_version=$(get_sdk_version_from_setup_cfg)
           echo "Release version: $release_version"
 
           # make sure release_version is greater than last github release

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -138,45 +138,11 @@ jobs:
         run: echo "LTS_CYCLE_FIRST_SDK_REF=release/2.129.0" >> $GITHUB_ENV # this should be updated when a new LTS cycle starts
 
       - name: Get latest release branch
-        shell: python
+        shell: shell
         run: |
-          import json
-          import os
-          import urllib.request
-          from packaging.version import InvalidVersion, parse
-
-          def parse_version(version: str):
-              try:
-                  return parse(version)
-              except InvalidVersion:
-                  return parse("0.0.0")
-
-          BRANCH_PREFIX = "release/"
-          per_page = 100
-          page = 1
-          branch_versions = []
-          while True:
-              url = f"https://api.github.com/repos/kili-technology/kili-python-sdk/branches?page={page}&per_page={per_page}&protected=true"
-              response = urllib.request.urlopen(url).read()
-              response = json.loads(response)
-              batch_branch_versions = [
-                  branch["name"].replace(BRANCH_PREFIX, "")
-                  for branch in response
-                  if branch["name"].startswith(BRANCH_PREFIX)
-              ]
-              branch_versions.extend(batch_branch_versions)
-              if len(response) < per_page:
-                  break
-              page += 1
-
-          release_versions = sorted(branch_versions, key=parse_version)
-          print(f"Release branches sorted: {release_versions}")
-
-          last_version = release_versions[-1]
-          print(f"Latest release branch is {BRANCH_PREFIX}{last_version}")
-
-          with open(os.environ["GITHUB_ENV"], "a") as f:
-              f.write(f"LASTEST_RELEASE_BRANCH={BRANCH_PREFIX}{last_version}")
+          # wget https://raw.githubusercontent.com/kili-technology/kili-python-sdk/master/.github/scripts/add_latest_release_branch_to_github_env.py
+          wget https://raw.githubusercontent.com/kili-technology/kili-python-sdk/ci/fix-ci-bug/.github/scripts/add_latest_release_branch_to_github_env.py
+          python add_latest_release_branch_to_github_env.py
 
       - name: Set checkout branch/tag and endpoint
         shell: bash

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -138,9 +138,8 @@ jobs:
         run: echo "LTS_CYCLE_FIRST_SDK_REF=release/2.129.0" >> $GITHUB_ENV # this should be updated when a new LTS cycle starts
 
       - name: Get latest release branch
-        shell: shell
+        shell: bash
         run: |
-          # wget https://raw.githubusercontent.com/kili-technology/kili-python-sdk/master/.github/scripts/add_latest_release_branch_to_github_env.py
           curl https://raw.githubusercontent.com/kili-technology/kili-python-sdk/ci/fix-ci-bug/.github/scripts/add_latest_release_branch_to_github_env.py --output add_latest_release_branch_to_github_env.py
           python add_latest_release_branch_to_github_env.py
 

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -140,8 +140,9 @@ jobs:
       - name: Get latest release branch
         shell: python
         run: |
-          import requests
+          import urllib.request
           import os
+          import json
           from packaging.version import parse, InvalidVersion
 
           def parse_version(version: str):
@@ -156,14 +157,19 @@ jobs:
           branch_versions = []
           while True:
               url = f"https://api.github.com/repos/kili-technology/kili-python-sdk/branches?page={page}&per_page={per_page}&protected=true"
-              response = requests.get(url).json()
+              response = urllib.request.urlopen(url).read()
+              response = json.loads(response)
               batch_branch_versions = [branch["name"].replace(BRANCH_PREFIX, "") for branch in response if branch["name"].startswith(BRANCH_PREFIX)]
               branch_versions.extend(batch_branch_versions)
               if len(response) < per_page:
                   break
               page += 1
 
-          last_version = sorted(branch_versions, key=parse_version)[-1]
+          release_versions = sorted(branch_versions, key=parse_version)
+          print(f"Release branches sorted: {release_versions}")
+
+          last_version = release_versions[-1]
+          print(f"Latest release branch is {BRANCH_PREFIX}{last_version}")
 
           with open(os.environ["GITHUB_ENV"], "a") as f:
               f.write(f"LASTEST_RELEASE_BRANCH={BRANCH_PREFIX}{last_version}")

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -141,7 +141,7 @@ jobs:
         shell: shell
         run: |
           # wget https://raw.githubusercontent.com/kili-technology/kili-python-sdk/master/.github/scripts/add_latest_release_branch_to_github_env.py
-          wget https://raw.githubusercontent.com/kili-technology/kili-python-sdk/ci/fix-ci-bug/.github/scripts/add_latest_release_branch_to_github_env.py
+          curl https://raw.githubusercontent.com/kili-technology/kili-python-sdk/ci/fix-ci-bug/.github/scripts/add_latest_release_branch_to_github_env.py --output add_latest_release_branch_to_github_env.py
           python add_latest_release_branch_to_github_env.py
 
       - name: Set checkout branch/tag and endpoint

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -137,12 +137,6 @@ jobs:
         shell: bash
         run: echo "LTS_CYCLE_FIRST_SDK_REF=release/2.129.0" >> $GITHUB_ENV # this should be updated when a new LTS cycle starts
 
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.7
-          cache: "pip"
-
       - name: Get latest release branch
         shell: python
         run: |
@@ -236,6 +230,12 @@ jobs:
         if: env.TEST_MODE == 'PREV_RELEASE_TESTS_STAGING'
         shell: bash
         run: rm -rf src # we want the previous release tests but the kili from master
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+          cache: "pip"
 
       - name: Upgrade pip
         run: python -m pip install --upgrade pip

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -137,14 +137,42 @@ jobs:
         shell: bash
         run: echo "LTS_CYCLE_FIRST_SDK_REF=release/2.129.0" >> $GITHUB_ENV # this should be updated when a new LTS cycle starts
 
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+          cache: "pip"
+
       - name: Get latest release branch
-        shell: bash
+        shell: python
         run: |
-          last_version=$(curl --silent "https://api.github.com/repos/kili-technology/kili-python-sdk/releases/latest" | jq -r .tag_name)
-          echo "Last version: $last_version"
-          IFS=. read -r major minor patch <<< "$last_version"
-          last_minor_version="$major.$minor.0"
-          echo "LASTEST_RELEASE_BRANCH=release/$last_minor_version" >> $GITHUB_ENV
+          import requests
+          import os
+          from packaging.version import parse, InvalidVersion
+
+          def parse_version(version: str):
+              try:
+                  return parse(version)
+              except InvalidVersion:
+                  return parse("0.0.0")
+
+          BRANCH_PREFIX = "release/"
+          per_page = 100
+          page = 1
+          branch_versions = []
+          while True:
+              url = f"https://api.github.com/repos/kili-technology/kili-python-sdk/branches?page={page}&per_page={per_page}&protected=true"
+              response = requests.get(url).json()
+              batch_branch_versions = [branch["name"].replace(BRANCH_PREFIX, "") for branch in response if branch["name"].startswith(BRANCH_PREFIX)]
+              branch_versions.extend(batch_branch_versions)
+              if len(response) < per_page:
+                  break
+              page += 1
+
+          last_version = sorted(branch_versions, key=parse_version)[-1]
+
+          with open(os.environ["GITHUB_ENV"], "a") as f:
+              f.write(f"LASTEST_RELEASE_BRANCH={BRANCH_PREFIX}{last_version}")
 
       - name: Set checkout branch/tag and endpoint
         shell: bash
@@ -208,12 +236,6 @@ jobs:
         if: env.TEST_MODE == 'PREV_RELEASE_TESTS_STAGING'
         shell: bash
         run: rm -rf src # we want the previous release tests but the kili from master
-
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.7
-          cache: "pip"
 
       - name: Upgrade pip
         run: python -m pip install --upgrade pip

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -140,10 +140,10 @@ jobs:
       - name: Get latest release branch
         shell: python
         run: |
-          import urllib.request
-          import os
           import json
-          from packaging.version import parse, InvalidVersion
+          import os
+          import urllib.request
+          from packaging.version import InvalidVersion, parse
 
           def parse_version(version: str):
               try:
@@ -159,7 +159,11 @@ jobs:
               url = f"https://api.github.com/repos/kili-technology/kili-python-sdk/branches?page={page}&per_page={per_page}&protected=true"
               response = urllib.request.urlopen(url).read()
               response = json.loads(response)
-              batch_branch_versions = [branch["name"].replace(BRANCH_PREFIX, "") for branch in response if branch["name"].startswith(BRANCH_PREFIX)]
+              batch_branch_versions = [
+                  branch["name"].replace(BRANCH_PREFIX, "")
+                  for branch in response
+                  if branch["name"].startswith(BRANCH_PREFIX)
+              ]
               branch_versions.extend(batch_branch_versions)
               if len(response) < per_page:
                   break

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -137,10 +137,10 @@ jobs:
         shell: bash
         run: echo "LTS_CYCLE_FIRST_SDK_REF=release/2.129.0" >> $GITHUB_ENV # this should be updated when a new LTS cycle starts
 
-      - name: Get latest release branch
+      - name: Add latest release branch to github env
         shell: bash
         run: |
-          curl https://raw.githubusercontent.com/kili-technology/kili-python-sdk/ci/fix-ci-bug/.github/scripts/add_latest_release_branch_to_github_env.py --output add_latest_release_branch_to_github_env.py
+          curl https://raw.githubusercontent.com/kili-technology/kili-python-sdk/master/.github/scripts/add_latest_release_branch_to_github_env.py --output add_latest_release_branch_to_github_env.py
           python add_latest_release_branch_to_github_env.py
 
       - name: Set checkout branch/tag and endpoint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,8 +77,8 @@ jobs:
           # ${{ github.ref_name }}: The short ref name of the branch or tag that triggered the workflow run.
           git checkout ${{ github.ref_name }}
 
-          source ./.github/scripts/utils.sh  # to load the function get_sdk_version
-          sdk_version=$(get_sdk_version)
+          source ./.github/scripts/utils.sh  # to load the function get_sdk_version_from_setup_cfg
+          sdk_version=$(get_sdk_version_from_setup_cfg)
 
           # create a branch to merge the release branch and master
           git checkout -b merge_release/$sdk_version


### PR DESCRIPTION
after creating the branch release/2.130.0, the e2e CI detected the latest branch as being release/2.129.0:

![image](https://user-images.githubusercontent.com/15847892/228534515-59b9cc17-32e9-427d-87e3-f6d8b039e189.png)

the e2e tests "release branch against preprod" were launched on release/2.129.0, when it should've been launched on release/2.130.0

with this fix:
![image](https://user-images.githubusercontent.com/15847892/228537509-b794e1da-9376-407b-a25b-74bd41e23538.png)
