### PR TITLE
fix: fix graphql schema caching bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ install_requires = [
     "urllib3>=1.26",
     "ffmpeg-python",
     "gql[requests,websockets]",
+    "filelock",
 ]
 
 image_requires = [

--- a/src/kili/core/graphql/graphql_client.py
+++ b/src/kili/core/graphql/graphql_client.py
@@ -33,11 +33,7 @@ class GraphQLClient:
     """GraphQL client."""
 
     def __init__(
-        self,
-        endpoint: str,
-        api_key: str,
-        client_name: GraphQLClientName,
-        verify: bool = True,
+        self, endpoint: str, api_key: str, client_name: GraphQLClientName, verify: bool = True
     ) -> None:
         self.endpoint = endpoint
         self.api_key = api_key

--- a/src/kili/core/graphql/graphql_client.py
+++ b/src/kili/core/graphql/graphql_client.py
@@ -28,6 +28,7 @@ from kili.exceptions import GraphQLError
 from kili.utils.logcontext import LogContext
 
 
+# pylint: disable=too-many-instance-attributes
 class GraphQLClient:
     """GraphQL client."""
 

--- a/src/kili/core/graphql/graphql_client.py
+++ b/src/kili/core/graphql/graphql_client.py
@@ -97,6 +97,8 @@ class GraphQLClient:
 
         with graphql_schema_path.open("w", encoding="utf-8") as file:
             file.write(schema_str)
+            file.write("\n")
+            file.flush()
 
     @property
     def graphql_schema_cache_dir(self) -> Path:

--- a/src/kili/core/graphql/graphql_client.py
+++ b/src/kili/core/graphql/graphql_client.py
@@ -100,8 +100,6 @@ class GraphQLClient:
 
     def _cache_graphql_schema(self, graphql_schema_path: Path) -> str:
         """Cache the graphql schema on disk."""
-        self.graphql_schema_cache_dir.mkdir(parents=True, exist_ok=True)
-
         with Client(transport=self._gql_transport, fetch_schema_from_transport=True) as session:
             schema_str = print_schema(session.client.schema)  # type: ignore
 
@@ -117,12 +115,12 @@ class GraphQLClient:
     @property
     def graphql_schema_cache_dir(self) -> Path:
         """Get the path of the GraphQL schema cache directory."""
-        return Path.home() / ".cache" / "kili" / "graphql"
+        path = Path.home() / ".cache" / "kili" / "graphql"
+        path.mkdir(parents=True, exist_ok=True)
+        return path
 
     def _purge_graphql_schema_cache_dir(self) -> None:
         """Purge the schema cache directory."""
-        self.graphql_schema_cache_dir.mkdir(parents=True, exist_ok=True)
-
         with self._cache_dir_lock:
             for file in self.graphql_schema_cache_dir.glob("*.graphql"):
                 file.unlink()

--- a/src/kili/core/graphql/graphql_client.py
+++ b/src/kili/core/graphql/graphql_client.py
@@ -91,7 +91,7 @@ class GraphQLClient:
 
     def _cache_graphql_schema(self, graphql_schema_path: Path) -> None:
         """Cache the graphql schema on disk."""
-        graphql_schema_path.parent.mkdir(parents=True, exist_ok=True)
+        self.graphql_schema_cache_dir.mkdir(parents=True, exist_ok=True)
 
         with Client(transport=self._gql_transport, fetch_schema_from_transport=True) as session:
             schema_str = print_schema(session.client.schema)  # type: ignore
@@ -110,6 +110,8 @@ class GraphQLClient:
 
     def _purge_graphql_schema_cache_dir(self) -> None:
         """Purge the schema cache directory."""
+        self.graphql_schema_cache_dir.mkdir(parents=True, exist_ok=True)
+
         # Use mutex to avoid multiple processes operating in the cache directory at the same time
         with FileLock(self.graphql_schema_cache_dir / "cache_dir.lock", timeout=3):
             for file in self.graphql_schema_cache_dir.glob("*.graphql"):

--- a/tests/e2e/test_graphql_client.py
+++ b/tests/e2e/test_graphql_client.py
@@ -1,5 +1,4 @@
 """Test module for the GraphQL client."""
-import os
 from pathlib import Path
 from unittest import mock
 
@@ -7,21 +6,13 @@ import pytest
 from gql.transport import exceptions
 from graphql import build_ast_schema, parse
 
-from kili.core.graphql.graphql_client import GraphQLClient, GraphQLClientName
+from kili.client import Kili
 from kili.exceptions import GraphQLError
 
 
 def test_gql_bad_query_remote_validation():
     """Test validation by the server no local schema."""
-    api_endpoint = os.getenv("KILI_API_ENDPOINT")
-    api_key = os.getenv("KILI_API_KEY")
-
-    client = GraphQLClient(
-        endpoint=api_endpoint,  # type: ignore
-        api_key=api_key,  # type: ignore
-        client_name=GraphQLClientName.SDK,
-        verify=True,
-    )
+    client = Kili().auth.client
 
     query = """
     query MyQuery {
@@ -51,10 +42,10 @@ def test_outdated_cached_schema(mocker):
     the client should refecth an up-to-date schema and retry the query automatically
     """
     SCHEMA_PATH = Path.home() / ".cache" / "kili" / "graphql" / "schema.graphql"
-    mocker.patch.object(GraphQLClient, "_get_graphql_schema_path", return_value=SCHEMA_PATH)
-
-    api_endpoint = os.getenv("KILI_API_ENDPOINT")
-    api_key = os.getenv("KILI_API_KEY")
+    mocker.patch(
+        "kili.core.graphql.graphql_client.GraphQLClient._get_graphql_schema_path",
+        return_value=SCHEMA_PATH,
+    )
 
     # write a fake schema
     if SCHEMA_PATH.is_file():
@@ -71,12 +62,7 @@ def test_outdated_cached_schema(mocker):
     SCHEMA_PATH.parent.mkdir(parents=True, exist_ok=True)
     SCHEMA_PATH.write_text(fake_schema)
 
-    client = GraphQLClient(
-        endpoint=api_endpoint,  # type: ignore
-        api_key=api_key,  # type: ignore
-        client_name=GraphQLClientName.SDK,
-        verify=True,
-    )
+    client = Kili().auth.client
 
     client._gql_client.schema = build_ast_schema(parse(fake_schema))
 
@@ -88,8 +74,8 @@ def test_outdated_cached_schema(mocker):
 
     assert "email" in client._gql_client.schema.type_map["User"].fields  # type: ignore
 
-    assert result["me"]["id"]  # pylint: disable=unsubscriptable-object
-    assert result["me"]["email"]  # pylint: disable=unsubscriptable-object
+    assert result["me"]["id"]
+    assert result["me"]["email"]
 
     if SCHEMA_PATH.is_file():
         SCHEMA_PATH.unlink()


### PR DESCRIPTION
We had this bug several times during the past few days:

```text
E       graphql.error.syntax_error.GraphQLSyntaxError: Syntax Error: Unexpected <EOF>.
E       
E       GraphQL request:1:1
E       1 |
E         | ^
```

this bug would only happen on `test_copy_project_e2e_with_ocr_metadata`

It's hard to reproduce and happens randomly.

Could be caused by writing the schema on disk and reading it just after when the writing is not finished.

Or cause by the fact that we now run tests in parallel. So we can have two kili clients caching the schema at the same time.
