### PR TITLE
ci: add retries for script fetching release branches from github

### DIFF
--- a/.github/scripts/add_latest_release_branch_to_github_env.py
+++ b/.github/scripts/add_latest_release_branch_to_github_env.py
@@ -15,16 +15,26 @@ def parse_version(version: str) -> Version:
         return parse("0.0.0")
 
 
+github_token = os.environ["GITHUB_TOKEN"]
+headers = {
+    "Authorization": f"Bearer {github_token}",
+    "Accept": "application/vnd.github+json",
+}
+
 BRANCH_PREFIX = "release/"
 per_page = 100
 page = 1
 retries = 0
 branch_versions = []
 while True:
-    url = f"https://api.github.com/repos/kili-technology/kili-python-sdk/branches?page={page}&per_page={per_page}&protected=true"
+    url = (
+        "https://api.github.com/repos/kili-technology/kili-python-sdk"
+        + f"/branches?page={page}&per_page={per_page}&protected=true"
+    )
 
     try:
-        with urllib.request.urlopen(url) as response:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req) as response:
             data = response.read()
     except urllib.error.HTTPError as err:
         print(f"Error while fetching branches: {err}")

--- a/.github/scripts/add_latest_release_branch_to_github_env.py
+++ b/.github/scripts/add_latest_release_branch_to_github_env.py
@@ -1,12 +1,14 @@
 """This script adds the latest release branch to the github env file."""
 import json
 import os
+import urllib.error
 import urllib.request
+from time import sleep
 
-from packaging.version import InvalidVersion, parse
+from packaging.version import InvalidVersion, Version, parse
 
 
-def parse_version(version: str):
+def parse_version(version: str) -> Version:
     try:
         return parse(version)
     except InvalidVersion:
@@ -16,20 +18,34 @@ def parse_version(version: str):
 BRANCH_PREFIX = "release/"
 per_page = 100
 page = 1
-
+retries = 0
 branch_versions = []
 while True:
     url = f"https://api.github.com/repos/kili-technology/kili-python-sdk/branches?page={page}&per_page={per_page}&protected=true"
-    response = urllib.request.urlopen(url).read()
-    response = json.loads(response)
+
+    try:
+        with urllib.request.urlopen(url) as response:
+            data = response.read()
+    except urllib.error.HTTPError as err:
+        print(f"Error while fetching branches: {err}")
+        if err.code != 403:
+            raise err
+        sleep(2**retries)
+        retries += 1
+        continue
+
+    response = json.loads(data)
+
     batch_branch_versions = [
         branch["name"].replace(BRANCH_PREFIX, "")
         for branch in response
         if branch["name"].startswith(BRANCH_PREFIX)
     ]
     branch_versions.extend(batch_branch_versions)
+
     if len(response) < per_page:
         break
+
     page += 1
 
 release_versions = sorted(branch_versions, key=parse_version)

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -143,6 +143,8 @@ jobs:
         run: |
           curl https://raw.githubusercontent.com/kili-technology/kili-python-sdk/master/.github/scripts/add_latest_release_branch_to_github_env.py --output add_latest_release_branch_to_github_env.py
           python add_latest_release_branch_to_github_env.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set checkout branch/tag and endpoint
         shell: bash

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -139,6 +139,7 @@ jobs:
 
       - name: Add latest release branch to github env
         shell: bash
+        timeout-minutes: 3
         run: |
           curl https://raw.githubusercontent.com/kili-technology/kili-python-sdk/master/.github/scripts/add_latest_release_branch_to_github_env.py --output add_latest_release_branch_to_github_env.py
           python add_latest_release_branch_to_github_env.py


### PR DESCRIPTION
should solve:

```shell
Run curl https://raw.githubusercontent.com/***/kili-python-sdk/master/.github/scripts/add_latest_release_branch_to_github_env.py --output add_latest_release_branch_to_github_env.py
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  1220  100  1220    0     0   8141      0 --:--:-- --:--:-- --:--:--  8243
Traceback (most recent call last):
  File "D:\a\kili-python-sdk\kili-python-sdk\add_latest_release_branch_to_github_env.py", line 23, in <module>
    response = urllib.request.urlopen(url).read()
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\urllib\request.py", line 214, in urlopen
    return opener.open(url, data, timeout)
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\urllib\request.py", line 523, in open
    response = meth(req, response)
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\urllib\request.py", line 632, in http_response
    response = self.parent.error(
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\urllib\request.py", line 561, in error
    return self._call_chain(*args)
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\urllib\request.py", line 494, in _call_chain
    result = func(*args)
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\urllib\request.py", line 641, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 403: rate limit exceeded
```