### PR TITLE
fix: forbid export to COCO and VOC when project is connected to cloud storage

### DIFF
--- a/src/kili/entrypoints/queries/label/__init__.py
+++ b/src/kili/entrypoints/queries/label/__init__.py
@@ -689,6 +689,8 @@ class QueriesLabel:
 
         !!! warning "Cloud storage"
             Export with asset download (`with_assets=True`) is not allowed for projects connected to a cloud storage.
+            As they require an access to the assets to read their dimension, the COCO and Pascal VOC formats are not
+            allowed in this case.
 
         !!! Example
             ```python

--- a/src/kili/services/export/exceptions.py
+++ b/src/kili/services/export/exceptions.py
@@ -19,3 +19,7 @@ class NotCompatibleInputType(ValueError):
 
 class NotExportableAssetError(ValueError):
     """Exception thrown when the assets can't be exported."""
+
+
+class NotAccessibleAssetError(ValueError):
+    """Exception thrown when the assets can't be accessed."""

--- a/src/kili/services/export/format/base.py
+++ b/src/kili/services/export/format/base.py
@@ -28,7 +28,11 @@ from kili.services.project import get_project
 from kili.services.types import Job, ProjectId
 from kili.utils.tempfile import TemporaryDirectory
 
-from ..exceptions import NotCompatibleOptions, NotExportableAssetError
+from ..exceptions import (
+    NotAccessibleAssetError,
+    NotCompatibleOptions,
+    NotExportableAssetError,
+)
 
 
 class ExportParams(NamedTuple):
@@ -200,11 +204,13 @@ class AbstractExporter(ABC):  # pylint: disable=too-many-instance-attributes
                     resolution_str = (
                         "This export format requires accessing the image height and width."
                     )
+                    exception_type = NotAccessibleAssetError
                 else:
                     resolution_str = (
                         "Please disable the download of assets by setting `with_assets=False`."
                     )
-                raise NotCompatibleOptions(
+                    exception_type = NotCompatibleOptions
+                raise exception_type(
                     "Export with download of assets is not allowed on projects with data"
                     f" connections. {resolution_str}"
                 )

--- a/src/kili/services/export/format/base.py
+++ b/src/kili/services/export/format/base.py
@@ -4,6 +4,7 @@ import csv
 import json
 import logging
 import shutil
+import warnings
 from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path
@@ -85,6 +86,13 @@ class AbstractExporter(ABC):  # pylint: disable=too-many-instance-attributes
         self.project_json_interface = project_info["jsonInterface"]
         self.project_input_type = project_info["inputType"]
         self.project_title = project_info["title"]
+
+        if self.requires_asset_access and not self.with_assets:
+            warnings.warn(
+                "For an export this format, the download of assets cannot be disabled.",
+                stacklevel=2,
+            )
+            self.with_assets = True
 
     @abstractmethod
     def _check_arguments_compatibility(self) -> None:

--- a/src/kili/services/export/format/base.py
+++ b/src/kili/services/export/format/base.py
@@ -49,6 +49,8 @@ class ExportParams(NamedTuple):
 class AbstractExporter(ABC):  # pylint: disable=too-many-instance-attributes
     """Abstract class defining the interface for all exporters."""
 
+    requires_asset_access = False
+
     def __init__(
         self,
         export_params: ExportParams,
@@ -163,10 +165,17 @@ class AbstractExporter(ABC):  # pylint: disable=too-many-instance-attributes
                 options=QueryOptions(disable_tqdm=True, first=1, skip=0),
             )
             if len(list(data_connections_gen)) > 0:
+                if self.requires_asset_access:
+                    resolution_str = (
+                        "This export format requires accessing the image height and width."
+                    )
+                else:
+                    resolution_str = (
+                        "Please disable the download of assets by setting `with_assets=False`."
+                    )
                 raise NotCompatibleOptions(
                     "Export with download of assets is not allowed on projects with data"
-                    " connections. Please disable the download of assets by setting"
-                    " `with_assets=False`."
+                    f" connections. {resolution_str}"
                 )
 
         self.logger.warning("Fetching assets...")

--- a/src/kili/services/export/format/base.py
+++ b/src/kili/services/export/format/base.py
@@ -192,7 +192,10 @@ class AbstractExporter(ABC):  # pylint: disable=too-many-instance-attributes
             self.process_and_save(assets, self.output_file)
 
     def _check_asset_access(self):
-        """Check asset access: if asset download is enabled and there are data connections, we forbid the export"""
+        """Check asset access.
+
+        If asset download is enabled and there are data connections, we forbid the export.
+        """
         if self.with_assets:
             data_connections_gen = DataConnectionsQuery(self.auth.client)(
                 where=DataConnectionsWhere(project_id=self.project_id),

--- a/src/kili/services/export/format/coco/__init__.py
+++ b/src/kili/services/export/format/coco/__init__.py
@@ -2,7 +2,6 @@
 
 import json
 import time
-import warnings
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -33,15 +32,6 @@ class CocoExporter(AbstractExporter):
     """Common code for COCO exporter."""
 
     requires_asset_access = True
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if not self.with_assets:
-            warnings.warn(
-                "For an export to the COCO format, the download of assets cannot be disabled.",
-                stacklevel=2,
-            )
-        self.with_assets = True
 
     def _check_arguments_compatibility(self):
         """Checks if the export label format is compatible with the export options."""

--- a/src/kili/services/export/format/coco/__init__.py
+++ b/src/kili/services/export/format/coco/__init__.py
@@ -32,6 +32,8 @@ DATA_SUBDIR = "data"
 class CocoExporter(AbstractExporter):
     """Common code for COCO exporter."""
 
+    requires_asset_access = True
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if not self.with_assets:

--- a/src/kili/services/export/format/voc/__init__.py
+++ b/src/kili/services/export/format/voc/__init__.py
@@ -1,6 +1,5 @@
 """Common code for the PASCAL VOC exporter."""
 
-import warnings
 import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Dict, List, Sequence

--- a/src/kili/services/export/format/voc/__init__.py
+++ b/src/kili/services/export/format/voc/__init__.py
@@ -23,17 +23,7 @@ from ...media.video import cut_video, get_video_dimensions
 class VocExporter(AbstractExporter):
     """Common code for VOC exporter."""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if not self.with_assets:
-            warnings.warn(
-                (
-                    "For an export to the Pascal VOC format, the download of assets cannot be"
-                    " disabled."
-                ),
-                stacklevel=2,
-            )
-        self.with_assets = True
+    requires_asset_access = True
 
     def _check_arguments_compatibility(self):
         """Check if the export label format is compatible with the export options."""

--- a/src/kili/services/export/format/yolo/__init__.py
+++ b/src/kili/services/export/format/yolo/__init__.py
@@ -201,11 +201,10 @@ class YoloExporter(AbstractExporter):
                 or job.get("isModel")
             ):
                 continue
-            for category in job.get("content", {}).get("categories", {}):
+            for cat_number, category in enumerate(job.get("content", {}).get("categories", {})):
                 merged_categories_id[get_category_full_name(job_id, category)] = JobCategory(
                     category_name=category, id=cat_number, job_id=job_id
                 )
-                cat_number += 1
 
         return merged_categories_id
 

--- a/tests/services/export/test_coco.py
+++ b/tests/services/export/test_coco.py
@@ -8,14 +8,16 @@ import pytest
 import requests
 from PIL import Image
 
+from kili.entrypoints.queries.label import QueriesLabel
 from kili.orm import Asset
-from kili.services.export.exceptions import NoCompatibleJobError
+from kili.services.export.exceptions import NoCompatibleJobError, NotCompatibleOptions
 from kili.services.export.format.coco import (
     CocoExporter,
     _convert_kili_semantic_to_coco,
     _get_coco_categories_with_mapping,
     _get_coco_geometry_from_kili_bpoly,
 )
+from kili.services.export.format.kili import KiliExporter
 from kili.services.types import Job, JobName
 from kili.utils.tempfile import TemporaryDirectory
 
@@ -566,4 +568,43 @@ def test_coco_export_with_multi_jobs():
         assert (
             categories_by_id[coco_annotation["annotations"][1]["category_id"]]
             == "MAIN_JOB/SPAGHETTIS"
+        )
+
+
+def test_when_exporting_to_coco_given_a_project_with_data_connection_then_it_should_crash(mocker):
+    get_project_return_val = {
+        "jsonInterface": {"jobs": {"JOB": {"tools": ["rectangle"], "mlTask": "OBJECT_DETECTION"}}},
+        "inputType": "IMAGE",
+        "title": "",
+    }
+    mocker.patch("kili.services.export.get_project", return_value=get_project_return_val)
+    mocker.patch(
+        "kili.entrypoints.queries.asset.media_downloader.ProjectQuery.__call__",
+        return_value=(i for i in [get_project_return_val]),
+    )
+    mocker.patch(
+        "kili.services.export.format.base.get_project", return_value=get_project_return_val
+    )
+    mocker.patch.object(KiliExporter, "_check_arguments_compatibility", return_value=None)
+    mocker.patch.object(KiliExporter, "_check_project_compatibility", return_value=None)
+    mocker.patch(
+        "kili.services.export.format.base.DataConnectionsQuery.__call__",
+        return_value=(i for i in [{"id": "fake_data_connection_id"}]),
+    )
+
+    kili = QueriesLabel(auth=mocker.MagicMock())
+
+    with pytest.raises(
+        NotCompatibleOptions,
+        match=(
+            "Export with download of assets is not allowed on projects with data"
+            " connections. This export format requires accessing the image height and width."
+        ),
+    ):
+        kili.export_labels(
+            project_id="fake_proj_id",
+            filename="fake_filename",
+            fmt="coco",
+            layout="merged",
+            with_assets=False,
         )

--- a/tests/services/export/test_coco.py
+++ b/tests/services/export/test_coco.py
@@ -10,7 +10,11 @@ from PIL import Image
 
 from kili.entrypoints.queries.label import QueriesLabel
 from kili.orm import Asset
-from kili.services.export.exceptions import NoCompatibleJobError, NotCompatibleOptions
+from kili.services.export.exceptions import (
+    NoCompatibleJobError,
+    NotAccessibleAssetError,
+    NotCompatibleOptions,
+)
 from kili.services.export.format.coco import (
     CocoExporter,
     _convert_kili_semantic_to_coco,
@@ -595,7 +599,7 @@ def test_when_exporting_to_coco_given_a_project_with_data_connection_then_it_sho
     kili = QueriesLabel(auth=mocker.MagicMock())
 
     with pytest.raises(
-        NotCompatibleOptions,
+        NotAccessibleAssetError,
         match=(
             "Export with download of assets is not allowed on projects with data"
             " connections. This export format requires accessing the image height and width."

--- a/tests/services/export/test_coco.py
+++ b/tests/services/export/test_coco.py
@@ -13,7 +13,6 @@ from kili.orm import Asset
 from kili.services.export.exceptions import (
     NoCompatibleJobError,
     NotAccessibleAssetError,
-    NotCompatibleOptions,
 )
 from kili.services.export.format.coco import (
     CocoExporter,
@@ -298,7 +297,7 @@ def test__get_coco_image_annotations_without_annotation():
 )
 @patch.object(CocoExporter, "__init__", lambda x: None)
 def test__check_project_compatibility(jobs, expected_error):
-    exporter = CocoExporter()
+    exporter = CocoExporter()  # type: ignore
     exporter.project_input_type = "IMAGE"
     exporter.project_json_interface = {"jobs": jobs}
     if expected_error:

--- a/tests/services/export/test_export.py
+++ b/tests/services/export/test_export.py
@@ -756,7 +756,7 @@ def test_export_with_asset_filter_kwargs_unknown_arg(mocker):
         )
 
 
-def test_when_exporting_with_assets_given_a_project_with_data_connection_with_asset_cloud_storage_then_it_should_crash(
+def test_when_exporting_with_assets_given_a_project_with_data_connection_then_it_should_crash(
     mocker,
 ):
     get_project_return_val = {

--- a/tests/services/export/test_export.py
+++ b/tests/services/export/test_export.py
@@ -648,6 +648,17 @@ def test_export_service_layout(
             },
             NoCompatibleJobError,
         ),
+        (
+            "When exporting, given an unexisting format, it throws an error",
+            {
+                "export_kwargs": {
+                    "project_id": "semantic_segmentation",
+                    "label_format": "notexisting",
+                    "split_option": "merged",
+                },
+            },
+            ValueError,
+        ),
     ],
 )
 @patch.object(ProjectQuery, "__call__", side_effect=mocked_ProjectQuery)

--- a/tests/services/export/test_export.py
+++ b/tests/services/export/test_export.py
@@ -780,8 +780,6 @@ def test_when_exporting_with_assets_given_a_project_with_data_connection_then_it
     mocker.patch(
         "kili.services.export.format.base.get_project", return_value=get_project_return_val
     )
-    mocker.patch.object(KiliExporter, "_check_arguments_compatibility", return_value=None)
-    mocker.patch.object(KiliExporter, "_check_project_compatibility", return_value=None)
     mocker.patch(
         "kili.services.export.format.base.DataConnectionsQuery.__call__",
         return_value=(i for i in [{"id": "fake_data_connection_id"}]),

--- a/tests/services/export/test_export.py
+++ b/tests/services/export/test_export.py
@@ -756,9 +756,19 @@ def test_export_with_asset_filter_kwargs_unknown_arg(mocker):
         )
 
 
-def test_export_with_asset_cloud_storage_should_crash(mocker):
+def test_when_exporting_with_assets_given_a_project_with_data_connection_with_asset_cloud_storage_then_it_should_crash(
+    mocker,
+):
     get_project_return_val = {
-        "jsonInterface": {"jobs": {"JOB": {"tools": ["rectangle"], "mlTask": "OBJECT_DETECTION"}}},
+        "jsonInterface": {
+            "jobs": {
+                "JOB": {
+                    "tools": ["rectangle"],
+                    "mlTask": "OBJECT_DETECTION",
+                    "content": {"categories": ["CLASS_A", "CLASS_B"]},
+                }
+            }
+        },
         "inputType": "IMAGE",
         "title": "",
     }
@@ -790,7 +800,7 @@ def test_export_with_asset_cloud_storage_should_crash(mocker):
         kili.export_labels(
             project_id="fake_proj_id",
             filename="fake_filename",
-            fmt="pascal_voc",
+            fmt="yolo_v5",
             layout="merged",
             with_assets=True,
         )

--- a/tests/services/export/test_voc.py
+++ b/tests/services/export/test_voc.py
@@ -56,8 +56,6 @@ def test_when_exporting_to_voc_given_a_project_with_data_connection_then_it_shou
     mocker.patch(
         "kili.services.export.format.base.get_project", return_value=get_project_return_val
     )
-    mocker.patch.object(KiliExporter, "_check_arguments_compatibility", return_value=None)
-    mocker.patch.object(KiliExporter, "_check_project_compatibility", return_value=None)
     mocker.patch(
         "kili.services.export.format.base.DataConnectionsQuery.__call__",
         return_value=(i for i in [{"id": "fake_data_connection_id"}]),

--- a/tests/services/export/test_voc.py
+++ b/tests/services/export/test_voc.py
@@ -3,7 +3,10 @@ from pathlib import Path
 import pytest
 
 from kili.entrypoints.queries.label import QueriesLabel
-from kili.services.export.exceptions import NotCompatibleOptions
+from kili.services.export.exceptions import (
+    NotAccessibleAssetError,
+    NotCompatibleOptions,
+)
 from kili.services.export.format.kili import KiliExporter
 from kili.services.export.format.voc import _convert_from_kili_to_voc_format
 from tests.fakes.fake_data import asset_image_1, asset_image_1_without_annotation
@@ -63,7 +66,7 @@ def test_when_exporting_to_voc_given_a_project_with_data_connection_then_it_shou
     kili = QueriesLabel(auth=mocker.MagicMock())
 
     with pytest.raises(
-        NotCompatibleOptions,
+        NotAccessibleAssetError,
         match=(
             "Export with download of assets is not allowed on projects with data"
             " connections. This export format requires accessing the image height and width."

--- a/tests/services/export/test_voc.py
+++ b/tests/services/export/test_voc.py
@@ -1,5 +1,10 @@
 from pathlib import Path
 
+import pytest
+
+from kili.entrypoints.queries.label import QueriesLabel
+from kili.services.export.exceptions import NotCompatibleOptions
+from kili.services.export.format.kili import KiliExporter
 from kili.services.export.format.voc import _convert_from_kili_to_voc_format
 from tests.fakes.fake_data import asset_image_1, asset_image_1_without_annotation
 
@@ -32,3 +37,42 @@ def test__convert_from_kili_to_voc_format_no_annotation():
         "./tests/services/export/expected/car_1_without_annotation.xml"
     ).read_text(encoding="utf-8")
     assert annotations == expected_annotations
+
+
+def test_when_exporting_to_voc_given_a_project_with_data_connection_then_it_should_crash(mocker):
+    get_project_return_val = {
+        "jsonInterface": {"jobs": {"JOB": {"tools": ["rectangle"], "mlTask": "OBJECT_DETECTION"}}},
+        "inputType": "IMAGE",
+        "title": "",
+    }
+    mocker.patch("kili.services.export.get_project", return_value=get_project_return_val)
+    mocker.patch(
+        "kili.entrypoints.queries.asset.media_downloader.ProjectQuery.__call__",
+        return_value=(i for i in [get_project_return_val]),
+    )
+    mocker.patch(
+        "kili.services.export.format.base.get_project", return_value=get_project_return_val
+    )
+    mocker.patch.object(KiliExporter, "_check_arguments_compatibility", return_value=None)
+    mocker.patch.object(KiliExporter, "_check_project_compatibility", return_value=None)
+    mocker.patch(
+        "kili.services.export.format.base.DataConnectionsQuery.__call__",
+        return_value=(i for i in [{"id": "fake_data_connection_id"}]),
+    )
+
+    kili = QueriesLabel(auth=mocker.MagicMock())
+
+    with pytest.raises(
+        NotCompatibleOptions,
+        match=(
+            "Export with download of assets is not allowed on projects with data"
+            " connections. This export format requires accessing the image height and width."
+        ),
+    ):
+        kili.export_labels(
+            project_id="fake_proj_id",
+            filename="fake_filename",
+            fmt="pascal_voc",
+            layout="merged",
+            with_assets=False,
+        )

--- a/tests/services/export/test_voc.py
+++ b/tests/services/export/test_voc.py
@@ -3,11 +3,7 @@ from pathlib import Path
 import pytest
 
 from kili.entrypoints.queries.label import QueriesLabel
-from kili.services.export.exceptions import (
-    NotAccessibleAssetError,
-    NotCompatibleOptions,
-)
-from kili.services.export.format.kili import KiliExporter
+from kili.services.export.exceptions import NotAccessibleAssetError
 from kili.services.export.format.voc import _convert_from_kili_to_voc_format
 from tests.fakes.fake_data import asset_image_1, asset_image_1_without_annotation
 


### PR DESCRIPTION
- fix: COCO and VOC exports not possible when data connection
- refactor: isolate asset access test
- tests: fix missing content
- feat: adding specific exception for asset access
- style: pylint and cleanup
- docs: add warning
