### PR TITLE
chore: remove deprecated arguments in QueriesAsset

### DIFF
--- a/src/kili/entrypoints/queries/asset/__init__.py
+++ b/src/kili/entrypoints/queries/asset/__init__.py
@@ -1,6 +1,5 @@
 """Asset queries."""
 
-import warnings
 from typing import Dict, Generator, Iterable, List, Optional, Union, overload
 
 import pandas as pd
@@ -54,22 +53,12 @@ class QueriesAsset:
             "status",
         ],
         asset_id_in: Optional[List[str]] = None,
-        consensus_mark_gt: Optional[float] = None,
-        consensus_mark_lt: Optional[float] = None,
         disable_tqdm: bool = False,
         external_id_contains: Optional[List[str]] = None,
         first: Optional[int] = None,
         format: Optional[str] = None,
-        honeypot_mark_gt: Optional[float] = None,
-        honeypot_mark_lt: Optional[float] = None,
         label_author_in: Optional[List[str]] = None,
-        label_consensus_mark_gt: Optional[float] = None,
-        label_consensus_mark_lt: Optional[float] = None,
         label_created_at: Optional[str] = None,
-        label_created_at_gt: Optional[str] = None,
-        label_created_at_lt: Optional[str] = None,
-        label_honeypot_mark_gt: Optional[float] = None,
-        label_honeypot_mark_lt: Optional[float] = None,
         label_type_in: Optional[List[str]] = None,
         metadata_where: Optional[dict] = None,
         skipped: Optional[bool] = None,
@@ -123,22 +112,12 @@ class QueriesAsset:
             "status",
         ],
         asset_id_in: Optional[List[str]] = None,
-        consensus_mark_gt: Optional[float] = None,
-        consensus_mark_lt: Optional[float] = None,
         disable_tqdm: bool = False,
         external_id_contains: Optional[List[str]] = None,
         first: Optional[int] = None,
         format: Optional[str] = None,
-        honeypot_mark_gt: Optional[float] = None,
-        honeypot_mark_lt: Optional[float] = None,
         label_author_in: Optional[List[str]] = None,
-        label_consensus_mark_gt: Optional[float] = None,
-        label_consensus_mark_lt: Optional[float] = None,
         label_created_at: Optional[str] = None,
-        label_created_at_gt: Optional[str] = None,
-        label_created_at_lt: Optional[str] = None,
-        label_honeypot_mark_gt: Optional[float] = None,
-        label_honeypot_mark_lt: Optional[float] = None,
         label_type_in: Optional[List[str]] = None,
         metadata_where: Optional[dict] = None,
         skipped: Optional[bool] = None,
@@ -192,22 +171,12 @@ class QueriesAsset:
             "status",
         ],
         asset_id_in: Optional[List[str]] = None,
-        consensus_mark_gt: Optional[float] = None,
-        consensus_mark_lt: Optional[float] = None,
         disable_tqdm: bool = False,
         external_id_contains: Optional[List[str]] = None,
         first: Optional[int] = None,
         format: Optional[str] = None,
-        honeypot_mark_gt: Optional[float] = None,
-        honeypot_mark_lt: Optional[float] = None,
         label_author_in: Optional[List[str]] = None,
-        label_consensus_mark_gt: Optional[float] = None,
-        label_consensus_mark_lt: Optional[float] = None,
         label_created_at: Optional[str] = None,
-        label_created_at_gt: Optional[str] = None,
-        label_created_at_lt: Optional[str] = None,
-        label_honeypot_mark_gt: Optional[float] = None,
-        label_honeypot_mark_lt: Optional[float] = None,
         label_type_in: Optional[List[str]] = None,
         metadata_where: Optional[dict] = None,
         skipped: Optional[bool] = None,
@@ -248,23 +217,13 @@ class QueriesAsset:
             fields: All the fields to request among the possible fields for the assets.
                     See [the documentation](https://docs.kili-technology.com/reference/graphql-api#asset) for all possible fields.
             first: Maximum number of assets to return.
-            consensus_mark_gt: Deprecated. Use `consensus_mark_gte` instead.
-            consensus_mark_lt: Deprecated. Use `consensus_mark_lte` instead.
             external_id_contains: Returned assets have an external id that belongs to that list, if given.
             metadata_where: Filters by the values of the metadata of the asset.
-            honeypot_mark_gt: Deprecated. Use `honeypot_mark_gte` instead.
-            honeypot_mark_lt: Deprecated. Use `honeypot_mark_lte` instead.
             status_in: Returned assets should have a status that belongs to that list, if given.
                 Possible choices: `TODO`, `ONGOING`, `LABELED`, `TO_REVIEW` or `REVIEWED`.
             label_type_in: Returned assets should have a label whose type belongs to that list, if given.
             label_author_in: Returned assets should have a label whose author belongs to that list, if given. An author can be designated by the first name, the last name, or the first name + last name.
-            label_consensus_mark_gt: Deprecated. Use `label_consensus_mark_gte` instead.
-            label_consensus_mark_lt: Deprecated. Use `label_consensus_mark_lte` instead.
             label_created_at: Returned assets should have a label whose creation date is equal to this date.
-            label_created_at_gt: Deprecated. Use `label_created_at_gte` instead.
-            label_created_at_lt: Deprecated. Use `label_created_at_lte` instead.
-            label_honeypot_mark_gt: Deprecated. Use `label_honeypot_mark_gte` instead.
-            label_honeypot_mark_lt: Deprecated. Use `label_honeypot_mark_lte` instead.
             skipped: Returned assets should be skipped
             updated_at_gte: Returned assets should have a label whose update date is greater or equal to this date.
             updated_at_lte: Returned assets should have a label whose update date is lower or equal to this date.
@@ -343,61 +302,25 @@ class QueriesAsset:
         if label_category_search:
             validate_category_search_query(label_category_search)
 
-        for arg_name, arg_value in zip(
-            (
-                "consensus_mark_gt",
-                "consensus_mark_lt",
-                "honeypot_mark_gt",
-                "honeypot_mark_lt",
-                "label_consensus_mark_gt",
-                "label_consensus_mark_lt",
-                "label_created_at_gt",
-                "label_created_at_lt",
-                "label_honeypot_mark_gt",
-                "label_honeypot_mark_lt",
-            ),
-            (
-                consensus_mark_gt,
-                consensus_mark_lt,
-                honeypot_mark_gt,
-                honeypot_mark_lt,
-                label_consensus_mark_gt,
-                label_consensus_mark_lt,
-                label_created_at_gt,
-                label_created_at_lt,
-                label_honeypot_mark_gt,
-                label_honeypot_mark_lt,
-            ),
-        ):
-            if arg_value:
-                warnings.warn(
-                    (
-                        f"'{arg_name}' is deprecated, please use"
-                        f" '{arg_name.replace('_gt', '_gte').replace('_lt', '_lte')}' instead."
-                    ),
-                    DeprecationWarning,
-                    stacklevel=1,
-                )
-
         where = AssetWhere(
             project_id=project_id,
             asset_id=asset_id,
             asset_id_in=asset_id_in,
-            consensus_mark_gte=consensus_mark_gt or consensus_mark_gte,
-            consensus_mark_lte=consensus_mark_lt or consensus_mark_lte,
+            consensus_mark_gte=consensus_mark_gte,
+            consensus_mark_lte=consensus_mark_lte,
             external_id_contains=external_id_contains,
-            honeypot_mark_gte=honeypot_mark_gt or honeypot_mark_gte,
-            honeypot_mark_lte=honeypot_mark_lt or honeypot_mark_lte,
+            honeypot_mark_gte=honeypot_mark_gte,
+            honeypot_mark_lte=honeypot_mark_lte,
             inference_mark_gte=inference_mark_gte,
             inference_mark_lte=inference_mark_lte,
             label_author_in=label_author_in,
-            label_consensus_mark_gte=label_consensus_mark_gt or label_consensus_mark_gte,
-            label_consensus_mark_lte=label_consensus_mark_lt or label_consensus_mark_lte,
+            label_consensus_mark_gte=label_consensus_mark_gte,
+            label_consensus_mark_lte=label_consensus_mark_lte,
             label_created_at=label_created_at,
-            label_created_at_gte=label_created_at_gt or label_created_at_gte,
-            label_created_at_lte=label_created_at_lt or label_created_at_lte,
-            label_honeypot_mark_gte=label_honeypot_mark_gt or label_honeypot_mark_gte,
-            label_honeypot_mark_lte=label_honeypot_mark_lt or label_honeypot_mark_lte,
+            label_created_at_gte=label_created_at_gte,
+            label_created_at_lte=label_created_at_lte,
+            label_honeypot_mark_gte=label_honeypot_mark_gte,
+            label_honeypot_mark_lte=label_honeypot_mark_lte,
             label_type_in=label_type_in,
             metadata_where=metadata_where,
             skipped=skipped,
@@ -433,19 +356,9 @@ class QueriesAsset:
         external_id_contains: Optional[List[str]] = None,
         metadata_where: Optional[dict] = None,
         status_in: Optional[List[str]] = None,
-        consensus_mark_gt: Optional[float] = None,
-        consensus_mark_lt: Optional[float] = None,
-        honeypot_mark_gt: Optional[float] = None,
-        honeypot_mark_lt: Optional[float] = None,
         label_type_in: Optional[List[str]] = None,
         label_author_in: Optional[List[str]] = None,
-        label_consensus_mark_gt: Optional[float] = None,
-        label_consensus_mark_lt: Optional[float] = None,
         label_created_at: Optional[str] = None,
-        label_created_at_gt: Optional[str] = None,
-        label_created_at_lt: Optional[str] = None,
-        label_honeypot_mark_gt: Optional[float] = None,
-        label_honeypot_mark_lt: Optional[float] = None,
         skipped: Optional[bool] = None,
         updated_at_gte: Optional[str] = None,
         updated_at_lte: Optional[str] = None,
@@ -480,19 +393,9 @@ class QueriesAsset:
             external_id_contains: Returned assets should have an external id that belongs to that list, if given.
             metadata_where: Filters by the values of the metadata of the asset.
             status_in: Returned assets should have a status that belongs to that list, if given. Possible choices: `TODO`, `ONGOING`, `LABELED`, `TO_REVIEW` or `REVIEWED`.
-            consensus_mark_gt: Deprecated. Use `consensus_mark_gte` instead.
-            consensus_mark_lt: Deprecated. Use `consensus_mark_lte` instead.
-            honeypot_mark_gt: Deprecated. Use `honeypot_mark_gte` instead.
-            honeypot_mark_lt: Deprecated. Use `honeypot_mark_lte` instead.
             label_type_in: Returned assets should have a label whose type belongs to that list, if given.
             label_author_in: Returned assets should have a label whose author belongs to that list, if given. An author can be designated by the first name, the last name, or the first name + last name.
-            label_consensus_mark_gt: Deprecated. Use `label_consensus_mark_gte` instead.
-            label_consensus_mark_lt: Deprecated. Use `label_consensus_mark_lte` instead.
             label_created_at: Returned assets should have a label whose creation date is equal to this date.
-            label_created_at_gt: Deprecated. Use `label_created_at_gte` instead.
-            label_created_at_lt: Deprecated. Use `label_created_at_lte` instead.
-            label_honeypot_mark_gt: Deprecated. Use `label_honeypot_mark_gte` instead.
-            label_honeypot_mark_lt: Deprecated. Use `label_honeypot_mark_lte` instead.
             skipped: Returned assets should be skipped.
             updated_at_gte: Returned assets should have a label whose update date is greated or equal to this date.
             updated_at_lte: Returned assets should have a label whose update date is lower or equal to this date.
@@ -539,62 +442,26 @@ class QueriesAsset:
         if label_category_search:
             validate_category_search_query(label_category_search)
 
-        for arg_name, arg_value in zip(
-            (
-                "consensus_mark_gt",
-                "consensus_mark_lt",
-                "honeypot_mark_gt",
-                "honeypot_mark_lt",
-                "label_consensus_mark_gt",
-                "label_consensus_mark_lt",
-                "label_created_at_gt",
-                "label_created_at_lt",
-                "label_honeypot_mark_gt",
-                "label_honeypot_mark_lt",
-            ),
-            (
-                consensus_mark_gt,
-                consensus_mark_lt,
-                honeypot_mark_gt,
-                honeypot_mark_lt,
-                label_consensus_mark_gt,
-                label_consensus_mark_lt,
-                label_created_at_gt,
-                label_created_at_lt,
-                label_honeypot_mark_gt,
-                label_honeypot_mark_lt,
-            ),
-        ):
-            if arg_value:
-                warnings.warn(
-                    (
-                        f"'{arg_name}' is deprecated, please use"
-                        f" '{arg_name.replace('_gt', '_gte').replace('_lt', '_lte')}' instead."
-                    ),
-                    DeprecationWarning,
-                    stacklevel=1,
-                )
-
         where = AssetWhere(
             project_id=project_id,
             asset_id=asset_id,
             asset_id_in=asset_id_in,
-            consensus_mark_gte=consensus_mark_gt or consensus_mark_gte,
-            consensus_mark_lte=consensus_mark_lt or consensus_mark_lte,
+            consensus_mark_gte=consensus_mark_gte,
+            consensus_mark_lte=consensus_mark_lte,
             external_id_contains=external_id_contains,
-            honeypot_mark_gte=honeypot_mark_gt or honeypot_mark_gte,
-            honeypot_mark_lte=honeypot_mark_lt or honeypot_mark_lte,
+            honeypot_mark_gte=honeypot_mark_gte,
+            honeypot_mark_lte=honeypot_mark_lte,
             inference_mark_gte=inference_mark_gte,
             inference_mark_lte=inference_mark_lte,
             label_author_in=label_author_in,
             label_reviewer_in=label_reviewer_in,
-            label_consensus_mark_gte=label_consensus_mark_gt or label_consensus_mark_gte,
-            label_consensus_mark_lte=label_consensus_mark_lt or label_consensus_mark_lte,
+            label_consensus_mark_gte=label_consensus_mark_gte,
+            label_consensus_mark_lte=label_consensus_mark_lte,
             label_created_at=label_created_at,
-            label_created_at_gte=label_created_at_gt or label_created_at_gte,
-            label_created_at_lte=label_created_at_lt or label_created_at_lte,
-            label_honeypot_mark_gte=label_honeypot_mark_gt or label_honeypot_mark_gte,
-            label_honeypot_mark_lte=label_honeypot_mark_lt or label_honeypot_mark_lte,
+            label_created_at_gte=label_created_at_gte,
+            label_created_at_lte=label_created_at_lte,
+            label_honeypot_mark_gte=label_honeypot_mark_gte,
+            label_honeypot_mark_lte=label_honeypot_mark_lte,
             label_type_in=label_type_in,
             metadata_where=metadata_where,
             skipped=skipped,


### PR DESCRIPTION
e2e tests don't pass since it's BC

need to discuss this PR

maybe remove for SDK V3