### PR TITLE
fix: inverse .jobs and .frames order for video label parsing

### DIFF
--- a/src/kili/core/enums.py
+++ b/src/kili/core/enums.py
@@ -36,15 +36,12 @@ HubspotSubscriptionStatus = Literal[
 InputType = Literal[
     "AUDIO",
     "IMAGE",
-    "NA",
     "PDF",
     "TEXT",
     "TIME_SERIES",
     "VIDEO",
     "VIDEO_LEGACY",
-    "URL",
 ]
-
 
 InvitationStatus = Literal[
     "ACCEPTED",

--- a/src/kili/services/label_data_parsing/json_response.py
+++ b/src/kili/services/label_data_parsing/json_response.py
@@ -165,7 +165,9 @@ class ParsedVideoJobs(_ParsedJobs):
                         project_info=project_info,
                         job_payload=job_response,
                     )
-                    for _, frame_json_response in json_response.items()
+                    for _, frame_json_response in sorted(
+                        json_response.items(), key=lambda item: int(item[0])  # sort by frame id
+                    )
                     for job_name, job_response in frame_json_response.items()
                     if job_name == current_job_name
                 ]

--- a/src/kili/services/label_data_parsing/json_response.py
+++ b/src/kili/services/label_data_parsing/json_response.py
@@ -5,8 +5,23 @@ from typing import Dict, Iterator, List, Optional, Tuple
 
 from kili.services.label_data_parsing import job_response as job_response_module
 
-from .exceptions import JobNotExistingError
+from .exceptions import FrameIndexError, JobNotExistingError
 from .types import Project
+
+
+class FramesList(List["job_response_module.JobPayload"]):
+    """List class that allows to access the JobPayload object corresponding to a frame number."""
+
+    def __getitem__(self, key: int) -> "job_response_module.JobPayload":
+        """Returns the JobPayload object corresponding to the frame number."""
+        if not 0 <= key <= len(self) - 1:
+            raise FrameIndexError(frame_index=key, nb_frames=len(self))
+        return super().__getitem__(key)
+
+    @property
+    def frames(self) -> "FramesList":
+        """Returns the list of frames."""
+        return self
 
 
 class ParsedJobs:
@@ -71,11 +86,6 @@ class ParsedJobs:
         if job_name not in self._json_data:
             raise JobNotExistingError(job_name)
         return self._json_data[job_name]
-
-    @property
-    def jobs(self) -> "ParsedJobs":
-        """Returns self."""
-        return self
 
     def to_dict(self) -> Dict:
         """Returns the parsed json response as a dict."""

--- a/src/kili/services/label_data_parsing/json_response.py
+++ b/src/kili/services/label_data_parsing/json_response.py
@@ -241,12 +241,12 @@ class JobPayload(FramesList, job_response_module.JobPayload):
     # pylint: disable=line-too-long
     """JobPayload class.
 
-    It can be used to access the job response of a job `job_name`: `label.jobs["job_name"]`.
+    It is the value of the parsed job response of a job `job_name`: `label.jobs["job_name"]`.
 
     If the job is a video job, it can be used to access the job response of a frame `frame_number`: `label.jobs["job_name"].frames[frame_number]`.
     """
 
-    # Class only used for type checking.
+    # Class only used for return type hints.
     # It should not be instantiated.
     # It inherits from both FramesList and JobResponseModule.JobPayload to expose the methods
     # and properties of both classes.

--- a/src/kili/services/label_data_parsing/json_response.py
+++ b/src/kili/services/label_data_parsing/json_response.py
@@ -17,13 +17,11 @@ class _ParsedVideoJobs:
         json_response: Dict,
         job_names_to_parse: Optional[List[str]] = None,
     ) -> None:
-        self.project_info = project_info
-
         self._json_data: Dict[str, "FramesList"] = {}
 
         self._nb_frames = len(json_response)
 
-        json_interface = self.project_info["jsonInterface"]
+        json_interface = project_info["jsonInterface"]
 
         # all job names in the json response should be in the json interface too
         for _, frame_response in json_response.items():
@@ -48,7 +46,7 @@ class _ParsedVideoJobs:
                 job_response = frame_json_response.get(current_job_name, {})
                 job_payload = job_response_module.JobPayload(
                     job_name=current_job_name,
-                    project_info=self.project_info,
+                    project_info=project_info,
                     job_payload=job_response,
                 )
                 frames_list_for_job.append(job_payload)
@@ -78,11 +76,9 @@ class _ParsedOtherJobs:
         json_response: Dict,
         job_names_to_parse: Optional[List[str]] = None,
     ) -> None:
-        self.project_info = project_info
-
         self._json_data: Dict[str, "job_response_module.JobPayload"] = {}
 
-        json_interface = self.project_info["jsonInterface"]
+        json_interface = project_info["jsonInterface"]
 
         # all job names in the json response should be in the json interface too
         for job_name in json_response:
@@ -106,7 +102,7 @@ class _ParsedOtherJobs:
             if (
                 not job_interface["isChild"]  # check if parent
                 and job_interface["required"]  # check if required
-                and "VIDEO" not in self.project_info["inputType"]  # can have empty frames
+                and "VIDEO" not in project_info["inputType"]  # can have empty frames
                 and not job_response
             ):
                 raise JobNotExistingError(job_name)

--- a/src/kili/services/label_data_parsing/json_response.py
+++ b/src/kili/services/label_data_parsing/json_response.py
@@ -69,7 +69,7 @@ class _ParsedVideoJobs:
 
 
 # pylint: disable=too-few-public-methods
-class _ParseClassicJobs:
+class _ParsedJobs:
     def __init__(
         self,
         project_info: Project,
@@ -128,7 +128,7 @@ def _is_video_response(project_info: Project, json_response: Dict) -> bool:
     return True
 
 
-class ParsedJobs(_ParseClassicJobs, _ParsedVideoJobs):
+class ParsedJobs(_ParsedJobs, _ParsedVideoJobs):
     """Class for label json response parsing."""
 
     def __init__(
@@ -158,7 +158,7 @@ class ParsedJobs(_ParseClassicJobs, _ParsedVideoJobs):
                 job_names_to_parse=job_names_to_parse,
             )
         else:
-            _ParseClassicJobs.__init__(
+            _ParsedJobs.__init__(
                 self,
                 project_info=project_info,
                 json_response=json_response,
@@ -169,7 +169,7 @@ class ParsedJobs(_ParseClassicJobs, _ParsedVideoJobs):
         """Returns the parsed json response as a dict."""
         if self._is_video_response:
             return _ParsedVideoJobs.to_dict(self)
-        return _ParseClassicJobs.to_dict(self)
+        return _ParsedJobs.to_dict(self)
 
     def __repr__(self) -> str:
         """Returns the representation of the object."""

--- a/src/kili/services/label_data_parsing/label.py
+++ b/src/kili/services/label_data_parsing/label.py
@@ -1,23 +1,12 @@
 """Module for label parsing."""
 
 from copy import deepcopy
-from typing import Dict, List
+from typing import Dict
 
 from kili.core.enums import InputType
 from kili.services.label_data_parsing import json_response as json_response_module
 
-from .exceptions import FrameIndexError
 from .types import Project
-
-
-class FramesList(List["json_response_module.ParsedJobs"]):
-    """List class that allows to access the ParsedJobs object corresponding to a frame number."""
-
-    def __getitem__(self, key: int) -> "json_response_module.ParsedJobs":
-        """Returns the ParsedJobs object corresponding to the frame number."""
-        if not 0 <= key <= len(self) - 1:
-            raise FrameIndexError(frame_index=key, nb_frames=len(self))
-        return super().__getitem__(key)
 
 
 class ParsedLabel(Dict):
@@ -39,34 +28,21 @@ class ParsedLabel(Dict):
             ```python
             label = kili.labels(...)[0]
             parsed_label = ParsedLabel(label, json_interface, input_type)
-            print(parsed_label.jobs["JOB_0"].category.name)  # "A"
+            print(parsed_label.jobs["JOB_0"].category.name)
             ```
         """
         super().__init__(deepcopy(label))
 
         project_info = Project(inputType=input_type, jsonInterface=json_interface["jobs"])
 
-        if "VIDEO" in input_type:
-            self.frames = FramesList(
-                json_response_module.ParsedJobs(
-                    project_info=project_info, json_response=frame_json_resp
-                )
-                for _, frame_json_resp in sorted(
-                    self["jsonResponse"].items(), key=lambda item: int(item[0])
-                )
-            )
-        else:
-            self.jobs = json_response_module.ParsedJobs(
-                project_info=project_info, json_response=self["jsonResponse"]
-            )
+        self.jobs = json_response_module.ParsedJobs(
+            project_info=project_info, json_response=self["jsonResponse"]
+        )
 
     def to_dict(self) -> Dict:
         """Returns a copy of the parsed label as a dict."""
         ret = {k: deepcopy(v) for k, v in self.items() if k != "jsonResponse"}
-        if hasattr(self, "frames"):
-            ret["jsonResponse"] = {str(k): v.to_dict() for k, v in enumerate(self.frames)}
-        else:
-            ret["jsonResponse"] = self.jobs.to_dict()
+        ret["jsonResponse"] = self.jobs.to_dict()
         return ret
 
     def __repr__(self) -> str:

--- a/src/kili/services/label_data_parsing/label.py
+++ b/src/kili/services/label_data_parsing/label.py
@@ -1,12 +1,11 @@
 """Module for label parsing."""
 
 from copy import deepcopy
-from typing import Dict
+from typing import Dict, Union, overload
 
-from kili.core.enums import InputType
 from kili.services.label_data_parsing import json_response as json_response_module
 
-from .types import Project
+from .types import InputType, Project
 
 
 class ParsedLabel(Dict):
@@ -33,16 +32,62 @@ class ParsedLabel(Dict):
         """
         super().__init__(deepcopy(label))
 
-        project_info = Project(inputType=input_type, jsonInterface=json_interface["jobs"])
+        self.jobs = self._initialize_jobs(json_interface=json_interface, input_type=input_type)
 
+    @overload
+    def _initialize_jobs(
+        self, json_interface: Dict, input_type: InputType = "AUDIO"
+    ) -> "json_response_module.ParsedJobs":
+        ...
+
+    @overload
+    def _initialize_jobs(
+        self, json_interface: Dict, input_type: InputType = "IMAGE"
+    ) -> "json_response_module.ParsedJobs":
+        ...
+
+    @overload
+    def _initialize_jobs(
+        self, json_interface: Dict, input_type: InputType = "PDF"
+    ) -> "json_response_module.ParsedJobs":
+        ...
+
+    @overload
+    def _initialize_jobs(
+        self, json_interface: Dict, input_type: InputType = "TEXT"
+    ) -> "json_response_module.ParsedJobs":
+        ...
+
+    @overload
+    def _initialize_jobs(
+        self, json_interface: Dict, input_type: InputType = "TIME_SERIES"
+    ) -> "json_response_module.ParsedJobs":
+        ...
+
+    @overload
+    def _initialize_jobs(
+        self, json_interface: Dict, input_type: InputType = "VIDEO"
+    ) -> "json_response_module.ParsedVideoJobs":
+        ...
+
+    @overload
+    def _initialize_jobs(
+        self, json_interface: Dict, input_type: InputType = "VIDEO_LEGACY"
+    ) -> "json_response_module.ParsedVideoJobs":
+        ...
+
+    def _initialize_jobs(
+        self, json_interface: Dict, input_type: InputType
+    ) -> Union["json_response_module.ParsedVideoJobs", "json_response_module.ParsedJobs"]:
+        """Initializes the jobs attribute."""
+        project_info = Project(inputType=input_type, jsonInterface=json_interface["jobs"])
         if "VIDEO" in input_type:
-            self.jobs = json_response_module.ParsedVideoJobs(
+            return json_response_module.ParsedVideoJobs(
                 project_info=project_info, json_response=self["jsonResponse"]
             )
-        else:
-            self.jobs = json_response_module.ParsedJobs(
-                project_info=project_info, json_response=self["jsonResponse"]
-            )
+        return json_response_module.ParsedJobs(
+            project_info=project_info, json_response=self["jsonResponse"]
+        )
 
     def to_dict(self) -> Dict:
         """Returns a copy of the parsed label as a dict."""

--- a/src/kili/services/label_data_parsing/label.py
+++ b/src/kili/services/label_data_parsing/label.py
@@ -34,14 +34,9 @@ class ParsedLabel(Dict):
 
         project_info = Project(inputType=input_type, jsonInterface=json_interface["jobs"])
 
-        if "VIDEO" in input_type:
-            self.jobs = json_response_module.ParsedVideoJobs(
-                project_info=project_info, json_response=self["jsonResponse"]
-            )
-        else:
-            self.jobs = json_response_module.ParsedJobs(
-                project_info=project_info, json_response=self["jsonResponse"]
-            )
+        self.jobs = json_response_module.ParsedJobs(
+            project_info=project_info, json_response=self["jsonResponse"]
+        )
 
     def to_dict(self) -> Dict:
         """Returns a copy of the parsed label as a dict."""

--- a/src/kili/services/label_data_parsing/label.py
+++ b/src/kili/services/label_data_parsing/label.py
@@ -35,9 +35,14 @@ class ParsedLabel(Dict):
 
         project_info = Project(inputType=input_type, jsonInterface=json_interface["jobs"])
 
-        self.jobs = json_response_module.ParsedJobs(
-            project_info=project_info, json_response=self["jsonResponse"]
-        )
+        if "VIDEO" in input_type:
+            self.jobs = json_response_module.ParsedVideoJobs(
+                project_info=project_info, json_response=self["jsonResponse"]
+            )
+        else:
+            self.jobs = json_response_module.ParsedJobs(
+                project_info=project_info, json_response=self["jsonResponse"]
+            )
 
     def to_dict(self) -> Dict:
         """Returns a copy of the parsed label as a dict."""

--- a/src/kili/services/label_data_parsing/label.py
+++ b/src/kili/services/label_data_parsing/label.py
@@ -1,7 +1,7 @@
 """Module for label parsing."""
 
 from copy import deepcopy
-from typing import Dict, Union, overload
+from typing import Dict
 
 from kili.services.label_data_parsing import json_response as json_response_module
 
@@ -32,62 +32,16 @@ class ParsedLabel(Dict):
         """
         super().__init__(deepcopy(label))
 
-        self.jobs = self._initialize_jobs(json_interface=json_interface, input_type=input_type)
-
-    @overload
-    def _initialize_jobs(
-        self, json_interface: Dict, input_type: InputType = "AUDIO"
-    ) -> "json_response_module.ParsedJobs":
-        ...
-
-    @overload
-    def _initialize_jobs(
-        self, json_interface: Dict, input_type: InputType = "IMAGE"
-    ) -> "json_response_module.ParsedJobs":
-        ...
-
-    @overload
-    def _initialize_jobs(
-        self, json_interface: Dict, input_type: InputType = "PDF"
-    ) -> "json_response_module.ParsedJobs":
-        ...
-
-    @overload
-    def _initialize_jobs(
-        self, json_interface: Dict, input_type: InputType = "TEXT"
-    ) -> "json_response_module.ParsedJobs":
-        ...
-
-    @overload
-    def _initialize_jobs(
-        self, json_interface: Dict, input_type: InputType = "TIME_SERIES"
-    ) -> "json_response_module.ParsedJobs":
-        ...
-
-    @overload
-    def _initialize_jobs(
-        self, json_interface: Dict, input_type: InputType = "VIDEO"
-    ) -> "json_response_module.ParsedVideoJobs":
-        ...
-
-    @overload
-    def _initialize_jobs(
-        self, json_interface: Dict, input_type: InputType = "VIDEO_LEGACY"
-    ) -> "json_response_module.ParsedVideoJobs":
-        ...
-
-    def _initialize_jobs(
-        self, json_interface: Dict, input_type: InputType
-    ) -> Union["json_response_module.ParsedVideoJobs", "json_response_module.ParsedJobs"]:
-        """Initializes the jobs attribute."""
         project_info = Project(inputType=input_type, jsonInterface=json_interface["jobs"])
+
         if "VIDEO" in input_type:
-            return json_response_module.ParsedVideoJobs(
+            self.jobs = json_response_module.ParsedVideoJobs(
                 project_info=project_info, json_response=self["jsonResponse"]
             )
-        return json_response_module.ParsedJobs(
-            project_info=project_info, json_response=self["jsonResponse"]
-        )
+        else:
+            self.jobs = json_response_module.ParsedJobs(
+                project_info=project_info, json_response=self["jsonResponse"]
+            )
 
     def to_dict(self) -> Dict:
         """Returns a copy of the parsed label as a dict."""

--- a/tests/services/label_data_parsing/mutation/test_resp_mutation.py
+++ b/tests/services/label_data_parsing/mutation/test_resp_mutation.py
@@ -699,6 +699,7 @@ def test_video_project_set_score():
 
     parsed_label = ParsedLabel(label=label, json_interface=json_interface, input_type="VIDEO")
 
+    a = parsed_label.jobs["JOB_0"]
     assert len(parsed_label.jobs["JOB_0"].frames) == 2
 
     frame = parsed_label.jobs["JOB_0"].frames[1]
@@ -706,3 +707,34 @@ def test_video_project_set_score():
     assert frame.annotations[0].score is None
     frame.annotations[0].score = 42
     assert frame.annotations[0].score == 42
+
+    label_as_dict = parsed_label.to_dict()
+    assert label_as_dict == {
+        "jsonResponse": {
+            "0": {},
+            "1": {
+                "JOB_0": {
+                    "annotations": [
+                        {
+                            "children": {},
+                            "boundingPoly": [
+                                {
+                                    "normalizedVertices": [
+                                        {"x": 0.3046607129483673, "y": 0.6337517633095981},
+                                        {"x": 0.3046607129483673, "y": 0.5534349836511678},
+                                        {"x": 0.3670709937679789, "y": 0.5534349836511678},
+                                        {"x": 0.3670709937679789, "y": 0.6337517633095981},
+                                    ]
+                                }
+                            ],
+                            "categories": [{"name": "OBJECT_B"}],
+                            "mid": "20230407140827577-43802",
+                            "type": "rectangle",
+                            "isKeyFrame": True,
+                            "score": 42,
+                        },
+                    ]
+                }
+            },
+        }
+    }

--- a/tests/services/label_data_parsing/mutation/test_resp_mutation.py
+++ b/tests/services/label_data_parsing/mutation/test_resp_mutation.py
@@ -699,10 +699,10 @@ def test_video_project_set_score():
 
     parsed_label = ParsedLabel(label=label, json_interface=json_interface, input_type="VIDEO")
 
-    assert len(parsed_label.frames) == 2
+    assert len(parsed_label.jobs["JOB_0"].frames) == 2
 
-    frame = parsed_label.frames[1]
+    frame = parsed_label.jobs["JOB_0"].frames[1]
 
-    assert frame.jobs["JOB_0"].annotations[0].score is None
-    frame.jobs["JOB_0"].annotations[0].score = 42
-    assert frame.jobs["JOB_0"].annotations[0].score == 42
+    assert frame.annotations[0].score is None
+    frame.annotations[0].score = 42
+    assert frame.annotations[0].score == 42

--- a/tests/services/label_data_parsing/mutation/test_resp_mutation.py
+++ b/tests/services/label_data_parsing/mutation/test_resp_mutation.py
@@ -1,6 +1,12 @@
 from copy import deepcopy
 
-from kili.services.label_data_parsing.json_response import ParsedJobs
+from typing_extensions import assert_type
+
+from kili.services.label_data_parsing.json_response import (
+    FramesList,
+    JobPayload,
+    ParsedJobs,
+)
 from kili.services.label_data_parsing.label import ParsedLabel
 from kili.services.label_data_parsing.types import Project
 
@@ -698,6 +704,10 @@ def test_video_project_set_score():
     label = {"jsonResponse": json_resp}
 
     parsed_label = ParsedLabel(label=label, json_interface=json_interface, input_type="VIDEO")
+
+    job_payload = parsed_label.jobs["JOB_0"]
+    assert_type(job_payload, JobPayload)
+    assert_type(job_payload.frames, FramesList)
 
     assert len(parsed_label.jobs["JOB_0"].frames) == 2
 

--- a/tests/services/label_data_parsing/mutation/test_resp_mutation.py
+++ b/tests/services/label_data_parsing/mutation/test_resp_mutation.py
@@ -699,7 +699,6 @@ def test_video_project_set_score():
 
     parsed_label = ParsedLabel(label=label, json_interface=json_interface, input_type="VIDEO")
 
-    a = parsed_label.jobs["JOB_0"]
     assert len(parsed_label.jobs["JOB_0"].frames) == 2
 
     frame = parsed_label.jobs["JOB_0"].frames[1]

--- a/tests/services/label_data_parsing/parsing/test_resp_parsing.py
+++ b/tests/services/label_data_parsing/parsing/test_resp_parsing.py
@@ -958,31 +958,31 @@ def test_video_project_classification():
 
     parsed_label = ParsedLabel(label=label, json_interface=json_interface, input_type="VIDEO")
 
-    assert len(parsed_label.frames) == 9
-    assert not hasattr(parsed_label, "jobs")
+    assert len(parsed_label.jobs["FRAME_CLASSIF_JOB"].frames) == 9
+    assert not hasattr(parsed_label, "frames")
 
-    assert parsed_label.frames[5].jobs["FRAME_CLASSIF_JOB"].is_key_frame is True
-    assert parsed_label.frames[5].jobs["FRAME_CLASSIF_JOB"].category.name == "OBJECT_A"
-    assert parsed_label.frames[5].jobs["FRAME_CLASSIF_JOB"].category.confidence == 100
+    assert parsed_label.jobs["FRAME_CLASSIF_JOB"].frames[5].is_key_frame is True
+    assert parsed_label.jobs["FRAME_CLASSIF_JOB"].frames[5].category.name == "OBJECT_A"
+    assert parsed_label.jobs["FRAME_CLASSIF_JOB"].frames[5].category.confidence == 100
 
-    assert parsed_label.frames[6].jobs["FRAME_CLASSIF_JOB"].is_key_frame is False
-    assert parsed_label.frames[6].jobs["FRAME_CLASSIF_JOB"].category.name == "OBJECT_B"
-    assert parsed_label.frames[6].jobs["FRAME_CLASSIF_JOB"].category.confidence == 42
+    assert parsed_label.jobs["FRAME_CLASSIF_JOB"].frames[6].is_key_frame is False
+    assert parsed_label.jobs["FRAME_CLASSIF_JOB"].frames[6].category.name == "OBJECT_B"
+    assert parsed_label.jobs["FRAME_CLASSIF_JOB"].frames[6].category.confidence == 42
 
-    for i, frame in enumerate(parsed_label.frames):
+    for i, frame in enumerate(parsed_label.jobs["FRAME_CLASSIF_JOB"].frames):
         if i == 5:
-            frame.jobs["FRAME_CLASSIF_JOB"].category.name = "OBJECT_A"
-            frame.jobs["FRAME_CLASSIF_JOB"].category.confidence = 100
+            frame.category.name = "OBJECT_A"
+            frame.category.confidence = 100
         elif i == 6:
-            frame.jobs["FRAME_CLASSIF_JOB"].category.name = "OBJECT_B"
-            frame.jobs["FRAME_CLASSIF_JOB"].category.confidence = 42
+            frame.category.name = "OBJECT_B"
+            frame.category.confidence = 42
 
-    assert parsed_label.frames[0].to_dict() == {}
+    assert parsed_label.jobs["FRAME_CLASSIF_JOB"].frames[0].to_dict() == {}
 
     with pytest.raises(
         FrameIndexError, match="Frame index 999999999 out of range for frame list of size 9."
     ):
-        _ = parsed_label.frames[999999999]
+        _ = parsed_label.jobs["FRAME_CLASSIF_JOB"].frames[999999999]
 
     assert parsed_label.to_dict() == label
 
@@ -1098,17 +1098,17 @@ def test_video_project_object_detection():
 
     parsed_label = ParsedLabel(label=label, json_interface=json_interface, input_type="VIDEO")
 
-    assert len(parsed_label.frames) == 2
+    assert len(parsed_label.jobs["JOB_0"].frames) == 2
 
-    frame = parsed_label.frames[1]
+    frame = parsed_label.jobs["JOB_0"].frames[1]
 
-    first_annotation = frame.jobs["JOB_0"].annotations[0]
+    first_annotation = frame.annotations[0]
     assert first_annotation.category.name == "OBJECT_B"
     assert first_annotation.type == "rectangle"
     assert first_annotation.is_key_frame is True
     assert len(first_annotation.bounding_poly) == 1
 
-    second_annotation = frame.jobs["JOB_0"].annotations[1]
+    second_annotation = frame.annotations[1]
     assert second_annotation.category.name == "OBJECT_A"
     assert second_annotation.type == "rectangle"
     assert second_annotation.is_key_frame is False


### PR DESCRIPTION
purpose of this PR was to switch the `label.frames[42].jobs["job_name"]` to `label.jobs["job_name"].frames[42]`

done:
- removed the project input types that are not in the graphql schema anymore
- in `label.py`, the `ParsedLabel` doesn't have a `.frames` attribute anymore
- in `json_response.py`, the `ParsedJobs` inherits from two private classes `_ParsedOtherJobs` and `_ParsedVideoJobs`, and chooses the right class at runtime depending if the label is a video label or not
- I had to introduce a "fake" class `class JobPayload(FramesList, job_response_module.JobPayload):`. This class is used to expose all attributes/methods of both `FramesList` (for the `.frames` attribute), and all properties of `job_response_module.JobPayload` so that autocompletion works during coding