### PR TITLE
perf: improve Kili client initialization time

### DIFF
--- a/src/kili/client.py
+++ b/src/kili/client.py
@@ -60,7 +60,8 @@ class Kili(  # pylint: disable=too-many-ancestors
     def __init__(
         self, api_key=None, api_endpoint=None, verify=True, client_name=GraphQLClientName.SDK
     ):
-        """
+        """Initialize Kili client.
+
         Args:
             api_key: User API key generated
                 from https://cloud.kili-technology.com/label/my-account/api-key

--- a/src/kili/core/authentication.py
+++ b/src/kili/core/authentication.py
@@ -1,4 +1,5 @@
 """API authentication module."""
+import os
 import warnings
 from datetime import datetime, timedelta
 from typing import Dict
@@ -23,12 +24,23 @@ class KiliAuth:
     def __init__(
         self, api_key: str, api_endpoint: str, client_name: GraphQLClientName, verify=True
     ) -> None:
+        """Initialize KiliAuth.
+
+        Args:
+            api_key: Kili API key.
+            api_endpoint: Kili API endpoint.
+            client_name: Name of the client.
+            verify: Whether to verify the SSL certificate.
+        """
         self.api_key = api_key
         self.api_endpoint = api_endpoint
         self.client_name = client_name
         self.verify = verify
 
-        self.check_api_key_valid()
+        skip_checks = os.environ.get("KILI_SDK_SKIP_CHECKS", None) is not None
+
+        if not skip_checks:
+            self.check_api_key_valid()
 
         self.client = GraphQLClient(
             endpoint=api_endpoint,
@@ -37,11 +49,8 @@ class KiliAuth:
             verify=self.verify,
         )
 
-        self.check_expiry_of_key_is_close()
-
-        user = self.get_user()
-        self.user_id = user["id"]
-        self.user_email = user["email"]
+        if not skip_checks:
+            self.check_expiry_of_key_is_close()
 
     def check_api_key_valid(self) -> None:
         """Check that the api_key provided is valid."""

--- a/src/kili/core/graphql/graphql_client.py
+++ b/src/kili/core/graphql/graphql_client.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import os
 import random
 import string
 import threading
@@ -35,6 +36,14 @@ class GraphQLClient:
     def __init__(
         self, endpoint: str, api_key: str, client_name: GraphQLClientName, verify: bool = True
     ) -> None:
+        """Initialize the GraphQL client.
+
+        Args:
+            endpoint: Kili API endpoint.
+            api_key: Kili API key.
+            client_name: Name of the client.
+            verify: Whether to verify the SSL certificate.
+        """
         self.endpoint = endpoint
         self.api_key = api_key
         self.client_name = client_name
@@ -43,6 +52,7 @@ class GraphQLClient:
         self.ws_endpoint = self.endpoint.replace("http", "ws")
 
         gql_requests_logger.setLevel(logging.WARNING)
+
         self._gql_transport = RequestsHTTPTransport(
             url=endpoint,
             headers=self._get_headers(),
@@ -73,6 +83,9 @@ class GraphQLClient:
 
     def _initizalize_graphql_client(self) -> Client:
         """Initialize the GraphQL client."""
+        if os.environ.get("KILI_SDK_SKIP_CHECKS", None) is not None:
+            return Client(transport=self._gql_transport, fetch_schema_from_transport=False)
+
         graphql_schema_path = self._get_graphql_schema_path()
 
         # In some cases (local development), we cannot get the kili version from the backend

--- a/src/kili/entrypoints/mutations/label/__init__.py
+++ b/src/kili/entrypoints/mutations/label/__init__.py
@@ -157,7 +157,9 @@ class MutationsLabel:
             >>> kili.append_to_labels(label_asset_id=asset_id, json_response={...})
         """
         if author_id is None:
-            author_id = self.auth.user_id
+            user = self.auth.get_user()
+            author_id = user["id"]
+
         check_asset_identifier_arguments(
             project_id,
             [label_asset_id] if label_asset_id else None,

--- a/tests/e2e/test_client.py
+++ b/tests/e2e/test_client.py
@@ -22,14 +22,3 @@ def test_client_init_not_too_long_with_checks_disabled():
     time_spent = timer.timeit(number=1)
 
     assert time_spent < 0.1
-
-
-def test_client_with_checks_disabled_always_faster_than_with_checks_enabled():
-    timer_with_checks = timeit.Timer("_ = Kili()", setup="from kili.client import Kili")
-    time_spent_with_checks = timer_with_checks.timeit(number=1)
-
-    with mock.patch.dict("os.environ", {"KILI_SDK_SKIP_CHECKS": "True"}):
-        timer_without_checks = timeit.Timer("_ = Kili()", setup="from kili.client import Kili")
-        time_spent_without_checks = timer_without_checks.timeit(number=1)
-
-    assert time_spent_with_checks > 10 * time_spent_without_checks  # one order of magnitude

--- a/tests/e2e/test_client.py
+++ b/tests/e2e/test_client.py
@@ -1,0 +1,43 @@
+import timeit
+from unittest import mock
+
+
+def test_client_init_not_too_long():
+    timer = timeit.Timer("_ = Kili()", setup="from kili.client import Kili")
+    time_spent = timer.timeit(number=1)
+
+    assert time_spent < 3
+
+
+@mock.patch.dict("os.environ", {"KILI_SDK_SKIP_CHECKS": "True"})
+def test_client_init_not_too_long_with_checks_disabled():
+    timer = timeit.Timer("_ = Kili()", setup="from kili.client import Kili")
+    time_spent = timer.timeit(number=1)
+
+    assert time_spent < 0.1
+
+
+def test_client_with_checks_disabled_always_faster_than_with_checks_enabled():
+    timer_with_checks = timeit.Timer("_ = Kili()", setup="from kili.client import Kili")
+    time_spent_with_checks = timer_with_checks.timeit(number=1)
+
+    with mock.patch.dict("os.environ", {"KILI_SDK_SKIP_CHECKS": "True"}):
+        timer_without_checks = timeit.Timer("_ = Kili()", setup="from kili.client import Kili")
+        time_spent_without_checks = timer_without_checks.timeit(number=1)
+
+    assert time_spent_with_checks > 10 * time_spent_without_checks  # one order of magnitude
+
+
+def test_import_and_init_time_not_too_long():
+    timer = timeit.Timer("from kili.client import Kili; _ = Kili()")
+    time_spent = timer.timeit(number=1)
+
+    assert time_spent < 3
+
+
+@mock.patch.dict("os.environ", {"KILI_SDK_SKIP_CHECKS": "True"})
+def test_import_and_init_time_not_too_long_with_checks_disabled():
+    timer = timeit.Timer("from kili.client import Kili; _ = Kili()")
+    time_spent = timer.timeit(number=1)
+
+    assert time_spent < 0.5

--- a/tests/e2e/test_client.py
+++ b/tests/e2e/test_client.py
@@ -6,14 +6,14 @@ def test_client_init_not_too_long():
     timer = timeit.Timer("_ = Kili()", setup="from kili.client import Kili")
     time_spent = timer.timeit(number=1)
 
-    assert time_spent < 2
+    assert time_spent < 3
 
 
 def test_import_and_init_time_not_too_long():
     timer = timeit.Timer("from kili.client import Kili; _ = Kili()")
     time_spent = timer.timeit(number=1)
 
-    assert time_spent < 3
+    assert time_spent < 4
 
 
 @mock.patch.dict("os.environ", {"KILI_SDK_SKIP_CHECKS": "True"})

--- a/tests/e2e/test_client.py
+++ b/tests/e2e/test_client.py
@@ -6,6 +6,13 @@ def test_client_init_not_too_long():
     timer = timeit.Timer("_ = Kili()", setup="from kili.client import Kili")
     time_spent = timer.timeit(number=1)
 
+    assert time_spent < 2
+
+
+def test_import_and_init_time_not_too_long():
+    timer = timeit.Timer("from kili.client import Kili; _ = Kili()")
+    time_spent = timer.timeit(number=1)
+
     assert time_spent < 3
 
 
@@ -26,18 +33,3 @@ def test_client_with_checks_disabled_always_faster_than_with_checks_enabled():
         time_spent_without_checks = timer_without_checks.timeit(number=1)
 
     assert time_spent_with_checks > 10 * time_spent_without_checks  # one order of magnitude
-
-
-def test_import_and_init_time_not_too_long():
-    timer = timeit.Timer("from kili.client import Kili; _ = Kili()")
-    time_spent = timer.timeit(number=1)
-
-    assert time_spent < 3
-
-
-@mock.patch.dict("os.environ", {"KILI_SDK_SKIP_CHECKS": "True"})
-def test_import_and_init_time_not_too_long_with_checks_disabled():
-    timer = timeit.Timer("from kili.client import Kili; _ = Kili()")
-    time_spent = timer.timeit(number=1)
-
-    assert time_spent < 0.5


### PR DESCRIPTION
done:
- stop storing user id and email in kiliauth saves 100ms
- add an env var `KILI_SDK_SKIP_CHECKS` that disables checks and graphql schema related stuff

`from kili.client import Kili` takes around ~700ms (mostly because of pandas)

`kili = Kili()` takes ~0s when checks are disabled

to consider:
- pandas import takes ~500ms...: It's pretty easy to add lazy loading of import. But I haven't found yet how to type pd.Dataframe 🤔  We can keep it as is for now. Maybe updating to more recent versions of pandas could improve this (we are using old version now because of python3.7)


