### PR TITLE
fix: fetch deprecated fields of graphql schema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ install_requires = [
     "pydantic>=1.0.0,<2.0.0",
     "urllib3>=1.26,<2.0.0",
     "ffmpeg-python>=0.2.0,<0.3.0",
-    "gql[requests,websockets]>=3.0.0,<4.0.0",
+    "gql[requests,websockets]>=3.5.0b4,<4.0.0",
     "filelock>=3.0.0,<4.0.0",
 ]
 

--- a/src/kili/core/graphql/graphql_client.py
+++ b/src/kili/core/graphql/graphql_client.py
@@ -81,17 +81,35 @@ class GraphQLClient:
             "apollographql-client-version": __version__,
         }
 
+    def _get_introspection_args(self) -> Dict[str, bool]:
+        """Get the introspection arguments."""
+        return {
+            "descriptions": True,  # descriptions for the schema, types, fields, and arguments
+            "specified_by_url": False,  # https://spec.graphql.org/draft/#sec--specifiedBy
+            "directive_is_repeatable": True,  # include repeatability of directives
+            "schema_description": True,  # include schema description
+            "input_value_deprecation": True,  # request deprecated input fields
+        }
+
     def _initizalize_graphql_client(self) -> Client:
         """Initialize the GraphQL client."""
         if os.environ.get("KILI_SDK_SKIP_CHECKS", None) is not None:
-            return Client(transport=self._gql_transport, fetch_schema_from_transport=False)
+            return Client(
+                transport=self._gql_transport,
+                fetch_schema_from_transport=False,
+                introspection_args=self._get_introspection_args(),
+            )
 
         graphql_schema_path = self._get_graphql_schema_path()
 
         # In some cases (local development), we cannot get the kili version from the backend
         # and therefore we cannot determine the schema version, so we don't cache the schema
         if graphql_schema_path is None:
-            return Client(transport=self._gql_transport, fetch_schema_from_transport=True)
+            return Client(
+                transport=self._gql_transport,
+                fetch_schema_from_transport=True,
+                introspection_args=self._get_introspection_args(),
+            )
 
         with self._cache_dir_lock:
             if not (graphql_schema_path.is_file() and graphql_schema_path.stat().st_size > 0):
@@ -100,11 +118,19 @@ class GraphQLClient:
             else:
                 schema_str = graphql_schema_path.read_text(encoding="utf-8")
 
-        return Client(schema=schema_str, transport=self._gql_transport)
+        return Client(
+            transport=self._gql_transport,
+            schema=schema_str,
+            introspection_args=self._get_introspection_args(),
+        )
 
     def _cache_graphql_schema(self, graphql_schema_path: Path) -> str:
         """Cache the graphql schema on disk."""
-        with Client(transport=self._gql_transport, fetch_schema_from_transport=True) as session:
+        with Client(
+            transport=self._gql_transport,
+            fetch_schema_from_transport=True,
+            introspection_args=self._get_introspection_args(),
+        ) as session:
             schema_str = print_schema(session.client.schema)  # type: ignore
 
         with self._cache_dir_lock:


### PR DESCRIPTION
currently, the dependency graphql-core does not fetch all deprecated fields in the graphql schema

see: https://github.com/graphql-python/gql/issues/399

this PR fixes this

e2e tests on staging, preprod and LTS pass