### PR TITLE
ci: add pre-commit hook to block kili api keys

### DIFF
--- a/.github/scripts/detect_api_key.py
+++ b/.github/scripts/detect_api_key.py
@@ -1,0 +1,37 @@
+"""Pre-commit to check if api key is present in the code."""
+
+import re
+import sys
+from pathlib import Path
+
+API_KEY_PATTERN = re.compile(r"(?<!id\":\s\")\b([a-f\d]{8}(-[a-f\d]{4}){3}-[a-f\d]{12})\b(?!\.)")
+
+IGNORE = [
+    "0005d3cc-3c3f-40b9-93c3-46231c3eb813",  # dicom tag id in recipe
+]
+
+
+def main() -> None:
+    args = sys.argv[1:]
+
+    for filepath_str in args:
+        filepath = Path(filepath_str)
+        assert filepath.exists(), f"{filepath_str} does not exist"
+
+        try:
+            content_str = filepath.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+
+        search_result = API_KEY_PATTERN.search(content_str)
+
+        if search_result:
+            if search_result.group(0) in IGNORE:
+                continue
+
+            print(f"API key found in {filepath_str}:  {search_result.group(0)}")
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,3 +66,10 @@ repos:
         pass_filenames: true
         require_serial: true
         additional_dependencies: [click, nbconvert]
+      - id: detect-kili-api-key
+        name: Detect Kili API key
+        language: python
+        entry: python .github/scripts/detect_api_key.py
+        stages: [commit, merge-commit]
+        always_run: false
+        pass_filenames: true


### PR DESCRIPTION
Sometimes I put an api key directly in the scripts for running tests, and I almost pushed a branch with an api key on github🙃

the detect-private-key of pre-commit-hooks only detects ssh keys, so I made a simple script to check our kili keys

the regex pattern excludes false positives, especially in jupyter notebook, where cells or attachments have the same unique ids format