### PR TITLE
test: add profiling info to client init e2e test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,8 @@ dev_extra = [
     "ipykernel",
     # image utils
     "opencv-python",
+    # profiling
+    "pyinstrument",
 ]
 
 setup(

--- a/tests/e2e/test_client.py
+++ b/tests/e2e/test_client.py
@@ -1,12 +1,15 @@
+import pyinstrument
 import timeit
 from unittest import mock
 
 
 def test_import_and_init_time_not_too_long():
-    timer = timeit.Timer("from kili.client import Kili; _ = Kili()")
-    time_spent = timer.timeit(number=1)
-
-    assert time_spent < 5
+    with pyinstrument.Profiler() as profiler:
+        import kili.client
+        _ = kili.client.Kili()
+       
+    time_spent = profiler.last_session.duration
+    assert time_spent < 5, profiler.output_text(unicode=True, color=True)
 
 
 @mock.patch.dict("os.environ", {"KILI_SDK_SKIP_CHECKS": "True"})

--- a/tests/e2e/test_client.py
+++ b/tests/e2e/test_client.py
@@ -1,15 +1,17 @@
-import pyinstrument
 import timeit
 from unittest import mock
 
+from pyinstrument.profiler import Profiler
+
 
 def test_import_and_init_time_not_too_long():
-    with pyinstrument.Profiler() as profiler:
+    with Profiler() as profiler:
         import kili.client
+
         _ = kili.client.Kili()
-       
-    time_spent = profiler.last_session.duration
-    assert time_spent < 5, profiler.output_text(unicode=True, color=True)
+
+    time_spent = profiler.last_session.duration  # type: ignore
+    assert time_spent < 5, profiler.output_text(unicode=True)
 
 
 @mock.patch.dict("os.environ", {"KILI_SDK_SKIP_CHECKS": "True"})

--- a/tests/e2e/test_client.py
+++ b/tests/e2e/test_client.py
@@ -6,9 +6,9 @@ from pyinstrument.profiler import Profiler
 
 def test_import_and_init_time_not_too_long():
     with Profiler() as profiler:
-        import kili.client
+        from kili.client import Kili
 
-        _ = kili.client.Kili()
+        _ = Kili()
 
     time_spent = profiler.last_session.duration  # type: ignore
     assert time_spent < 5, profiler.output_text(unicode=True)


### PR DESCRIPTION
e2e: https://github.com/kili-technology/kili-python-sdk/actions/runs/4934039946/jobs/8818611523