### PR TITLE
feat: set better default fields for kili.labels()

### DIFF
--- a/src/kili/entrypoints/queries/label/__init__.py
+++ b/src/kili/entrypoints/queries/label/__init__.py
@@ -197,6 +197,7 @@ class QueriesLabel:
             "jsonResponse",
             "labelType",
             "secondsToLabel",
+            "isLatestLabelForUser",
         ],
         first: Optional[int] = None,
         honeypot_mark_gte: Optional[float] = None,


### PR DESCRIPTION
Hava found that it was hard to find the latest label for an asset while using kili.labels

this PR makes the isLatestLabelForUser label field more visible