### PR TITLE
fix: fix box orientation in bbox label utils

### DIFF
--- a/src/kili/utils/labels/bbox.py
+++ b/src/kili/utils/labels/bbox.py
@@ -93,7 +93,7 @@ def bbox_points_to_normalized_vertices(
         point_to_normalized_point(
             point, img_width=img_width, img_height=img_height, origin_location=origin_location
         )
-        for point in (top_left, bottom_left, bottom_right, top_right)
+        for point in (bottom_left, top_left, top_right, bottom_right)
     ]
 
     return vertices
@@ -159,7 +159,7 @@ def normalized_vertices_to_bbox_points(
     ret = {}
 
     for vertex, point_name in zip(
-        normalized_vertices, ("top_left", "bottom_left", "bottom_right", "top_right")
+        normalized_vertices, ("bottom_left", "top_left", "top_right", "bottom_right")
     ):
         ret[point_name] = normalized_point_to_point(
             vertex, img_width=img_width, img_height=img_height, origin_location=origin_location

--- a/tests/utils/labels/test_bbox.py
+++ b/tests/utils/labels/test_bbox.py
@@ -204,3 +204,69 @@ def test_bbox_points_to_normalized_vertices(test_name, inputs, output, origin_lo
     assert bbox_points["bottom_right"] == pytest.approx(inputs["bottom_right"])
     assert bbox_points["top_right"] == pytest.approx(inputs["top_right"])
     assert bbox_points["top_left"] == pytest.approx(inputs["top_left"])
+
+
+# DO NOT DELETE. USED FOR DEBUGGING
+# def debug_using_kili_project():
+#     kili = Kili()
+#     project = kili.create_project(
+#         input_type="IMAGE",
+#         json_interface={
+#             "jobs": {
+#                 "OBJECT_DETECTION_JOB": {
+#                     "content": {
+#                         "categories": {"A": {"children": [], "color": "#472CED", "name": "A"}},
+#                         "input": "radio",
+#                     },
+#                     "instruction": "Box",
+#                     "mlTask": "OBJECT_DETECTION",
+#                     "required": 1,
+#                     "tools": ["rectangle"],
+#                     "isChild": False,
+#                 }
+#             }
+#         },
+#         title="test bbox",
+#     )
+
+#     kili.append_many_to_dataset(
+#         project["id"],
+#         content_array=[
+#             "https://storage.googleapis.com/label-public-staging/car/car_1.jpg"  # 1920 1080
+#         ],
+#         external_id_array=["car_1"],
+#     )
+
+#     points = {
+#         "bottom_left": {"x": 0, "y": 1070},
+#         "bottom_right": {"x": 500, "y": 1070},
+#         "top_right": {"x": 500, "y": 1080},
+#         "top_left": {"x": 0, "y": 1080},
+#         "img_width": 1920,
+#         "img_height": 1080,
+#     }
+#     normalizedVertices = bbox_points_to_normalized_vertices(**points, origin_location="bottom_left")
+
+#     kili.append_labels(
+#         json_response_array=[
+#             {
+#                 "OBJECT_DETECTION_JOB": {
+#                     "annotations": [
+#                         {
+#                             "boundingPoly": [{"normalizedVertices": normalizedVertices}],
+#                             "categories": [{"name": "A"}],
+#                             "type": "rectangle",
+#                         }
+#                     ]
+#                 }
+#             }
+#         ],
+#         asset_external_id_array=["car_1"],
+#         project_id=project["id"],
+#     )
+
+
+# if __name__ == "__main__":
+#     from kili.client import Kili
+
+#     debug_using_kili_project()

--- a/tests/utils/labels/test_bbox.py
+++ b/tests/utils/labels/test_bbox.py
@@ -7,7 +7,7 @@ from kili.utils.labels.bbox import (
 
 
 @pytest.mark.parametrize(
-    "test_name,inputs,output",
+    "test_name,inputs,output,origin_location",
     [
         (
             "box full image pixels",
@@ -19,7 +19,8 @@ from kili.utils.labels.bbox import (
                 "img_width": 1920,
                 "img_height": 1080,
             },
-            [{"x": 0, "y": 0}, {"x": 0, "y": 1}, {"x": 1, "y": 1}, {"x": 1, "y": 0}],
+            [{"x": 0, "y": 1}, {"x": 0, "y": 0}, {"x": 1, "y": 0}, {"x": 1, "y": 1}],
+            "bottom_left",
         ),
         (
             "box full image normalized pixels",
@@ -29,7 +30,8 @@ from kili.utils.labels.bbox import (
                 "top_right": {"x": 1, "y": 1},
                 "top_left": {"x": 0, "y": 1},
             },
-            [{"x": 0, "y": 0}, {"x": 0, "y": 1}, {"x": 1, "y": 1}, {"x": 1, "y": 0}],
+            [{"x": 0, "y": 1}, {"x": 0, "y": 0}, {"x": 1, "y": 0}, {"x": 1, "y": 1}],
+            "bottom_left",
         ),
         (
             "box left half part of the image",
@@ -41,7 +43,8 @@ from kili.utils.labels.bbox import (
                 "img_width": 1920,
                 "img_height": 1080,
             },
-            [{"x": 0, "y": 0}, {"x": 0, "y": 1}, {"x": 0.5, "y": 1}, {"x": 0.5, "y": 0}],
+            [{"x": 0, "y": 1}, {"x": 0, "y": 0}, {"x": 0.5, "y": 0}, {"x": 0.5, "y": 1}],
+            "bottom_left",
         ),
         (
             "box left half part of the image already normalized",
@@ -51,7 +54,8 @@ from kili.utils.labels.bbox import (
                 "top_right": {"x": 0.5, "y": 1},
                 "top_left": {"x": 0, "y": 1},
             },
-            [{"x": 0, "y": 0}, {"x": 0, "y": 1}, {"x": 0.5, "y": 1}, {"x": 0.5, "y": 0}],
+            [{"x": 0, "y": 1}, {"x": 0, "y": 0}, {"x": 0.5, "y": 0}, {"x": 0.5, "y": 1}],
+            "bottom_left",
         ),
         (
             "box right half part of the image",
@@ -61,7 +65,8 @@ from kili.utils.labels.bbox import (
                 "top_right": {"x": 1, "y": 1},
                 "top_left": {"x": 0.5, "y": 1},
             },
-            [{"x": 0.5, "y": 0}, {"x": 0.5, "y": 1}, {"x": 1, "y": 1}, {"x": 1, "y": 0}],
+            [{"x": 0.5, "y": 1}, {"x": 0.5, "y": 0}, {"x": 1, "y": 0}, {"x": 1, "y": 1}],
+            "bottom_left",
         ),
         (
             "box horizontal center part of the image full width",
@@ -71,7 +76,8 @@ from kili.utils.labels.bbox import (
                 "top_right": {"x": 1, "y": 0.75},
                 "top_left": {"x": 0.0, "y": 0.75},
             },
-            [{"x": 0, "y": 0.25}, {"x": 0, "y": 0.75}, {"x": 1, "y": 0.75}, {"x": 1, "y": 0.25}],
+            [{"x": 0, "y": 0.75}, {"x": 0, "y": 0.25}, {"x": 1, "y": 0.25}, {"x": 1, "y": 0.75}],
+            "bottom_left",
         ),
         (
             "square small box bottom left corner",
@@ -84,11 +90,12 @@ from kili.utils.labels.bbox import (
                 "img_height": 1080,
             },
             [
-                {"x": 0, "y": 0.9907407407407407},
                 {"x": 0, "y": 1},
-                {"x": 0.005208333333333333, "y": 1},
-                {"x": 0.005208333333333333, "y": 0.9907407407407407},
+                {"x": 0, "y": 1070 / 1080},
+                {"x": 10 / 1920, "y": 1070 / 1080},
+                {"x": 10 / 1920, "y": 1},
             ],
+            "bottom_left",
         ),
         (
             "square small box bottom right corner",
@@ -101,11 +108,12 @@ from kili.utils.labels.bbox import (
                 "img_height": 1080,
             },
             [
-                {"x": 0.9947916666666666, "y": 0.9907407407407407},
-                {"x": 0.9947916666666666, "y": 1},
+                {"x": 1910 / 1920, "y": 1},
+                {"x": 1910 / 1920, "y": 1070 / 1080},
+                {"x": 1, "y": 1070 / 1080},
                 {"x": 1, "y": 1},
-                {"x": 1, "y": 0.9907407407407407},
             ],
+            "bottom_left",
         ),
         (
             "square small box top right corner",
@@ -118,11 +126,12 @@ from kili.utils.labels.bbox import (
                 "img_height": 1080,
             },
             [
-                {"x": 0.9947916666666666, "y": 0},
-                {"x": 0.9947916666666666, "y": 0.0092592592592593},
-                {"x": 1, "y": 0.0092592592592593},
+                {"x": 1910 / 1920, "y": 10 / 1080},
+                {"x": 1910 / 1920, "y": 0},
                 {"x": 1, "y": 0},
+                {"x": 1, "y": 10 / 1080},
             ],
+            "bottom_left",
         ),
         (
             "square small box top left corner",
@@ -135,11 +144,12 @@ from kili.utils.labels.bbox import (
                 "img_height": 1080,
             },
             [
+                {"x": 0, "y": 10 / 1080},
                 {"x": 0, "y": 0},
-                {"x": 0, "y": 0.0092592592592593},
-                {"x": 0.005208333333333333, "y": 0.0092592592592593},
-                {"x": 0.005208333333333333, "y": 0},
+                {"x": 10 / 1920, "y": 0},
+                {"x": 10 / 1920, "y": 10 / 1080},
             ],
+            "bottom_left",
         ),
         (
             "small box somewhere in the top right quarter of the image",
@@ -152,20 +162,44 @@ from kili.utils.labels.bbox import (
                 "img_height": 1080,
             },
             [
-                {"x": 0.5208333333333334, "y": 0.3055555555555556},
-                {"x": 0.5208333333333334, "y": 0.35185185185185186},
-                {"x": 0.546875, "y": 0.35185185185185186},
-                {"x": 0.546875, "y": 0.3055555555555556},
+                {"x": 1000 / 1920, "y": 1 - (700 / 1080)},
+                {"x": 1000 / 1920, "y": 1 - (750 / 1080)},
+                {"x": 1050 / 1920, "y": 1 - (750 / 1080)},
+                {"x": 1050 / 1920, "y": 1 - (700 / 1080)},
             ],
+            "bottom_left",
+        ),
+        (
+            "small box top left corner of the image. input points in kili space (top_left)",
+            {
+                "bottom_left": {"x": 0, "y": 10},
+                "bottom_right": {"x": 10, "y": 10},
+                "top_right": {"x": 10, "y": 0},
+                "top_left": {"x": 0, "y": 0},
+                "img_width": 1920,
+                "img_height": 1080,
+            },
+            [
+                {"x": 0, "y": 10 / 1080},
+                {"x": 0, "y": 0},
+                {"x": 10 / 1920, "y": 0},
+                {"x": 10 / 1920, "y": 10 / 1080},
+            ],
+            "top_left",
         ),
     ],
 )
-def test_bbox_points_to_normalized_vertices(test_name, inputs, output):
-    vertices = bbox_points_to_normalized_vertices(**inputs)
-    assert vertices == output
+def test_bbox_points_to_normalized_vertices(test_name, inputs, output, origin_location):
+    # input test points are defined in the space with origin bottom left
+    vertices = bbox_points_to_normalized_vertices(**inputs, origin_location=origin_location)
+    for computed_vertex, expected_vertex in zip(vertices, output):  # type: ignore
+        assert computed_vertex == pytest.approx(expected_vertex)
 
     bbox_points = normalized_vertices_to_bbox_points(
-        vertices, img_width=inputs.get("img_width"), img_height=inputs.get("img_height")
+        vertices,
+        img_width=inputs.get("img_width"),
+        img_height=inputs.get("img_height"),
+        origin_location=origin_location,
     )
     assert bbox_points["bottom_left"] == pytest.approx(inputs["bottom_left"])
     assert bbox_points["bottom_right"] == pytest.approx(inputs["bottom_right"])

--- a/tests/utils/labels/test_bbox.py
+++ b/tests/utils/labels/test_bbox.py
@@ -190,7 +190,6 @@ from kili.utils.labels.bbox import (
     ],
 )
 def test_bbox_points_to_normalized_vertices(test_name, inputs, output, origin_location):
-    # input test points are defined in the space with origin bottom left
     vertices = bbox_points_to_normalized_vertices(**inputs, origin_location=origin_location)
     for computed_vertex, expected_vertex in zip(vertices, output):  # type: ignore
         assert computed_vertex == pytest.approx(expected_vertex)
@@ -205,68 +204,3 @@ def test_bbox_points_to_normalized_vertices(test_name, inputs, output, origin_lo
     assert bbox_points["bottom_right"] == pytest.approx(inputs["bottom_right"])
     assert bbox_points["top_right"] == pytest.approx(inputs["top_right"])
     assert bbox_points["top_left"] == pytest.approx(inputs["top_left"])
-
-
-# DO NOT DELETE. USED FOR DEBUGGING
-# def debug_using_kili_project():
-#     kili = Kili()
-#     project = kili.create_project(
-#         input_type="IMAGE",
-#         json_interface={
-#             "jobs": {
-#                 "OBJECT_DETECTION_JOB": {
-#                     "content": {
-#                         "categories": {"A": {"children": [], "color": "#472CED", "name": "A"}},
-#                         "input": "radio",
-#                     },
-#                     "instruction": "Box",
-#                     "mlTask": "OBJECT_DETECTION",
-#                     "required": 1,
-#                     "tools": ["rectangle"],
-#                     "isChild": False,
-#                 }
-#             }
-#         },
-#         title="test bbox",
-#     )
-
-#     kili.append_many_to_dataset(
-#         project["id"],
-#         content_array=[
-#             "https://storage.googleapis.com/label-public-staging/car/car_1.jpg"  # 1920 1080
-#         ],
-#         external_id_array=["car_1"],
-#     )
-
-#     points = {
-#         "bottom_left": {"x": 1000, "y": 700},
-#         "bottom_right": {"x": 1050, "y": 700},
-#         "top_right": {"x": 1050, "y": 750},
-#         "top_left": {"x": 1000, "y": 750},
-#         "img_width": 1920,
-#         "img_height": 1080,
-#     }
-#     normalizedVertices = bbox_points_to_normalized_vertices(**points)
-#     kili.append_labels(
-#         json_response_array=[
-#             {
-#                 "OBJECT_DETECTION_JOB": {
-#                     "annotations": [
-#                         {
-#                             "boundingPoly": [{"normalizedVertices": normalizedVertices}],
-#                             "categories": [{"name": "A"}],
-#                             "type": "rectangle",
-#                         }
-#                     ]
-#                 }
-#             }
-#         ],
-#         asset_external_id_array=["car_1"],
-#         project_id=project["id"],
-#     )
-
-
-# if __name__ == "__main__":
-#     from kili.client import Kili
-
-#     debug_using_kili_project()

--- a/tests/utils/labels/test_point.py
+++ b/tests/utils/labels/test_point.py
@@ -3,17 +3,38 @@ import pytest
 from kili.utils.labels.point import normalized_point_to_point, point_to_normalized_point
 
 
-def test_point_conversion():
-    point = {"x": 2.0, "y": 2.0}  # bottom left corner
+def test_point_conversion_origin_bottom_left():
+    # point bottom left side of the image
+    point = {"x": 2.0, "y": 2.0}
     img_width = 20
     img_height = 10
-    normalized_point = point_to_normalized_point(point, img_width, img_height)
+
+    normalized_point = point_to_normalized_point(
+        point, img_width, img_height, origin_location="bottom_left"
+    )
 
     assert normalized_point == {"x": 0.1, "y": 0.8}
 
-    assert normalized_point_to_point(normalized_point, img_width, img_height) == pytest.approx(
-        point
+    assert normalized_point_to_point(
+        normalized_point, img_width, img_height, origin_location="bottom_left"
+    ) == pytest.approx(point)
+
+
+def test_point_conversion_origin_top_left():
+    # point top right side of the image
+    point = {"x": 19.0, "y": 1.0}
+    img_width = 20
+    img_height = 10
+
+    normalized_point = point_to_normalized_point(
+        point, img_width, img_height, origin_location="top_left"
     )
+
+    assert normalized_point == {"x": 19 / 20, "y": 1 / 10}
+
+    assert normalized_point_to_point(
+        normalized_point, img_width, img_height, origin_location="top_left"
+    ) == pytest.approx(point)
 
 
 def test_origin_location_point_to_normalized_point():
@@ -23,6 +44,7 @@ def test_origin_location_point_to_normalized_point():
 
 
 def test_origin_location_normalized_point_to_point():
+    # vertex middle of the image (kili space)
     vertex = {"x": 0.5, "y": 0.5}
     assert (
         normalized_point_to_point(vertex, origin_location="top_left")
@@ -30,8 +52,10 @@ def test_origin_location_normalized_point_to_point():
         == vertex
     )
 
+    # vertex top left corner of the image (kili space)
     vertex = {"x": 0.4, "y": 0.1}
     assert normalized_point_to_point(vertex, origin_location="top_left") == {"x": 0.4, "y": 0.1}
 
+    # vertex top left corner of the image (kili space)
     vertex = {"x": 0.4, "y": 0.1}
     assert normalized_point_to_point(vertex, origin_location="bottom_left") == {"x": 0.4, "y": 0.9}


### PR DESCRIPTION
currently, the boxes returned by `bbox_points_to_normalized_vertices` are upside down. In other terms, the box is at  the right position, but the rotation handle is at the bottom instead of being at the top of the box.