### PR TITLE
test: add delay after mutation to account for replica lag

### DIFF
--- a/tests/e2e/test_projects.py
+++ b/tests/e2e/test_projects.py
@@ -1,3 +1,4 @@
+import time
 import uuid
 
 import pytest
@@ -28,6 +29,8 @@ def projects_uuid(kili: Kili):
         title="test_projects.py not archived 2" + projects_uuid,
     )["id"]
     kili.archive_project(proj_id_archived)
+
+    time.sleep(1)  # wait for the project to be archived (replica lag)
 
     yield projects_uuid
 


### PR DESCRIPTION
```bash
FAILED tests/e2e/test_projects.py::test_projects_query_archived_project - AssertionError: assert 2 == 3
 +  where 2 = len([***'id': 'cljwiufjx004n0j7v5hjr78m0'***, ***'id': 'cljwiuetc004j0j7v08exed7n'***])
 +    where [***'id': 'cljwiufjx004n0j7v5hjr78m0'***, ***'id': 'cljwiuetc004j0j7v08exed7n'***] = <bound method QueriesProject.projects of <kili.client.Kili object at 0x00000219D7FB9A90>>(fields=['id'], search_query='8c354ef2-ae64-4cd6-925e-43e3d6fe1065')
 +      where <bound method QueriesProject.projects of <kili.client.Kili object at 0x00000219D7FB9A90>> = <kili.client.Kili object at 0x00000219D7FB9A90>.projects
 +  and   3 = <bound method QueriesProject.count_projects of <kili.client.Kili object at 0x00000219D7FB9A90>>(search_query='8c354ef2-ae64-4cd6-925e-43e3d6fe1065')
 +    where <bound method QueriesProject.count_projects of <kili.client.Kili object at 0x00000219D7FB9A90>> = <kili.client.Kili object at 0x00000219D7FB9A90>.count_projects
```