### PR TITLE
fix: fix bug when no data is returned

### DIFF
--- a/src/kili/entrypoints/mutations/asset/__init__.py
+++ b/src/kili/entrypoints/mutations/asset/__init__.py
@@ -403,7 +403,7 @@ class MutationsAsset(BaseOperationEntrypointMixin):
             retry=retry_if_exception_type(MutationError),
             reraise=True,
         )
-        def verify_last_batch(last_batch: Dict, results: List):
+        def verify_last_batch(last_batch: Dict, results: List) -> None:
             """Check that all assets in the last batch have been deleted."""
             # in some case the results is [{'data': None}]
             project_id_ = project_id or results[0]["data"].get("id")
@@ -476,7 +476,7 @@ class MutationsAsset(BaseOperationEntrypointMixin):
             retry=retry_if_exception_type(MutationError),
             reraise=True,
         )
-        def verify_last_batch(last_batch: Dict, results: List):
+        def verify_last_batch(last_batch: Dict, results: List) -> None:
             """Check that all assets in the last batch have been sent to review."""
             # in some case the results is [{'data': None}]
             project_id_ = project_id or results[0]["data"].get("id")
@@ -559,13 +559,12 @@ class MutationsAsset(BaseOperationEntrypointMixin):
         )
         def verify_last_batch(last_batch: Dict, results: List) -> None:
             """Check that all assets in the last batch have been sent back to queue."""
-            asset_ids = last_batch["asset_ids"][-1:]  # check lastest asset of the batch only
-
             # in some case the results is [{'data': None}]
             project_id_ = project_id or results[0]["data"].get("id")
             if project_id_ is None:
                 return
 
+            asset_ids = last_batch["asset_ids"][-1:]  # check lastest asset of the batch only
             nb_assets_in_queue = AssetQuery(self.graphql_client, self.http_client).count(
                 AssetWhere(
                     project_id=project_id_,


### PR DESCRIPTION
kili.send_back_to_queue(asset_ids=["blabla"])

would give:
```
  File "/Users/jonasm/kili-python-sdk/src/kili/entrypoints/mutations/asset/__init__.py", line 567, in send_back_to_queue
    results = mutate_from_paginated_call(
  File "/Users/jonasm/kili-python-sdk/src/kili/core/utils/pagination.py", line 116, in mutate_from_paginated_call
    last_batch_callback(batch, results)
  File "/opt/anaconda3/envs/python38/lib/python3.8/site-packages/tenacity/__init__.py", line 289, in wrapped_f
    return self(f, *args, **kw)
  File "/opt/anaconda3/envs/python38/lib/python3.8/site-packages/tenacity/__init__.py", line 379, in __call__
    do = self.iter(retry_state=retry_state)
  File "/opt/anaconda3/envs/python38/lib/python3.8/site-packages/tenacity/__init__.py", line 314, in iter
    return fut.result()
  File "/opt/anaconda3/envs/python38/lib/python3.8/concurrent/futures/_base.py", line 437, in result
    return self.__get_result()
  File "/opt/anaconda3/envs/python38/lib/python3.8/concurrent/futures/_base.py", line 389, in __get_result
    raise self._exception
  File "/opt/anaconda3/envs/python38/lib/python3.8/site-packages/tenacity/__init__.py", line 382, in __call__
    result = fn(*args, **kwargs)
  File "/Users/jonasm/kili-python-sdk/src/kili/entrypoints/mutations/asset/__init__.py", line 559, in verify_last_batch
    project_id=results[0]["data"]["id"],
TypeError: 'NoneType' object is not subscriptable
```
results is: `[{'data': None}]`