### PR TITLE
fix: remove null from variables in gql query

### DIFF
--- a/src/kili/core/graphql/graphql_client.py
+++ b/src/kili/core/graphql/graphql_client.py
@@ -233,8 +233,8 @@ class GraphQLClient:
             return response_json["version"]
         return None
 
-    @classmethod
-    def _remove_nullable_inputs(cls, variables: Dict) -> Dict:
+    @staticmethod
+    def _remove_nullable_inputs(variables: Dict) -> Dict:
         """Remove nullable inputs from the variables."""
         return {k: v for k, v in variables.items() if v is not None}
 

--- a/src/kili/core/graphql/graphql_client.py
+++ b/src/kili/core/graphql/graphql_client.py
@@ -234,22 +234,9 @@ class GraphQLClient:
         return None
 
     @classmethod
-    def _remove_keys_with_none_values(cls, variables: Dict) -> Dict:
-        """Remove keys with None values from a nested dictionary."""
-        output_dict = {}
-        for key, value in variables.items():
-            if value is None:
-                continue
-
-            new_value = value
-            if isinstance(value, dict):
-                dict_without_nones = cls._remove_keys_with_none_values(value)
-                if len(dict_without_nones):
-                    new_value = dict_without_nones
-
-            output_dict[key] = new_value
-
-        return output_dict
+    def _remove_nullable_inputs(cls, variables: Dict) -> Dict:
+        """Remove nullable inputs from the variables."""
+        return {k: v for k, v in variables.items() if v is not None}
 
     def execute(
         self, query: Union[str, DocumentNode], variables: Optional[Dict] = None, **kwargs
@@ -262,7 +249,7 @@ class GraphQLClient:
             kwargs: additional arguments to pass to the GraphQL client
         """
         document = query if isinstance(query, DocumentNode) else gql(query)
-        variables = self._remove_keys_with_none_values(variables) if variables else None
+        variables = self._remove_nullable_inputs(variables) if variables else None
 
         try:
             return self._execute_with_retries(document, variables, **kwargs)

--- a/src/kili/core/graphql/graphql_client.py
+++ b/src/kili/core/graphql/graphql_client.py
@@ -243,7 +243,9 @@ class GraphQLClient:
 
             new_value = value
             if isinstance(value, dict):
-                new_value = cls._remove_keys_with_none_values(value)
+                dict_without_nones = cls._remove_keys_with_none_values(value)
+                if len(dict_without_nones):
+                    new_value = dict_without_nones
 
             output_dict[key] = new_value
 


### PR DESCRIPTION
It's not a perfect solution, since the `variables` can be a nested dict.

Also, some inputs could have a non-nullable JSON type (`metadata: JSON!`), and in that case, if we pass `variables = {"metadata": {"truc": None}}` we don't want to remove the child dict.

e2e pass, so I think it's a good enough solution: https://github.com/kili-technology/kili-python-sdk/actions/runs/6349198396

