### PR TITLE
fix: missing graphql client init for internal methods

### DIFF
--- a/src/kili/presentation/client/internal.py
+++ b/src/kili/presentation/client/internal.py
@@ -25,6 +25,8 @@ class InternalClientMethods(MutationsOrganization):
         """
         super().__init__()
         self.kili_api_gateway = kili_api_gateway
+        self.http_client = kili_api_gateway.http_client
+        self.graphql_client = kili_api_gateway.graphql_client
 
     @typechecked
     def reset_password(self, email: str):


### PR DESCRIPTION
useful for the mutations, that have not been migrated yet towards the new archi