### PR TITLE
fix: don't query annotations resolver on LTS

### DIFF
--- a/src/kili/adapters/kili_api_gateway/label/common.py
+++ b/src/kili/adapters/kili_api_gateway/label/common.py
@@ -5,6 +5,7 @@ from kili.adapters.kili_api_gateway.helpers.queries import fragment_builder
 from kili.core.graphql.graphql_client import GraphQLClient
 from kili.domain.label import LabelId
 from kili.domain.types import ListOrTuple
+from kili.exceptions import GraphQLError
 
 from .operations import get_annotations_query
 
@@ -28,5 +29,12 @@ def list_annotations(
         video_transcription_annotation_fragment=fragment_builder(video_transcription_fields),
     )
     variables = {"where": {"labelId": label_id}}
-    result = graphql_client.execute(query, variables)
+
+    try:
+        result = graphql_client.execute(query, variables)
+    except GraphQLError as err:
+        if "Cannot query field" in str(err):  # not available on LTS
+            return []
+        raise
+
     return result["data"]


### PR DESCRIPTION
FAILED tests/e2e/test_copy_project.py::test_copy_project_e2e_video - kili.exceptions.GraphQLError: GraphQL error: "Cannot query field 'job' on type 'Annotation'."

e2e: https://github.com/kili-technology/kili-python-sdk/actions/runs/6823160395