### PR TITLE
fix: fix export when an asset has a slash

### DIFF
--- a/src/kili/services/export/format/base.py
+++ b/src/kili/services/export/format/base.py
@@ -3,7 +3,6 @@
 import csv
 import json
 import logging
-import os
 import shutil
 from abc import ABC, abstractmethod
 from datetime import datetime
@@ -14,7 +13,6 @@ from kili.domain.asset import AssetId
 from kili.domain.project import ProjectId
 from kili.services.export.exceptions import (
     NotCompatibleOptions,
-    NotExportableAssetError,
 )
 from kili.services.export.repository import AbstractContentRepository
 from kili.services.export.tools import (
@@ -174,14 +172,6 @@ class AbstractExporter(ABC):  # pylint: disable=too-many-instance-attributes
                 local_media_dir=str(self.images_folder),
                 asset_filter_kwargs=self.asset_filter_kwargs,
             )
-            # if the asset["externalId"] has slashes in it, the export will not work
-            # since the slashes will be interpreted as folders
-            if any(asset["externalId"].find(os.sep) != -1 for asset in assets):
-                raise NotExportableAssetError(
-                    "The export is not supported for assets with externalIds that contain slashes."
-                    " Please remove the slashes from the externalIds using"
-                    " `kili.change_asset_external_ids()` and try again."
-                )
 
             self._check_geotiff_export_compatibility(assets)
 

--- a/src/kili/services/export/format/geojson/__init__.py
+++ b/src/kili/services/export/format/geojson/__init__.py
@@ -93,7 +93,7 @@ def _process_asset(asset: Dict, labels_folder: Path) -> None:
     geojson_feature_collection = kili_json_response_to_feature_collection(
         asset["latestLabel"]["jsonResponse"]
     )
-
-    filename = f'{asset["externalId"]}.geojson'
-    with open(labels_folder / filename, "w", encoding="utf-8") as file:
+    filepath = labels_folder / f'{asset["externalId"]}.geojson'
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    with open(filepath, "w", encoding="utf-8") as file:
         json.dump(geojson_feature_collection, file)

--- a/src/kili/services/export/format/kili/__init__.py
+++ b/src/kili/services/export/format/kili/__init__.py
@@ -47,7 +47,9 @@ class KiliExporter(AbstractExporter):
             for asset in assets:
                 external_id = asset["externalId"].replace(" ", "_")
                 asset_json = json.dumps(asset, sort_keys=True, indent=4)
-                with (labels_folder / f"{external_id}.json").open("wb") as output_file:
+                file_path = labels_folder / f"{external_id}.json"
+                file_path.parent.mkdir(parents=True, exist_ok=True)
+                with file_path.open("wb") as output_file:
                     output_file.write(asset_json.encode("utf-8"))
 
         self.create_readme_kili_file(self.export_root_folder)

--- a/src/kili/services/export/format/voc/__init__.py
+++ b/src/kili/services/export/format/voc/__init__.py
@@ -123,7 +123,6 @@ def _process_asset(
         )
         xml_filename = f'{asset["externalId"]}.xml'
         filepath = labels_folder / xml_filename
-        print(filepath)
         filepath.parent.mkdir(parents=True, exist_ok=True)
         with open(filepath, "wb") as fout:
             fout.write(f"{annotations}\n".encode())

--- a/src/kili/services/export/format/voc/__init__.py
+++ b/src/kili/services/export/format/voc/__init__.py
@@ -106,8 +106,9 @@ def _process_asset(
             annotations = _convert_from_kili_to_voc_format(
                 json_response, width, height, parameters, valid_jobs
             )
-            xml_filename = f"{frame_name}.xml"
-            with open(labels_folder / xml_filename, "wb") as fout:
+            filepath = labels_folder / f"{frame_name}.xml"
+            filepath.parent.mkdir(parents=True, exist_ok=True)
+            with open(filepath, "wb") as fout:
                 fout.write(f"{annotations}\n".encode())
 
     elif project_input_type == "IMAGE":
@@ -121,7 +122,10 @@ def _process_asset(
             json_response, width, height, parameters, valid_jobs
         )
         xml_filename = f'{asset["externalId"]}.xml'
-        with open(labels_folder / xml_filename, "wb") as fout:
+        filepath = labels_folder / xml_filename
+        print(filepath)
+        filepath.parent.mkdir(parents=True, exist_ok=True)
+        with open(filepath, "wb") as fout:
             fout.write(f"{annotations}\n".encode())
 
 

--- a/src/kili/services/export/format/yolo/__init__.py
+++ b/src/kili/services/export/format/yolo/__init__.py
@@ -432,7 +432,9 @@ def _write_content_frame_to_file(
 
 
 def _write_labels_to_file(labels_folder: Path, filename: str, annotations: List[Tuple]) -> None:
-    with (labels_folder / f"{filename}.txt").open("wb") as fout:
+    file_path = labels_folder / f"{filename}.txt"
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    with file_path.open("wb") as fout:
         for category_idx, *points in annotations:
             points_str = " ".join([str(point) for point in points])
             fout.write(f"{category_idx} {points_str}\n".encode())

--- a/tests/unit/services/export/helpers/coco.py
+++ b/tests/unit/services/export/helpers/coco.py
@@ -33,7 +33,7 @@ def get_asset(
 
     return {
         "latestLabel": {"jsonResponse": json_response},
-        "externalId": "car_1",
+        "externalId": "ca/r_1",
         "jsonContent": "",
         "content": str(content_path),
     }

--- a/tests/unit/services/export/test_geojson.py
+++ b/tests/unit/services/export/test_geojson.py
@@ -66,37 +66,36 @@ def test_kili_export_labels_geojson(mocker: pytest_mock.MockerFixture):
     assert len(output["features"]) == 5  # 5 annotations in geotiff_image_project_assets.json
 
 
-def test_process_asset_with_external_id_containing_slash():
-    with TemporaryDirectory() as f:
-        asset = {
-            "latestLabel": {
-                "jsonResponse": {
-                    "JOB_0": {
-                        "annotations": [
-                            {
-                                "categories": [{"name": "OBJECT_A"}],
-                                "mid": "20230111125258113-44528",
-                                "type": "rectangle",
-                                "boundingPoly": [
-                                    {
-                                        "normalizedVertices": [
-                                            {"x": 0.6101435505380516, "y": 0.7689773770786136},
-                                            {"x": 0.6101435505380516, "y": 0.39426226491370664},
-                                            {"x": 0.8962087421313937, "y": 0.39426226491370664},
-                                            {"x": 0.8962087421313937, "y": 0.7689773770786136},
-                                        ]
-                                    }
-                                ],
-                                "polyline": [],
-                                "children": {},
-                            }
-                        ]
-                    }
+def test_process_asset_with_external_id_containing_slash(tmp_path: Path):
+    asset = {
+        "latestLabel": {
+            "jsonResponse": {
+                "JOB_0": {
+                    "annotations": [
+                        {
+                            "categories": [{"name": "OBJECT_A"}],
+                            "mid": "20230111125258113-44528",
+                            "type": "rectangle",
+                            "boundingPoly": [
+                                {
+                                    "normalizedVertices": [
+                                        {"x": 0.6101435505380516, "y": 0.7689773770786136},
+                                        {"x": 0.6101435505380516, "y": 0.39426226491370664},
+                                        {"x": 0.8962087421313937, "y": 0.39426226491370664},
+                                        {"x": 0.8962087421313937, "y": 0.7689773770786136},
+                                    ]
+                                }
+                            ],
+                            "polyline": [],
+                            "children": {},
+                        }
+                    ]
                 }
-            },
-            "externalId": "a/b.png",
-        }
-        label_path = Path(f) / "labels"
-        _process_asset(asset, label_path)
+            }
+        },
+        "externalId": "a/b.png",
+    }
+    label_path = Path(tmp_path) / "labels"
+    _process_asset(asset, label_path)
 
-        assert Path(label_path / "a/b.png.geojson").is_file()
+    assert Path(label_path / "a/b.png.geojson").is_file()

--- a/tests/unit/services/export/test_geojson.py
+++ b/tests/unit/services/export/test_geojson.py
@@ -6,7 +6,7 @@ from zipfile import ZipFile
 import pytest_mock
 
 from kili.presentation.client.label import LabelClientMethods
-from kili.services.export.format.geojson import GeoJsonExporter
+from kili.services.export.format.geojson import GeoJsonExporter, _process_asset
 
 
 def test_kili_export_labels_geojson(mocker: pytest_mock.MockerFixture):
@@ -64,3 +64,39 @@ def test_kili_export_labels_geojson(mocker: pytest_mock.MockerFixture):
 
     assert output["type"] == "FeatureCollection"
     assert len(output["features"]) == 5  # 5 annotations in geotiff_image_project_assets.json
+
+
+def test_process_asset_with_external_id_containing_slash():
+    with TemporaryDirectory() as f:
+        asset = {
+            "latestLabel": {
+                "jsonResponse": {
+                    "JOB_0": {
+                        "annotations": [
+                            {
+                                "categories": [{"name": "OBJECT_A"}],
+                                "mid": "20230111125258113-44528",
+                                "type": "rectangle",
+                                "boundingPoly": [
+                                    {
+                                        "normalizedVertices": [
+                                            {"x": 0.6101435505380516, "y": 0.7689773770786136},
+                                            {"x": 0.6101435505380516, "y": 0.39426226491370664},
+                                            {"x": 0.8962087421313937, "y": 0.39426226491370664},
+                                            {"x": 0.8962087421313937, "y": 0.7689773770786136},
+                                        ]
+                                    }
+                                ],
+                                "polyline": [],
+                                "children": {},
+                            }
+                        ]
+                    }
+                }
+            },
+            "externalId": "a/b.png",
+        }
+        label_path = Path(f) / "labels"
+        _process_asset(asset, label_path)
+
+        assert Path(label_path / "a/b.png.geojson").is_file()

--- a/tests/unit/services/export/test_kili.py
+++ b/tests/unit/services/export/test_kili.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from tempfile import TemporaryDirectory
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 from zipfile import ZipFile
 
 import pytest_mock
@@ -479,3 +479,50 @@ def test_kili_export_labels_non_normalized_video(mocker: pytest_mock.MockerFixtu
                 output = json.load(f)
 
     assert output == video_project_asset_unnormalized
+
+
+def test_save_assets_export_with_external_id_containing_slash(mocker: pytest_mock.MockerFixture):
+    with TemporaryDirectory() as export_root_folder:
+        mocker.patch.object(KiliExporter, "__init__", return_value=None)
+        exporter = KiliExporter()  # type: ignore  # pylint: disable=no-value-for-parameter
+        exporter.normalized_coordinates = False
+        exporter.logger = mocker.MagicMock()
+        exporter.with_assets = True
+        exporter.single_file = False
+        exporter.export_root_folder = Path(export_root_folder)
+        exporter.label_format = "kili"
+        exporter.project_id = "fake_proj_id"
+        exporter.export_type = "latest"
+        exporter.project = {
+            "id": "fake_proj_id",
+            "title": "fake_proj_title",
+            "inputType": "IMAGE",
+            "jsonInterface": {
+                "jobs": {
+                    "OBJECT_DETECTION_JOB": {
+                        "content": {
+                            "categories": {"A": {"children": [], "color": "#472CED", "name": "A"}},
+                            "input": "radio",
+                        },
+                        "instruction": "BBOX",
+                        "mlTask": "OBJECT_DETECTION",
+                        "required": 1,
+                        "tools": ["rectangle"],
+                        "isChild": False,
+                        "models": {"tracking": {}},
+                    }
+                }
+            },
+        }
+        with NamedTemporaryFile() as f:
+            f.write(b"")
+            assets = [
+                {
+                    "externalId": "a/b.png",
+                    "content": f.name,
+                    "jsonContent": f.name,
+                }
+            ]
+            with TemporaryDirectory() as export_folder:
+                exporter._save_assets_export(assets, Path(export_folder))  # pylint: disable=protected-access
+                assert Path(exporter.base_folder / "labels/a/b.png.json").is_file()

--- a/tests/unit/services/export/test_kili.py
+++ b/tests/unit/services/export/test_kili.py
@@ -481,48 +481,49 @@ def test_kili_export_labels_non_normalized_video(mocker: pytest_mock.MockerFixtu
     assert output == video_project_asset_unnormalized
 
 
-def test_save_assets_export_with_external_id_containing_slash(mocker: pytest_mock.MockerFixture):
-    with TemporaryDirectory() as export_root_folder:
-        mocker.patch.object(KiliExporter, "__init__", return_value=None)
-        exporter = KiliExporter()  # type: ignore  # pylint: disable=no-value-for-parameter
-        exporter.normalized_coordinates = False
-        exporter.logger = mocker.MagicMock()
-        exporter.with_assets = True
-        exporter.single_file = False
-        exporter.export_root_folder = Path(export_root_folder)
-        exporter.label_format = "kili"
-        exporter.project_id = "fake_proj_id"
-        exporter.export_type = "latest"
-        exporter.project = {
-            "id": "fake_proj_id",
-            "title": "fake_proj_title",
-            "inputType": "IMAGE",
-            "jsonInterface": {
-                "jobs": {
-                    "OBJECT_DETECTION_JOB": {
-                        "content": {
-                            "categories": {"A": {"children": [], "color": "#472CED", "name": "A"}},
-                            "input": "radio",
-                        },
-                        "instruction": "BBOX",
-                        "mlTask": "OBJECT_DETECTION",
-                        "required": 1,
-                        "tools": ["rectangle"],
-                        "isChild": False,
-                        "models": {"tracking": {}},
-                    }
+def test_save_assets_export_with_external_id_containing_slash(
+    mocker: pytest_mock.MockerFixture, tmp_path: Path
+):
+    mocker.patch.object(KiliExporter, "__init__", return_value=None)
+    exporter = KiliExporter()  # type: ignore  # pylint: disable=no-value-for-parameter
+    exporter.normalized_coordinates = False
+    exporter.logger = mocker.MagicMock()
+    exporter.with_assets = True
+    exporter.single_file = False
+    exporter.export_root_folder = tmp_path
+    exporter.label_format = "kili"
+    exporter.project_id = "fake_proj_id"  # type: ignore
+    exporter.export_type = "latest"
+    exporter.project = {
+        "id": "fake_proj_id",
+        "title": "fake_proj_title",
+        "inputType": "IMAGE",
+        "jsonInterface": {
+            "jobs": {
+                "OBJECT_DETECTION_JOB": {
+                    "content": {
+                        "categories": {"A": {"children": [], "color": "#472CED", "name": "A"}},
+                        "input": "radio",
+                    },
+                    "instruction": "BBOX",
+                    "mlTask": "OBJECT_DETECTION",
+                    "required": 1,
+                    "tools": ["rectangle"],
+                    "isChild": False,
+                    "models": {"tracking": {}},
                 }
-            },
-        }
-        with NamedTemporaryFile() as f:
-            f.write(b"")
-            assets = [
-                {
-                    "externalId": "a/b.png",
-                    "content": f.name,
-                    "jsonContent": f.name,
-                }
-            ]
-            with TemporaryDirectory() as export_folder:
-                exporter._save_assets_export(assets, Path(export_folder))  # pylint: disable=protected-access
-                assert Path(exporter.base_folder / "labels/a/b.png.json").is_file()
+            }
+        },
+    }
+    with NamedTemporaryFile() as f:
+        f.write(b"")
+        assets = [
+            {
+                "externalId": "a/b.png",
+                "content": f.name,
+                "jsonContent": f.name,
+            }
+        ]
+        export_folder = tmp_path / "export_folder"
+        exporter._save_assets_export(assets, Path(export_folder))  # pylint: disable=protected-access
+        assert Path(exporter.base_folder / "labels/a/b.png.json").is_file()

--- a/tests/unit/services/export/test_voc.py
+++ b/tests/unit/services/export/test_voc.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from tempfile import TemporaryDirectory
 
 import pytest
 
@@ -71,7 +70,7 @@ def test_when_exporting_to_voc_given_a_project_with_data_connection_then_it_shou
         )
 
 
-def test_process_asset_image_with_external_id():
+def test_process_asset_image_with_external_id(tmp_path: Path):
     asset = {
         "latestLabel": {
             "jsonResponse": {
@@ -102,7 +101,6 @@ def test_process_asset_image_with_external_id():
         "resolution": {"width": 1920, "height": 1080},
         "content": "fakecontent",
     }
-    with TemporaryDirectory() as f:
-        label_path = Path(f) / "labels"
-        _process_asset(asset, label_path, "IMAGE", ["JOB_0"])
-        assert Path(label_path / "a/b.png.xml").is_file()
+    label_path = Path(tmp_path) / "labels"
+    _process_asset(asset, label_path, "IMAGE", ["JOB_0"])
+    assert Path(label_path / "a/b.png.xml").is_file()

--- a/tests/unit/services/export/test_yolo.py
+++ b/tests/unit/services/export/test_yolo.py
@@ -416,12 +416,11 @@ names: ['F', 'G']
             )
 
 
-def test_write_labels_to_file_with_external_id_containing_slash():
-    with TemporaryDirectory() as directory:
-        _write_labels_to_file(
-            directory,
-            "image/1.jpg",
-            [(0, 0.501415026274802, 0.5296278884310182, 0.6727472455849373, 0.5381320101586394)],
-        )
+def test_write_labels_to_file_with_external_id_containing_slash(tmp_path: Path):
+    _write_labels_to_file(
+        tmp_path,
+        "image/1.jpg",
+        [(0, 0.501415026274802, 0.5296278884310182, 0.6727472455849373, 0.5381320101586394)],
+    )
 
-        assert (directory / "image" / "1.jpg.txt").is_file()
+    assert (tmp_path / "image" / "1.jpg.txt").is_file()

--- a/tests/unit/services/export/test_yolo.py
+++ b/tests/unit/services/export/test_yolo.py
@@ -13,6 +13,7 @@ from kili.services.export.format.yolo import (
     _convert_from_kili_to_yolo_format,
     _process_asset,
     _write_class_file,
+    _write_labels_to_file,
 )
 from kili.utils.tempfile import TemporaryDirectory
 from tests.fakes.fake_data import (
@@ -413,3 +414,14 @@ names: ['F', 'G']
                 Path(f"{extract_folder}/POLYGON_JOB/labels/trees.txt").read_text()
                 == "0 0.75 0.23 0.35 0.22 0.07 0.35\n"
             )
+
+
+def test_write_labels_to_file_with_external_id_containing_slash():
+    with TemporaryDirectory() as directory:
+        _write_labels_to_file(
+            directory,
+            "image/1.jpg",
+            [(0, 0.501415026274802, 0.5296278884310182, 0.6727472455849373, 0.5381320101586394)],
+        )
+
+        assert (directory / "image" / "1.jpg.txt").is_file()


### PR DESCRIPTION
for example, `as/set.png` will be exported as : 

- labels/
  - as /
    - set.png