### PR TITLE
feat(lab-2616): add contentTypes to compute dataConnection differences

### DIFF
--- a/src/kili/adapters/kili_api_gateway/cloud_storage/mappers.py
+++ b/src/kili/adapters/kili_api_gateway/cloud_storage/mappers.py
@@ -48,6 +48,7 @@ def compute_data_connection_difference_data_mapper(
     return {
         "blobPaths": data.blob_paths,
         "warnings": data.warnings,
+        "contentTypes": data.content_types,
     }
 
 

--- a/src/kili/adapters/kili_api_gateway/cloud_storage/types.py
+++ b/src/kili/adapters/kili_api_gateway/cloud_storage/types.py
@@ -30,6 +30,7 @@ class DataConnectionComputeDifferencesKiliAPIGatewayInput:
 
     blob_paths: List[str]
     warnings: List[str]
+    content_types: List[str]
 
 
 @dataclass

--- a/src/kili/use_cases/cloud_storage/__init__.py
+++ b/src/kili/use_cases/cloud_storage/__init__.py
@@ -325,7 +325,7 @@ def _compute_differences(
             " Data connection is already currently checking."
         )
 
-    blob_paths = warnings = None
+    blob_paths = warnings = content_types = None
 
     # for azure using credentials, it is required to provide the blob paths to compute the diffs
     if (
@@ -346,7 +346,11 @@ def _compute_differences(
         project_input_type = kili_api_gateway.get_project(
             project_id=data_connection["projectId"], fields=("inputType",)
         )["inputType"]
-        blob_paths, warnings = get_blob_paths_azure_data_connection_with_service_credentials(
+        (
+            blob_paths,
+            warnings,
+            content_types,
+        ) = get_blob_paths_azure_data_connection_with_service_credentials(
             input_type=project_input_type,
             data_connection=data_connection,
             data_integration=data_integration,
@@ -357,9 +361,9 @@ def _compute_differences(
         fields=("id",),
         data=(
             DataConnectionComputeDifferencesKiliAPIGatewayInput(
-                blob_paths=blob_paths, warnings=warnings
+                blob_paths=blob_paths, warnings=warnings, content_types=content_types
             )
-            if blob_paths is not None and warnings is not None
+            if blob_paths is not None and warnings is not None and content_types is not None
             else None
         ),
     )

--- a/src/kili/use_cases/cloud_storage/azure.py
+++ b/src/kili/use_cases/cloud_storage/azure.py
@@ -11,7 +11,7 @@ from kili.domain.project import InputType
 
 def get_blob_paths_azure_data_connection_with_service_credentials(
     data_connection: Dict, data_integration: Dict, input_type: InputType
-) -> Tuple[List[str], List[str]]:
+) -> Tuple[List[str], List[str], List[str]]:
     """Get the blob paths for an Azure data connection using service credentials."""
     if not (data_integration["azureSASToken"] and data_integration["azureConnectionURL"]):
         raise ValueError(
@@ -81,9 +81,10 @@ class AzureBucket:
 
     def get_blob_paths_azure_data_connection_with_service_credentials(
         self, selected_folders: Optional[List[str]], input_type: InputType
-    ) -> Tuple[List[str], List[str]]:
+    ) -> Tuple[List[str], List[str], List[str]]:
         """Get the blob paths for an Azure data connection using service credentials."""
         blob_paths = []
+        content_types = []
         warnings = set()
         for blob in self.storage_bucket.list_blobs():
             if not hasattr(blob, "name") or not isinstance(blob.name, str):
@@ -114,8 +115,9 @@ class AzureBucket:
 
             else:
                 blob_paths.append(blob.name)
+                content_types.append(blob.content_settings.content_type)
 
-        return blob_paths, list(warnings)
+        return blob_paths, list(warnings), content_types
 
     @staticmethod
     def _is_content_type_compatible_with_input_type(

--- a/tests/integration/adapters/kili_api_gateway/test_cloud_storage.py
+++ b/tests/integration/adapters/kili_api_gateway/test_cloud_storage.py
@@ -40,7 +40,9 @@ def test_given_gateway_when_calling_compute_diff_with_data_then_it_works(
     gateway.compute_data_connection_differences(
         data_connection_id=DataConnectionId("fake_data_con_id"),
         data=DataConnectionComputeDifferencesKiliAPIGatewayInput(
-            blob_paths=["1.jpg", "2.jpg"], warnings=["warning1", "warning2"]
+            blob_paths=["1.jpg", "2.jpg"],
+            warnings=["warning1", "warning2"],
+            content_types=["image/jpeg", "image/jpeg"],
         ),
         fields=("id",),
     )
@@ -50,7 +52,11 @@ def test_given_gateway_when_calling_compute_diff_with_data_then_it_works(
         get_compute_data_connection_differences_mutation(" id"),
         {
             "where": {"id": "fake_data_con_id"},
-            "data": {"blobPaths": ["1.jpg", "2.jpg"], "warnings": ["warning1", "warning2"]},
+            "data": {
+                "blobPaths": ["1.jpg", "2.jpg"],
+                "warnings": ["warning1", "warning2"],
+                "contentTypes": ["image/jpeg", "image/jpeg"],
+            },
         },
     )
 


### PR DESCRIPTION
This MR should not be merged yet, we must wait for the contentTypes parameter to be added in the computeDifferences mutation of the API.