### PR TITLE
test: remove cron triggers on e2e tests on LTS instances

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -55,7 +55,6 @@ on:
       - main
   schedule:
     - cron: "0 7,15 * * 1-5" # MAIN_STAGING
-    - cron: "0 9 * * 1-5" # MAIN_LTS
     - cron: "0 11 * * 1-5" # PREV_RELEASE_TESTS_STAGING
     - cron: "0 13 * * 1-5" # LTS_CYCLE_FIRST_SDK_STAGING
 


### PR DESCRIPTION
LTS instances start on demand, so they might be off when test triggers.

