### PR TITLE
fix(LAB-2676): add sleep for wait for inference in notebook

### DIFF
--- a/docs/sdk/tutorials/inference_labels.md
+++ b/docs/sdk/tutorials/inference_labels.md
@@ -199,6 +199,8 @@ kili.append_labels(
 )
 ```
 
+Note: that the inference metric could appear as None at the beginning (as those calculs can be complex we choose to do it in a separate way and so the return could be delayed). Just wait a bit before trigger the fetch of the labels.
+
 You can now fetch the agreement between the human and the model, for human labels:
 
 

--- a/recipes/inference_labels.ipynb
+++ b/recipes/inference_labels.ipynb
@@ -35,6 +35,19 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
     "tags": []
    },
    "outputs": [],
@@ -340,6 +353,26 @@
     "    asset_external_id_array=[asset[\"external_id\"] for asset in stream_of_assets],\n",
     "    label_type=\"DEFAULT\",\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove_cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "time.sleep(40)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note: that the inference metric could appear as None at the beginning (as those calculs can be complex we choose to do it in a separate way and so the return could be delayed). Just wait a bit before trigger the fetch of the labels."
    ]
   },
   {
@@ -668,6 +701,20 @@
     "    label_type=\"INFERENCE\",\n",
     "    model_name=\"my_model\",\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove_cell",
+     "remove"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "time.sleep(40)"
    ]
   },
   {


### PR DESCRIPTION
The computation of inference, honeypot and reviewScore are now compute asynchronously so we need to wait for the data to be compute in the test.
