### PR TITLE
fix: ignore json loads errors

### DIFF
--- a/src/kili/adapters/kili_api_gateway/asset/formatters.py
+++ b/src/kili/adapters/kili_api_gateway/asset/formatters.py
@@ -9,14 +9,23 @@ from kili.domain.types import ListOrTuple
 def load_asset_json_fields(asset: Dict, fields: ListOrTuple[str]) -> Dict:
     """Load json fields of an asset."""
     if "jsonMetadata" in fields:
-        asset["jsonMetadata"] = json.loads(asset.get("jsonMetadata", "{}"))
+        try:
+            asset["jsonMetadata"] = json.loads(asset.get("jsonMetadata", "{}"))
+        except json.JSONDecodeError:
+            asset["jsonMetadata"] = {}
 
     if "labels.jsonResponse" in fields:
         asset_labels = asset.get("labels", [])
         for label in asset_labels:
-            label["jsonResponse"] = json.loads(label["jsonResponse"])
+            try:
+                label["jsonResponse"] = json.loads(label["jsonResponse"])
+            except json.JSONDecodeError:
+                label["jsonResponse"] = {}
 
     if "latestLabel.jsonResponse" in fields and asset.get("latestLabel") is not None:
-        asset["latestLabel"]["jsonResponse"] = json.loads(asset["latestLabel"]["jsonResponse"])
+        try:
+            asset["latestLabel"]["jsonResponse"] = json.loads(asset["latestLabel"]["jsonResponse"])
+        except json.JSONDecodeError:
+            asset["latestLabel"]["jsonResponse"] = {}
 
     return asset

--- a/src/kili/adapters/kili_api_gateway/label/formatters.py
+++ b/src/kili/adapters/kili_api_gateway/label/formatters.py
@@ -9,6 +9,9 @@ from kili.domain.types import ListOrTuple
 def load_label_json_fields(label: Dict, fields: ListOrTuple[str]) -> Dict:
     """Load json fields of a label."""
     if "jsonResponse" in fields:
-        label["jsonResponse"] = json.loads(label.get("jsonResponse", "{}"))
+        try:
+            label["jsonResponse"] = json.loads(label.get("jsonResponse", "{}"))
+        except json.JSONDecodeError:
+            label["jsonResponse"] = {}
 
     return label

--- a/src/kili/adapters/kili_api_gateway/project/formatters.py
+++ b/src/kili/adapters/kili_api_gateway/project/formatters.py
@@ -11,5 +11,8 @@ PROJECT_JSON_FIELDS = ("jsonInterface",)
 def load_project_json_fields(project: Dict, fields: ListOrTuple[str]) -> Dict:
     """Load json fields of a project."""
     if "jsonInterface" in fields and isinstance(project.get("jsonInterface"), str):
-        project["jsonInterface"] = json.loads(project["jsonInterface"])
+        try:
+            project["jsonInterface"] = json.loads(project["jsonInterface"])
+        except json.JSONDecodeError:
+            project["jsonInterface"] = {}
     return project

--- a/src/kili/services/copy_project/__init__.py
+++ b/src/kili/services/copy_project/__init__.py
@@ -205,7 +205,10 @@ class ProjectCopier:  # pylint: disable=too-few-public-methods
         # ocrMetadata field of assets need to be merged with jsonMetadata field
         for asset in assets:
             if isinstance(asset["jsonMetadata"], str):
-                asset["jsonMetadata"] = json.loads(asset["jsonMetadata"])
+                try:
+                    asset["jsonMetadata"] = json.loads(asset["jsonMetadata"])
+                except json.JSONDecodeError:
+                    asset["jsonMetadata"] = {}
             if asset["ocrMetadata"]:
                 asset["jsonMetadata"] = {**asset["jsonMetadata"], **asset["ocrMetadata"]}
 


### PR DESCRIPTION
In some cases, backend may return an empty string when having no values for jsonMetdata. In order to avoid blocking errors when backend return an invalid or empty json field, we consider the field as not set.

