### PR TITLE
chore(lab-2851): add a warning when trying to filter by more than 10+ partial external id

### DIFF
--- a/src/kili/adapters/kili_api_gateway/asset/mappers.py
+++ b/src/kili/adapters/kili_api_gateway/asset/mappers.py
@@ -1,10 +1,25 @@
 """GraphQL payload data mappers for asset operations."""
 
+import warnings
+
 from kili.domain.asset import AssetFilters
+
+MAX_PARTIAL_EXTERNAL_IDS_FILTER = 10
 
 
 def asset_where_mapper(filters: AssetFilters):
     """Build the GraphQL AssetWhere variable to be sent in an operation."""
+    if (
+        filters.external_id_in is not None
+        and len(filters.external_id_in) > MAX_PARTIAL_EXTERNAL_IDS_FILTER
+    ):
+        warnings.warn(
+            f"Requesting more than {MAX_PARTIAL_EXTERNAL_IDS_FILTER} partial external IDs"
+            "in a single query is deprecated. You can use the `external_id_strictly_in`"
+            f"field to filter by more than {MAX_PARTIAL_EXTERNAL_IDS_FILTER} external IDs. "
+            "This limit will be enforced in next versions.",
+            stacklevel=5,
+        )
     return {
         "id": filters.asset_id,
         "project": {


### PR DESCRIPTION
Querying with a lot of partial external id is costly for database.

In next releases, we will limit this search. We add a warning in the meantime.

---

<img width="1369" alt="exact_no_warning" src="https://github.com/kili-technology/kili-python-sdk/assets/83211006/9fd3af14-3975-4bac-8b13-7653caf906ec">

<img width="1361" alt="partial_external_id_warning" src="https://github.com/kili-technology/kili-python-sdk/assets/83211006/ebdacc2d-3ff9-44c9-8b52-1baa2aa47520">
