### PR TITLE
feat(LAB-2828): manage native video imports asynchronously

### DIFF
--- a/src/kili/services/asset_import/base.py
+++ b/src/kili/services/asset_import/base.py
@@ -7,7 +7,7 @@ import os
 import warnings
 from concurrent.futures import ThreadPoolExecutor
 from itertools import repeat
-from json import dumps
+from json import dumps, loads
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -207,9 +207,40 @@ class BaseBatchImporter:  # pylint: disable=too-many-instance-attributes
         """Builds an url from the parts."""
         return "/".join(parts)
 
+    @staticmethod
+    def are_native_videos(assets) -> bool:
+        """Determine if assets should be imported asynchronously and cut into frames."""
+        should_use_native_video_array = []
+        for asset in assets:
+            json_metadata = asset.get("json_metadata", "{}")
+            json_metadata_ = loads(json_metadata)
+            processing_parameters = json_metadata_.get("processingParameters", {})
+            should_use_native_video_array.append(
+                processing_parameters.get("shouldUseNativeVideo", True)
+            )
+        if all(should_use_native_video_array):
+            return True
+        if all(not b for b in should_use_native_video_array):
+            return False
+        raise ImportValidationError(
+            """
+            Cannot upload videos to split into frames
+            and video to keep as native in the same time.
+            Please separate the assets into 2 calls
+            """
+        )
+
     def _async_import_to_kili(self, assets: List[KiliResolverAsset]):
         """Import assets with asynchronous resolver."""
-        upload_type = "GEO_SATELLITE" if self.input_type == "IMAGE" else "VIDEO"
+        if self.input_type == "IMAGE":
+            upload_type = "GEO_SATELLITE"
+        elif self.input_type in ("VIDEO", "VIDEO_LEGACY"):
+            upload_type = "NATIVE_VIDEO" if self.are_native_videos(assets) else "FRAME_VIDEO"
+        else:
+            raise NotImplementedError(
+                f"Import of {self.input_type} assets is not supported in async calls"
+            )
+
         content = (
             {
                 "multiLayerContentArray": [asset["multi_layer_content"] for asset in assets],

--- a/tests/unit/services/asset_import/test_import_video.py
+++ b/tests/unit/services/asset_import/test_import_video.py
@@ -36,13 +36,12 @@ class VideoTestCase(ImportTestCase):
                 }
             }
         )
-        expected_parameters = self.get_expected_sync_call(
+        expected_parameters = self.get_expected_async_call(
             ["https://signed_url?id=id"],
             ["local video file to native"],
             ["unique_id"],
-            [False],
-            [""],
             [expected_json_metadata],
+            "NATIVE_VIDEO",
         )
         self.kili.graphql_client.execute.assert_called_with(*expected_parameters)
 
@@ -61,13 +60,12 @@ class VideoTestCase(ImportTestCase):
                 }
             }
         )
-        expected_parameters = self.get_expected_sync_call(
+        expected_parameters = self.get_expected_async_call(
             ["https://hosted-data"],
             ["hosted file"],
             ["unique_id"],
-            [False],
-            [""],
             [expected_json_metadata],
+            "NATIVE_VIDEO",
         )
         self.kili.graphql_client.execute.assert_called_with(*expected_parameters)
 
@@ -89,13 +87,12 @@ class VideoTestCase(ImportTestCase):
                 }
             }
         )
-        expected_parameters = self.get_expected_sync_call(
+        expected_parameters = self.get_expected_async_call(
             ["https://hosted-data"],
             ["hosted file"],
             ["unique_id"],
-            [False],
-            [""],
             [expected_json_metadata],
+            "NATIVE_VIDEO",
         )
         self.kili.graphql_client.execute.assert_called_with(*expected_parameters)
 
@@ -136,7 +133,7 @@ class VideoTestCase(ImportTestCase):
             ["local video to frames"],
             ["unique_id"],
             [expected_json_metadata],
-            "VIDEO",
+            "FRAME_VIDEO",
         )
         self.kili.graphql_client.execute.assert_called_with(*expected_parameters)
 
@@ -170,7 +167,7 @@ class VideoTestCase(ImportTestCase):
             ["changing fps"],
             ["unique_id"],
             [expected_json_metadata],
-            "VIDEO",
+            "FRAME_VIDEO",
         )
         self.kili.graphql_client.execute.assert_called_with(*expected_parameters)
 
@@ -296,13 +293,12 @@ class VideoTestCase(ImportTestCase):
                 },
             }
         )
-        expected_parameters = self.get_expected_sync_call(
+        expected_parameters = self.get_expected_async_call(
             ["https://hosted-data"],
             ["with metadata"],
             ["unique_id"],
-            [False],
-            [""],
             [expected_json_metadata],
+            "NATIVE_VIDEO",
         )
         self.kili.graphql_client.execute.assert_called_with(*expected_parameters)
 
@@ -332,12 +328,11 @@ class VideoLegacyTestCase(ImportTestCase):
                 }
             }
         )
-        expected_parameters = self.get_expected_sync_call(
+        expected_parameters = self.get_expected_async_call(
             ["https://hosted-data"],
             ["hosted file"],
             ["unique_id"],
-            [False],
-            [""],
             [expected_json_metadata],
+            "NATIVE_VIDEO",
         )
         self.kili.graphql_client.execute.assert_called_with(*expected_parameters)


### PR DESCRIPTION
This MR adds : 
- Async import management for all videos (NATIVE_VIDEO and FRAME_VIDEO)
- adds a limit (5 min) to wait for imported assets in case of async imports