### PR TITLE
feat(LAB-2944): add file data conversion prior to import for new llm format

### DIFF
--- a/src/kili/services/asset_import/exceptions.py
+++ b/src/kili/services/asset_import/exceptions.py
@@ -13,6 +13,10 @@ class ImportValidationError(Exception):
     """Raised when data given to import does not follow a right format."""
 
 
+class ImportFileConversionError(Exception):
+    """Raised when an error occurs during processing a llm file for conversion."""
+
+
 class UploadFromLocalDataForbiddenError(Exception):
     """Raised when data given to import does not follow a right format."""
 

--- a/src/kili/services/asset_import/helpers.py
+++ b/src/kili/services/asset_import/helpers.py
@@ -72,11 +72,14 @@ def process_json(data):
             }
         )
 
+    chat_item_ids = "_".join(item_ids)
+
     # Prepare additional_json_metadata
     additional_json_metadata = {
         "chat_id": chat_id,
         "models": "_".join(models[-2:]),  # Join the last two models
-        "chat_item_ids": "_".join(item_ids),  # Concatenate all item IDs
+        "chat_item_ids": chat_item_ids,  # Concatenate all item IDs
+        "text": f"Chat_id: {chat_id}\n\nChat_item_ids: {chat_item_ids}",
     }
 
     return transformed_data, additional_json_metadata

--- a/src/kili/services/asset_import/helpers.py
+++ b/src/kili/services/asset_import/helpers.py
@@ -1,0 +1,82 @@
+"""Helpers for the asset_import."""
+
+import warnings
+
+
+def is_chat_format(data, required_keys):
+    """Checks if llm file data is in chat format."""
+    if isinstance(data, dict):
+        return False
+
+    if not isinstance(data, list):
+        warnings.warn("Json file is not an array.")
+        return False
+
+    # Check each item in the array
+    for item in data:
+        # Ensure each item is a dictionary with the required keys
+        if not isinstance(item, dict) or not required_keys.issubset(item.keys()):
+            missing_keys = required_keys - set(item.keys())
+            warnings.warn(f"Array item missing keys : {missing_keys}", stacklevel=3)
+            return False
+    return True
+
+
+def process_json(data):
+    """Processes the llm file data : converts it to Kili format is chat format is present."""
+    # Initialize the transformed structure
+    transformed_data = {"prompts": [], "type": "markdown", "version": "0.1"}
+
+    # Temporary variables for processing
+    current_prompt = None
+    completions = []
+    models = []  # To store models for determining the last two
+    item_ids = []  # To store all item IDs for concatenation
+    chat_id = None
+
+    for item in data:
+        chat_id = item.get("chat_id", None)
+        item_ids.append(item["id"])
+
+        # Check if the model is null (indicating a prompt)
+        if item["model"] is None:
+            # If there's an existing prompt being processed, add it to the prompts list
+            if current_prompt is not None:
+                transformed_data["prompts"].append(
+                    {
+                        "completions": completions,
+                        "prompt": current_prompt["content"],
+                    }
+                )
+                completions = []  # Reset completions for the next prompt
+
+            # Update the current prompt
+            current_prompt = item
+        else:
+            # Add completion to the current prompt
+            completions.append(
+                {
+                    "content": item["content"],
+                    "title": item["role"],
+                }
+            )
+            # Collect model for this item
+            models.append(item["model"])
+
+    # Add the last prompt if it exists
+    if current_prompt is not None:
+        transformed_data["prompts"].append(
+            {
+                "completions": completions,
+                "prompt": current_prompt["content"],
+            }
+        )
+
+    # Prepare additional_json_metadata
+    additional_json_metadata = {
+        "chat_id": chat_id,
+        "models": "_".join(models[-2:]),  # Join the last two models
+        "chat_item_ids": "_".join(item_ids),  # Concatenate all item IDs
+    }
+
+    return transformed_data, additional_json_metadata

--- a/src/kili/services/asset_import/llm.py
+++ b/src/kili/services/asset_import/llm.py
@@ -21,6 +21,7 @@ class LLMDataType(Enum):
     """LLM data type."""
 
     DICT = "DICT"
+    LIST = "LIST"
     LOCAL_FILE = "LOCAL_FILE"
     HOSTED_FILE = "HOSTED_FILE"
 
@@ -46,7 +47,29 @@ class LLMDataImporter(BaseAbstractAssetImporter):
             return LLMDataType.LOCAL_FILE
         if all(isinstance(content, dict) for content in content_array):
             return LLMDataType.DICT
+        if all(isinstance(content, list) for content in content_array):
+            return LLMDataType.LIST
         raise ImportValidationError("Invalid value in content for LLM project.")
+
+    @staticmethod
+    def transform_asset_content(asset_content, json_metadata):
+        """Transform asset content."""
+        content, additional_json_metadata = process_json(asset_content)
+        transformed_asset_content = json.dumps(content).encode("utf-8")
+
+        json_metadata_dict = {}
+        if json_metadata and isinstance(json_metadata, str):
+            json_metadata_dict = json.loads(json_metadata)
+        elif json_metadata:
+            json_metadata_dict = json_metadata
+
+        merged_json_metadata = {
+            **json_metadata_dict,
+            **additional_json_metadata,
+        }
+        changed_json_metadata = json.dumps(merged_json_metadata)
+
+        return transformed_asset_content, changed_json_metadata
 
     def import_assets(self, assets: List[AssetLike]):
         """Import LLM assets into Kili."""
@@ -63,27 +86,16 @@ class LLMDataImporter(BaseAbstractAssetImporter):
             for asset in assets:
                 file_path = asset.get("content", None)
                 json_metadata = asset.get("json_metadata", "{}")
-
                 if file_path and isinstance(file_path, str):
                     try:
                         with open(file_path, encoding="utf-8") as file:
                             data = json.load(file)
 
                             if is_chat_format(data, {"role", "content", "id", "chat_id", "model"}):
-                                content, additional_json_metadata = process_json(data)
-                                asset["content"] = json.dumps(content).encode("utf-8")
-
-                                json_metadata_dict = {}
-                                if json_metadata and isinstance(json_metadata, str):
-                                    json_metadata_dict = json.loads(json_metadata)
-                                elif json_metadata:
-                                    json_metadata_dict = json_metadata
-
-                                merged_json_metadata = {
-                                    **json_metadata_dict,
-                                    **additional_json_metadata,
-                                }
-                                asset["json_metadata"] = json.dumps(merged_json_metadata)
+                                (
+                                    asset["content"],
+                                    asset["json_metadata"],
+                                ) = self.transform_asset_content(data, json_metadata)
 
                                 batch_importer = JSONBatchImporter(
                                     self.kili, self.project_params, batch_params, self.pbar
@@ -99,10 +111,22 @@ class LLMDataImporter(BaseAbstractAssetImporter):
             batch_importer = ContentBatchImporter(
                 self.kili, self.project_params, batch_params, self.pbar
             )
-        elif data_type == LLMDataType.DICT:
+        elif data_type in (LLMDataType.DICT, LLMDataType.LIST):
             for asset in assets:
                 if "content" in asset and isinstance(asset["content"], dict):
                     asset["content"] = json.dumps(asset["content"]).encode("utf-8")
+                elif (
+                    "content" in asset
+                    and isinstance(asset["content"], list)
+                    and is_chat_format(
+                        asset["content"], {"role", "content", "id", "chat_id", "model"}
+                    )
+                ):
+                    json_metadata = asset.get("json_metadata", "{}")
+                    asset["content"], asset["json_metadata"] = self.transform_asset_content(
+                        asset["content"], json_metadata
+                    )
+
             batch_params = BatchParams(is_hosted=False, is_asynchronous=False)
             batch_importer = JSONBatchImporter(
                 self.kili, self.project_params, batch_params, self.pbar

--- a/tests/unit/services/asset_import/test_import_llm.py
+++ b/tests/unit/services/asset_import/test_import_llm.py
@@ -1,6 +1,8 @@
+import json
 from unittest.mock import patch
 
 from kili.services.asset_import import import_assets
+from kili.services.asset_import.helpers import process_json
 from tests.unit.services.asset_import.base import ImportTestCase
 from tests.unit.services.asset_import.mocks import (
     mocked_request_signed_urls,
@@ -26,6 +28,49 @@ class LLMTestCase(ImportTestCase):
             [False],
             [""],
             ["{}"],
+        )
+        self.kili.graphql_client.execute.assert_called_with(*expected_parameters)
+
+    def test_upload_from_one_local_file_in_chat_format(self, *_):
+        self.kili.kili_api_gateway.get_project.return_value = {"inputType": "LLM_RLHF"}
+        url = "https://storage.googleapis.com/label-public-staging/asset-test-sample/llm/test_llm_file_in_chat_format.json"
+        path = self.downloader(url)
+        assets = [{"content": path, "external_id": "local llm file in chat format"}]
+        import_assets(self.kili, self.project_id, assets)
+
+        expected_parameters = self.get_expected_sync_call(
+            ["https://signed_url?id=id"],
+            ["local llm file in chat format"],
+            ["unique_id"],
+            [False],
+            [""],
+            [
+                '{"chat_id": "6e4094947af4902cd252421aba9a077e8e4402dd", "models": "model-large_model-medium", "chat_item_ids": "0455df65c2d6bb821a9dc9108ac1d79964a0f571_4c28c86c4b22b3397691ce5cf27197fcf7e8fb2d_7326ff17cbfe7e3cb91b008cf0c496fcd17a1074_375b55d44af2c8c801992089c797df8e12605dfb_9231d8819ac96cc8a6c4b7780c301b796c3f8bf2"}'
+            ],
+        )
+        self.kili.graphql_client.execute.assert_called_with(*expected_parameters)
+
+    def test_upload_from_one_local_file_in_chat_format_with_given_json_metadata(self, *_):
+        self.kili.kili_api_gateway.get_project.return_value = {"inputType": "LLM_RLHF"}
+        url = "https://storage.googleapis.com/label-public-staging/asset-test-sample/llm/test_llm_file_in_chat_format.json"
+        path = self.downloader(url)
+        assets = [
+            {
+                "content": path,
+                "external_id": "local llm file in chat format with json metadata",
+                "json_metadata": '{ "customKey": "customValue" }',
+            }
+        ]
+        import_assets(self.kili, self.project_id, assets)
+        expected_parameters = self.get_expected_sync_call(
+            ["https://signed_url?id=id"],
+            ["local llm file in chat format with json metadata"],
+            ["unique_id"],
+            [False],
+            [""],
+            [
+                '{"customKey": "customValue", "chat_id": "6e4094947af4902cd252421aba9a077e8e4402dd", "models": "model-large_model-medium", "chat_item_ids": "0455df65c2d6bb821a9dc9108ac1d79964a0f571_4c28c86c4b22b3397691ce5cf27197fcf7e8fb2d_7326ff17cbfe7e3cb91b008cf0c496fcd17a1074_375b55d44af2c8c801992089c797df8e12605dfb_9231d8819ac96cc8a6c4b7780c301b796c3f8bf2"}'
+            ],
         )
         self.kili.graphql_client.execute.assert_called_with(*expected_parameters)
 
@@ -57,3 +102,45 @@ class LLMTestCase(ImportTestCase):
             ["https://signed_url?id=id"], ["dict"], ["unique_id"], [False], [""], ["{}"]
         )
         self.kili.graphql_client.execute.assert_called_with(*expected_parameters)
+
+    def test_process_json(self, *_):
+        url = "https://storage.googleapis.com/label-public-staging/asset-test-sample/llm/test_llm_file_in_chat_format.json"
+        path = self.downloader(url)
+
+        with open(path) as file:
+            data = json.load(file)
+
+            processed_data = process_json(data)
+
+            assert processed_data == (
+                {
+                    "prompts": [
+                        {
+                            "completions": [
+                                {"content": "text of the assistant answer", "title": "assistant"}
+                            ],
+                            "prompt": "text of the user instructions",
+                        },
+                        {
+                            "completions": [
+                                {
+                                    "content": "text of the assistant answer A",
+                                    "title": "assistant_A",
+                                },
+                                {
+                                    "content": "text of the assistant answer B",
+                                    "title": "assistant_B",
+                                },
+                            ],
+                            "prompt": "text of the user instructions",
+                        },
+                    ],
+                    "type": "markdown",
+                    "version": "0.1",
+                },
+                {
+                    "chat_id": "6e4094947af4902cd252421aba9a077e8e4402dd",
+                    "models": "model-large_model-medium",
+                    "chat_item_ids": "0455df65c2d6bb821a9dc9108ac1d79964a0f571_4c28c86c4b22b3397691ce5cf27197fcf7e8fb2d_7326ff17cbfe7e3cb91b008cf0c496fcd17a1074_375b55d44af2c8c801992089c797df8e12605dfb_9231d8819ac96cc8a6c4b7780c301b796c3f8bf2",
+                },
+            )

--- a/tests/unit/services/asset_import/test_import_llm.py
+++ b/tests/unit/services/asset_import/test_import_llm.py
@@ -45,7 +45,7 @@ class LLMTestCase(ImportTestCase):
             [False],
             [""],
             [
-                '{"chat_id": "6e4094947af4902cd252421aba9a077e8e4402dd", "models": "model-large_model-medium", "chat_item_ids": "0455df65c2d6bb821a9dc9108ac1d79964a0f571_4c28c86c4b22b3397691ce5cf27197fcf7e8fb2d_7326ff17cbfe7e3cb91b008cf0c496fcd17a1074_375b55d44af2c8c801992089c797df8e12605dfb_9231d8819ac96cc8a6c4b7780c301b796c3f8bf2"}'
+                '{"chat_id": "6e4094947af4902cd252421aba9a077e8e4402dd", "models": "model-large_model-medium", "chat_item_ids": "0455df65c2d6bb821a9dc9108ac1d79964a0f571_4c28c86c4b22b3397691ce5cf27197fcf7e8fb2d_7326ff17cbfe7e3cb91b008cf0c496fcd17a1074_375b55d44af2c8c801992089c797df8e12605dfb_9231d8819ac96cc8a6c4b7780c301b796c3f8bf2", "text": "Chat_id: 6e4094947af4902cd252421aba9a077e8e4402dd\\n\\nChat_item_ids: 0455df65c2d6bb821a9dc9108ac1d79964a0f571_4c28c86c4b22b3397691ce5cf27197fcf7e8fb2d_7326ff17cbfe7e3cb91b008cf0c496fcd17a1074_375b55d44af2c8c801992089c797df8e12605dfb_9231d8819ac96cc8a6c4b7780c301b796c3f8bf2"}'
             ],
         )
         self.kili.graphql_client.execute.assert_called_with(*expected_parameters)
@@ -69,7 +69,7 @@ class LLMTestCase(ImportTestCase):
             [False],
             [""],
             [
-                '{"customKey": "customValue", "chat_id": "6e4094947af4902cd252421aba9a077e8e4402dd", "models": "model-large_model-medium", "chat_item_ids": "0455df65c2d6bb821a9dc9108ac1d79964a0f571_4c28c86c4b22b3397691ce5cf27197fcf7e8fb2d_7326ff17cbfe7e3cb91b008cf0c496fcd17a1074_375b55d44af2c8c801992089c797df8e12605dfb_9231d8819ac96cc8a6c4b7780c301b796c3f8bf2"}'
+                '{"customKey": "customValue", "chat_id": "6e4094947af4902cd252421aba9a077e8e4402dd", "models": "model-large_model-medium", "chat_item_ids": "0455df65c2d6bb821a9dc9108ac1d79964a0f571_4c28c86c4b22b3397691ce5cf27197fcf7e8fb2d_7326ff17cbfe7e3cb91b008cf0c496fcd17a1074_375b55d44af2c8c801992089c797df8e12605dfb_9231d8819ac96cc8a6c4b7780c301b796c3f8bf2", "text": "Chat_id: 6e4094947af4902cd252421aba9a077e8e4402dd\\n\\nChat_item_ids: 0455df65c2d6bb821a9dc9108ac1d79964a0f571_4c28c86c4b22b3397691ce5cf27197fcf7e8fb2d_7326ff17cbfe7e3cb91b008cf0c496fcd17a1074_375b55d44af2c8c801992089c797df8e12605dfb_9231d8819ac96cc8a6c4b7780c301b796c3f8bf2"}'
             ],
         )
         self.kili.graphql_client.execute.assert_called_with(*expected_parameters)
@@ -155,7 +155,7 @@ class LLMTestCase(ImportTestCase):
             [False],
             [""],
             [
-                '{"chat_id": "6e4094947af4902cd252421aba9a077e8e4402dd", "models": "model-large_model-medium", "chat_item_ids": "0455df65c2d6bb821a9dc9108ac1d79964a0f571_4c28c86c4b22b3397691ce5cf27197fcf7e8fb2d_7326ff17cbfe7e3cb91b008cf0c496fcd17a1074_375b55d44af2c8c801992089c797df8e12605dfb_9231d8819ac96cc8a6c4b7780c301b796c3f8bf2"}'
+                '{"chat_id": "6e4094947af4902cd252421aba9a077e8e4402dd", "models": "model-large_model-medium", "chat_item_ids": "0455df65c2d6bb821a9dc9108ac1d79964a0f571_4c28c86c4b22b3397691ce5cf27197fcf7e8fb2d_7326ff17cbfe7e3cb91b008cf0c496fcd17a1074_375b55d44af2c8c801992089c797df8e12605dfb_9231d8819ac96cc8a6c4b7780c301b796c3f8bf2", "text": "Chat_id: 6e4094947af4902cd252421aba9a077e8e4402dd\\n\\nChat_item_ids: 0455df65c2d6bb821a9dc9108ac1d79964a0f571_4c28c86c4b22b3397691ce5cf27197fcf7e8fb2d_7326ff17cbfe7e3cb91b008cf0c496fcd17a1074_375b55d44af2c8c801992089c797df8e12605dfb_9231d8819ac96cc8a6c4b7780c301b796c3f8bf2"}'
             ],
         )
         self.kili.graphql_client.execute.assert_called_with(*expected_parameters)
@@ -213,7 +213,7 @@ class LLMTestCase(ImportTestCase):
             [False],
             [""],
             [
-                '{"customKey": "customValue", "chat_id": "6e4094947af4902cd252421aba9a077e8e4402dd", "models": "model-large_model-medium", "chat_item_ids": "0455df65c2d6bb821a9dc9108ac1d79964a0f571_4c28c86c4b22b3397691ce5cf27197fcf7e8fb2d_7326ff17cbfe7e3cb91b008cf0c496fcd17a1074_375b55d44af2c8c801992089c797df8e12605dfb_9231d8819ac96cc8a6c4b7780c301b796c3f8bf2"}'
+                '{"customKey": "customValue", "chat_id": "6e4094947af4902cd252421aba9a077e8e4402dd", "models": "model-large_model-medium", "chat_item_ids": "0455df65c2d6bb821a9dc9108ac1d79964a0f571_4c28c86c4b22b3397691ce5cf27197fcf7e8fb2d_7326ff17cbfe7e3cb91b008cf0c496fcd17a1074_375b55d44af2c8c801992089c797df8e12605dfb_9231d8819ac96cc8a6c4b7780c301b796c3f8bf2", "text": "Chat_id: 6e4094947af4902cd252421aba9a077e8e4402dd\\n\\nChat_item_ids: 0455df65c2d6bb821a9dc9108ac1d79964a0f571_4c28c86c4b22b3397691ce5cf27197fcf7e8fb2d_7326ff17cbfe7e3cb91b008cf0c496fcd17a1074_375b55d44af2c8c801992089c797df8e12605dfb_9231d8819ac96cc8a6c4b7780c301b796c3f8bf2"}'
             ],
         )
         self.kili.graphql_client.execute.assert_called_with(*expected_parameters)
@@ -257,5 +257,6 @@ class LLMTestCase(ImportTestCase):
                     "chat_id": "6e4094947af4902cd252421aba9a077e8e4402dd",
                     "models": "model-large_model-medium",
                     "chat_item_ids": "0455df65c2d6bb821a9dc9108ac1d79964a0f571_4c28c86c4b22b3397691ce5cf27197fcf7e8fb2d_7326ff17cbfe7e3cb91b008cf0c496fcd17a1074_375b55d44af2c8c801992089c797df8e12605dfb_9231d8819ac96cc8a6c4b7780c301b796c3f8bf2",
+                    "text": "Chat_id: 6e4094947af4902cd252421aba9a077e8e4402dd\n\nChat_item_ids: 0455df65c2d6bb821a9dc9108ac1d79964a0f571_4c28c86c4b22b3397691ce5cf27197fcf7e8fb2d_7326ff17cbfe7e3cb91b008cf0c496fcd17a1074_375b55d44af2c8c801992089c797df8e12605dfb_9231d8819ac96cc8a6c4b7780c301b796c3f8bf2",
                 },
             )

--- a/tests/unit/services/asset_import/test_import_llm.py
+++ b/tests/unit/services/asset_import/test_import_llm.py
@@ -103,6 +103,121 @@ class LLMTestCase(ImportTestCase):
         )
         self.kili.graphql_client.execute.assert_called_with(*expected_parameters)
 
+    def test_upload_from_dict_in_chat_format(self, *_):
+        self.kili.kili_api_gateway.get_project.return_value = {"inputType": "LLM_RLHF"}
+        assets = [
+            {
+                "content": [
+                    {
+                        "role": "user",
+                        "content": "text of the user instructions",
+                        "id": "0455df65c2d6bb821a9dc9108ac1d79964a0f571",
+                        "chat_id": "6e4094947af4902cd252421aba9a077e8e4402dd",
+                        "model": None,
+                    },
+                    {
+                        "role": "assistant",
+                        "content": "text of the assistant answer",
+                        "id": "4c28c86c4b22b3397691ce5cf27197fcf7e8fb2d",
+                        "chat_id": "6e4094947af4902cd252421aba9a077e8e4402dd",
+                        "model": "model-large",
+                    },
+                    {
+                        "role": "user",
+                        "content": "text of the user instructions",
+                        "id": "7326ff17cbfe7e3cb91b008cf0c496fcd17a1074",
+                        "chat_id": "6e4094947af4902cd252421aba9a077e8e4402dd",
+                        "model": None,
+                    },
+                    {
+                        "role": "assistant_A",
+                        "content": "text of the assistant answer A",
+                        "id": "375b55d44af2c8c801992089c797df8e12605dfb",
+                        "chat_id": "6e4094947af4902cd252421aba9a077e8e4402dd",
+                        "model": "model-large",
+                    },
+                    {
+                        "role": "assistant_B",
+                        "content": "text of the assistant answer B",
+                        "id": "9231d8819ac96cc8a6c4b7780c301b796c3f8bf2",
+                        "chat_id": "6e4094947af4902cd252421aba9a077e8e4402dd",
+                        "model": "model-medium",
+                    },
+                ],
+                "external_id": "dict",
+            }
+        ]
+        import_assets(self.kili, self.project_id, assets)
+        expected_parameters = self.get_expected_sync_call(
+            ["https://signed_url?id=id"],
+            ["dict"],
+            ["unique_id"],
+            [False],
+            [""],
+            [
+                '{"chat_id": "6e4094947af4902cd252421aba9a077e8e4402dd", "models": "model-large_model-medium", "chat_item_ids": "0455df65c2d6bb821a9dc9108ac1d79964a0f571_4c28c86c4b22b3397691ce5cf27197fcf7e8fb2d_7326ff17cbfe7e3cb91b008cf0c496fcd17a1074_375b55d44af2c8c801992089c797df8e12605dfb_9231d8819ac96cc8a6c4b7780c301b796c3f8bf2"}'
+            ],
+        )
+        self.kili.graphql_client.execute.assert_called_with(*expected_parameters)
+
+    def test_upload_from_dict_in_chat_format_with_json_metadata(self, *_):
+        self.kili.kili_api_gateway.get_project.return_value = {"inputType": "LLM_RLHF"}
+        assets = [
+            {
+                "content": [
+                    {
+                        "role": "user",
+                        "content": "text of the user instructions",
+                        "id": "0455df65c2d6bb821a9dc9108ac1d79964a0f571",
+                        "chat_id": "6e4094947af4902cd252421aba9a077e8e4402dd",
+                        "model": None,
+                    },
+                    {
+                        "role": "assistant",
+                        "content": "text of the assistant answer",
+                        "id": "4c28c86c4b22b3397691ce5cf27197fcf7e8fb2d",
+                        "chat_id": "6e4094947af4902cd252421aba9a077e8e4402dd",
+                        "model": "model-large",
+                    },
+                    {
+                        "role": "user",
+                        "content": "text of the user instructions",
+                        "id": "7326ff17cbfe7e3cb91b008cf0c496fcd17a1074",
+                        "chat_id": "6e4094947af4902cd252421aba9a077e8e4402dd",
+                        "model": None,
+                    },
+                    {
+                        "role": "assistant_A",
+                        "content": "text of the assistant answer A",
+                        "id": "375b55d44af2c8c801992089c797df8e12605dfb",
+                        "chat_id": "6e4094947af4902cd252421aba9a077e8e4402dd",
+                        "model": "model-large",
+                    },
+                    {
+                        "role": "assistant_B",
+                        "content": "text of the assistant answer B",
+                        "id": "9231d8819ac96cc8a6c4b7780c301b796c3f8bf2",
+                        "chat_id": "6e4094947af4902cd252421aba9a077e8e4402dd",
+                        "model": "model-medium",
+                    },
+                ],
+                "json_metadata": '{ "customKey": "customValue" }',
+                "external_id": "dict",
+            }
+        ]
+        import_assets(self.kili, self.project_id, assets)
+        expected_parameters = self.get_expected_sync_call(
+            ["https://signed_url?id=id"],
+            ["dict"],
+            ["unique_id"],
+            [False],
+            [""],
+            [
+                '{"customKey": "customValue", "chat_id": "6e4094947af4902cd252421aba9a077e8e4402dd", "models": "model-large_model-medium", "chat_item_ids": "0455df65c2d6bb821a9dc9108ac1d79964a0f571_4c28c86c4b22b3397691ce5cf27197fcf7e8fb2d_7326ff17cbfe7e3cb91b008cf0c496fcd17a1074_375b55d44af2c8c801992089c797df8e12605dfb_9231d8819ac96cc8a6c4b7780c301b796c3f8bf2"}'
+            ],
+        )
+        self.kili.graphql_client.execute.assert_called_with(*expected_parameters)
+
     def test_process_json(self, *_):
         url = "https://storage.googleapis.com/label-public-staging/asset-test-sample/llm/test_llm_file_in_chat_format.json"
         path = self.downloader(url)


### PR DESCRIPTION
- Adds file data conversion from chat (Mistral) format (if present) to our asset content format
- Adds jsonMetadata for the following keys : 
  - chat_id
  - chat_item_ids
  - models
  - text (for asset interface display) : with chat_id and chat_item_ids
- Adds 3 tests : 
   - one for uploading a file in chat format without jsonMetadata
   - one for uploading a file in chat format with jsonMetadata
   - one for unit testing the processJson method which converts the chat format file data into llm kili format asset data