### PR TITLE
fix(lab-2558): fix area property of COCO export and ignore empty bboxes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
   "filelock >= 3.0.0, < 4.0.0",
   "pip-system-certs >= 4.0.0, < 5.0.0; platform_system=='Windows'",
   "pyrate-limiter >= 3, < 4",
+  "shapely >= 1.8, < 3",
 ]
 urls = { homepage = "https://github.com/kili-technology/kili-python-sdk" }
 


### PR DESCRIPTION
Currently it contains the area of the image instead of the area of the annotation and some annotations are exported with null dimensions.