### PR TITLE
feat: remove name from assetProjectModels query

### DIFF
--- a/src/kili/llm/services/export/dynamic.py
+++ b/src/kili/llm/services/export/dynamic.py
@@ -33,8 +33,8 @@ LABELS_NEEDED_FIELDS = [
 
 ASSET_NEEDED_FIELDS = [
     "assetProjectModels.id",
+    "assetProjectModels.projectModelId",
     "assetProjectModels.configuration",
-    "assetProjectModels.name",
     "content",
     "externalId",
     "jsonMetadata",
@@ -254,7 +254,7 @@ def _format_models_object(models, obfuscated_models):
     for model in models:
         model_configuration = {
             "id": model["id"],
-            "name": model["name"],
+            "projectModelId": model["projectModelId"],
             "configuration": model["configuration"],
         }
         res[obfuscated_models[model["id"]]] = model_configuration

--- a/tests/unit/llm/services/export/test_dynamic.py
+++ b/tests/unit/llm/services/export/test_dynamic.py
@@ -195,13 +195,13 @@ mock_fetch_assets = [
         "assetProjectModels": [
             {
                 "id": "clzief6pr003c7tc99680e8yj",
-                "name": "ProjectModelA",
-                "configuration": {"temperature": 1, "model": "auto"},
+                "projectModelId": "ProjectModelA",
+                "configuration": {"temperature": 1, "model": "my-model-1"},
             },
             {
                 "id": "clzief6ps003d7tc9fzgj2xkf",
-                "name": "ProjectModelB",
-                "configuration": {"temperature": 0.5, "model": "auto"},
+                "projectModelId": "ProjectModelB",
+                "configuration": {"temperature": 0.5, "model": "my-model-2"},
             },
         ],
         "externalId": "clzief6pg003a7tc9cn0p1obf",
@@ -242,19 +242,19 @@ expected_export = [
             "models": {
                 "A": {
                     "configuration": {
-                        "model": "auto",
+                        "model": "my-model-1",
                         "temperature": 1,
                     },
                     "id": "clzief6pr003c7tc99680e8yj",
-                    "name": "ProjectModelA",
+                    "projectModelId": "ProjectModelA",
                 },
                 "B": {
                     "configuration": {
-                        "model": "auto",
+                        "model": "my-model-2",
                         "temperature": 0.5,
                     },
                     "id": "clzief6ps003d7tc9fzgj2xkf",
-                    "name": "ProjectModelB",
+                    "projectModelId": "ProjectModelB",
                 },
             },
             "labels": [
@@ -310,19 +310,19 @@ expected_export = [
             "models": {
                 "A": {
                     "configuration": {
-                        "model": "auto",
+                        "model": "my-model-1",
                         "temperature": 1,
                     },
                     "id": "clzief6pr003c7tc99680e8yj",
-                    "name": "ProjectModelA",
+                    "projectModelId": "ProjectModelA",
                 },
                 "B": {
                     "configuration": {
-                        "model": "auto",
+                        "model": "my-model-2",
                         "temperature": 0.5,
                     },
                     "id": "clzief6ps003d7tc9fzgj2xkf",
-                    "name": "ProjectModelB",
+                    "projectModelId": "ProjectModelB",
                 },
             },
             "labels": [
@@ -392,19 +392,19 @@ expected_export = [
             "models": {
                 "A": {
                     "configuration": {
-                        "model": "auto",
+                        "model": "my-model-1",
                         "temperature": 1,
                     },
                     "id": "clzief6pr003c7tc99680e8yj",
-                    "name": "ProjectModelA",
+                    "projectModelId": "ProjectModelA",
                 },
                 "B": {
                     "configuration": {
-                        "model": "auto",
+                        "model": "my-model-2",
                         "temperature": 0.5,
                     },
                     "id": "clzief6ps003d7tc9fzgj2xkf",
-                    "name": "ProjectModelB",
+                    "projectModelId": "ProjectModelB",
                 },
             },
             "labels": [


### PR DESCRIPTION
Remove the field name from assetProjectModels query as it does not exist anymore in the API.

The name of the model that really matters for the user is still returned in the export.