### PR TITLE
fix(LAB-3323): prevent label export errors with some Python versions

### DIFF
--- a/src/kili/services/export/format/kili/__init__.py
+++ b/src/kili/services/export/format/kili/__init__.py
@@ -70,7 +70,7 @@ class KiliExporter(AbstractExporter):
                 json_content_list = [
                     str(Path(self.ASSETS_DIR_NAME) / Path(filepath).name)
                     for filepath in asset["jsonContent"]
-                    if Path(filepath).is_file()
+                    if isinstance(filepath, str) and Path(filepath).is_file()
                 ]
 
                 asset["jsonContent"] = json_content_list


### PR DESCRIPTION
is_file check crashes when filepath is a dict. It seems to occur with Python 2.8 and Python 2.12 but not with Python 2.11.

