### PR TITLE
fix(sup-1998): only cast CategoryList once per job

### DIFF
--- a/src/kili/services/label_data_parsing/job_response.py
+++ b/src/kili/services/label_data_parsing/job_response.py
@@ -33,7 +33,9 @@ class JobPayload:
         self._job_interface = project_info["jsonInterface"][job_name]  # type: ignore
 
         # cast lists to objects
-        if "categories" in self._json_data:
+        if "categories" in self._json_data and not isinstance(
+            self._json_data["categories"], category_module.CategoryList
+        ):
             self._json_data["categories"] = category_module.CategoryList(
                 job_name=self._job_name,
                 project_info=self._project_info,


### PR DESCRIPTION
Exports in the format `parsed_label` failed when multiple jobs in the interface referenced the same child classification job. The same child classification job categories dict was casted to a CategoryList multiple times which failed.