### PR TITLE
feat(LAB-3459): add missing code to import geospatial image through SDK

### DIFF
--- a/src/kili/core/constants.py
+++ b/src/kili/core/constants.py
@@ -12,6 +12,7 @@ mime_extensions = {
         "application/vnd.nitf, image/jp2,image/jpeg,image/png,image/bmp,image/gif,image/webp,"
         "image/x-icon,image/tiff,image/vnd.microsoft.icon,image/svg+xml,image/avif,image/apng"
     ),
+    "Geospatial": ("application/vnd.nitf, image/jp2, image/tiff"),
     "Pdf": "application/pdf",
     "Text": "text/plain",
     "TimeSeries": "text/csv",
@@ -21,6 +22,7 @@ mime_extensions = {
 mime_extensions_for_IV2 = {
     "AUDIO": mime_extensions["Audio"],
     "IMAGE": mime_extensions["Image"],
+    "GEOSPATIAL": mime_extensions["Geospatial"],
     "NA": "",
     "PDF": mime_extensions["Pdf"],
     "TEXT": mime_extensions["Text"],

--- a/src/kili/domain/project.py
+++ b/src/kili/domain/project.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 ProjectId = NewType("ProjectId", str)
 InputType = Literal[
-    "IMAGE", "PDF", "TEXT", "VIDEO", "LLM_RLHF", "LLM_INSTR_FOLLOWING", "LLM_STATIC"
+    "IMAGE", "GEOSPATIAL", "PDF", "TEXT", "VIDEO", "LLM_RLHF", "LLM_INSTR_FOLLOWING", "LLM_STATIC"
 ]
 
 

--- a/src/kili/services/asset_import/__init__.py
+++ b/src/kili/services/asset_import/__init__.py
@@ -52,7 +52,9 @@ def import_assets(  # pylint: disable=too-many-arguments
 
     if input_type not in importer_by_type:
         raise NotImplementedError(f"There is no importer for the input type: {input_type}")
-    if input_type != "IMAGE" and any(asset.get("multi_layer_content") for asset in assets):
+    if input_type not in ["IMAGE", "GEOSPATIAL"] and any(
+        asset.get("multi_layer_content") for asset in assets
+    ):
         raise ImportValidationError(
             f"Import of multi-layer assets is not supported for input type: {input_type}"
         )

--- a/src/kili/services/asset_import/__init__.py
+++ b/src/kili/services/asset_import/__init__.py
@@ -59,4 +59,4 @@ def import_assets(  # pylint: disable=too-many-arguments
     asset_importer = importer_by_type[input_type](*importer_params)
     casted_assets = cast(List[AssetLike], assets)
     asset_importer.check_asset_contents(casted_assets)
-    return asset_importer.import_assets(assets=casted_assets)
+    return asset_importer.import_assets(assets=casted_assets, input_type=input_type)

--- a/src/kili/services/asset_import/base.py
+++ b/src/kili/services/asset_import/base.py
@@ -236,7 +236,7 @@ class BaseBatchImporter:  # pylint: disable=too-many-instance-attributes
 
     def _async_import_to_kili(self, assets: List[KiliResolverAsset]):
         """Import assets with asynchronous resolver."""
-        if self.input_type == "IMAGE":
+        if self.input_type in ["IMAGE", "GEOSPATIAL"]:
             upload_type = "GEO_SATELLITE"
         elif self.input_type in ("VIDEO", "VIDEO_LEGACY"):
             upload_type = "NATIVE_VIDEO" if self.are_native_videos(assets) else "FRAME_VIDEO"

--- a/src/kili/services/asset_import/base.py
+++ b/src/kili/services/asset_import/base.py
@@ -62,7 +62,7 @@ class BatchParams(NamedTuple):
 
     is_asynchronous: bool
     is_hosted: bool
-    input_type: InputType = None
+    input_type: Optional[InputType] = None
 
 
 class ProcessingParams(NamedTuple):
@@ -103,8 +103,8 @@ class BaseBatchImporter:  # pylint: disable=too-many-instance-attributes
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logging.INFO)
 
-    def import_batch(
-        self, assets: ListOrTuple[AssetLike], verify: bool, input_type: InputType = None
+    def import_batch(  # pylint: disable=unused-argument
+        self, assets: ListOrTuple[AssetLike], verify: bool, input_type: Optional[InputType] = None
     ) -> List[str]:
         """Base actions to import a batch of asset.
 
@@ -299,7 +299,9 @@ class BaseBatchImporter:  # pylint: disable=too-many-instance-attributes
 class ContentBatchImporter(BaseBatchImporter):
     """Class defining the methods to import a batch of assets with content."""
 
-    def import_batch(self, assets: List[AssetLike], verify: bool, input_type: InputType = None):
+    def import_batch(
+        self, assets: List[AssetLike], verify: bool, input_type: Optional[InputType] = None
+    ):
         """Method to import a batch of asset with content."""
         assets = self.add_ids(assets)
         if not self.is_hosted:
@@ -334,7 +336,9 @@ class ContentBatchImporter(BaseBatchImporter):
         """Returns the data of the content (path) and its content type for each element in the array."""
         return list(map(self.get_content_type_and_data_from_content, content_array))
 
-    def upload_local_content_to_bucket(self, assets: List[AssetLike], input_type: InputType = None):
+    def upload_local_content_to_bucket(
+        self, assets: List[AssetLike], input_type: Optional[InputType] = None
+    ):
         """Upload local content to a bucket."""
         project_bucket_path = self.generate_project_bucket_path()
         # tuple containing (bucket_path, file_path, asset_index, content_index)
@@ -422,7 +426,9 @@ class JsonContentBatchImporter(BaseBatchImporter):
             )
         return [AssetLike(**{**asset, "json_content": url}) for asset, url in zip(assets, url_gen)]  # type: ignore
 
-    def import_batch(self, assets: List[AssetLike], verify: bool, input_type: InputType = None):
+    def import_batch(
+        self, assets: List[AssetLike], verify: bool, input_type: Optional[InputType] = None
+    ):
         """Method to import a batch of asset with json content."""
         assets = self.add_ids(assets)
         assets = self.loop_on_batch(self.stringify_json_content)(assets)
@@ -615,7 +621,7 @@ class BaseAbstractAssetImporter(abc.ABC):
         assets: List[AssetLike],
         batch_importer: BaseBatchImporter,
         batch_size=IMPORT_BATCH_SIZE,
-        input_type: InputType = None,
+        input_type: Optional[InputType] = None,
     ):
         """Split assets by batch and import them with a given batch importer."""
         batch_generator = batcher(assets, batch_size)

--- a/src/kili/services/asset_import/base.py
+++ b/src/kili/services/asset_import/base.py
@@ -53,7 +53,6 @@ from kili.utils.tqdm import tqdm
 
 FILTER_EXISTING_BATCH_SIZE = 1000
 
-
 if TYPE_CHECKING:
     from kili.client import Kili
 
@@ -63,6 +62,7 @@ class BatchParams(NamedTuple):
 
     is_asynchronous: bool
     is_hosted: bool
+    input_type: InputType = None
 
 
 class ProcessingParams(NamedTuple):
@@ -103,7 +103,9 @@ class BaseBatchImporter:  # pylint: disable=too-many-instance-attributes
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logging.INFO)
 
-    def import_batch(self, assets: ListOrTuple[AssetLike], verify: bool) -> List[str]:
+    def import_batch(
+        self, assets: ListOrTuple[AssetLike], verify: bool, input_type: InputType = None
+    ) -> List[str]:
         """Base actions to import a batch of asset.
 
         Returns:
@@ -297,7 +299,7 @@ class BaseBatchImporter:  # pylint: disable=too-many-instance-attributes
 class ContentBatchImporter(BaseBatchImporter):
     """Class defining the methods to import a batch of assets with content."""
 
-    def import_batch(self, assets: List[AssetLike], verify: bool):
+    def import_batch(self, assets: List[AssetLike], verify: bool, input_type: InputType = None):
         """Method to import a batch of asset with content."""
         assets = self.add_ids(assets)
         if not self.is_hosted:
@@ -312,7 +314,7 @@ class ContentBatchImporter(BaseBatchImporter):
                 if not asset.get("content") and not asset.get("multi_layer_content")
             ]
             if len(assets_with_content) > 0:
-                assets += self.upload_local_content_to_bucket(assets_with_content)
+                assets += self.upload_local_content_to_bucket(assets_with_content, input_type)
         return super().import_batch(assets, verify)
 
     def get_content_type_and_data_from_content(
@@ -332,7 +334,7 @@ class ContentBatchImporter(BaseBatchImporter):
         """Returns the data of the content (path) and its content type for each element in the array."""
         return list(map(self.get_content_type_and_data_from_content, content_array))
 
-    def upload_local_content_to_bucket(self, assets: List[AssetLike]):
+    def upload_local_content_to_bucket(self, assets: List[AssetLike], input_type: InputType = None):
         """Upload local content to a bucket."""
         project_bucket_path = self.generate_project_bucket_path()
         # tuple containing (bucket_path, file_path, asset_index, content_index)
@@ -343,12 +345,17 @@ class ContentBatchImporter(BaseBatchImporter):
             if multi_layer_content:
                 for j, item in enumerate(multi_layer_content):
                     bucket_path = BaseBatchImporter.build_url_from_parts(
-                        project_bucket_path, asset_id, "content", str(j)
+                        project_bucket_path,
+                        asset_id,
+                        "content",  # FIXME : multilayer GEOSPATIAL project must have .tif extension
+                        str(j),
                     )
                     to_upload.append((bucket_path, item.get("path"), i, j))
             else:
                 bucket_path = BaseBatchImporter.build_url_from_parts(
-                    project_bucket_path, asset_id, "content"
+                    project_bucket_path,
+                    asset_id,
+                    "content.tif" if input_type == "GEOSPATIAL" else "content",
                 )
                 to_upload.append((bucket_path, asset.get("content"), i, None))
         signed_urls = bucket.request_signed_urls(
@@ -418,7 +425,7 @@ class JsonContentBatchImporter(BaseBatchImporter):
             )
         return [AssetLike(**{**asset, "json_content": url}) for asset, url in zip(assets, url_gen)]  # type: ignore
 
-    def import_batch(self, assets: List[AssetLike], verify: bool):
+    def import_batch(self, assets: List[AssetLike], verify: bool, input_type: InputType = None):
         """Method to import a batch of asset with json content."""
         assets = self.add_ids(assets)
         assets = self.loop_on_batch(self.stringify_json_content)(assets)
@@ -443,7 +450,7 @@ class BaseAbstractAssetImporter(abc.ABC):
         self.pbar = tqdm(disable=logger_params.disable_tqdm)
 
     @abc.abstractmethod
-    def import_assets(self, assets: List[AssetLike]) -> List[str]:
+    def import_assets(self, assets: List[AssetLike], input_type: InputType) -> List[str]:
         """Import assets into Kili.
 
         Returns:
@@ -611,6 +618,7 @@ class BaseAbstractAssetImporter(abc.ABC):
         assets: List[AssetLike],
         batch_importer: BaseBatchImporter,
         batch_size=IMPORT_BATCH_SIZE,
+        input_type: InputType = None,
     ):
         """Split assets by batch and import them with a given batch importer."""
         batch_generator = batcher(assets, batch_size)
@@ -622,5 +630,5 @@ class BaseAbstractAssetImporter(abc.ABC):
         for i, batch_assets in enumerate(batch_generator):
             # check last batch only
             verify = i == (nb_batch - 1) and self.verify
-            created_asset_ids += batch_importer.import_batch(batch_assets, verify)
+            created_asset_ids += batch_importer.import_batch(batch_assets, verify, input_type)
         return created_asset_ids

--- a/src/kili/services/asset_import/base.py
+++ b/src/kili/services/asset_import/base.py
@@ -345,10 +345,7 @@ class ContentBatchImporter(BaseBatchImporter):
             if multi_layer_content:
                 for j, item in enumerate(multi_layer_content):
                     bucket_path = BaseBatchImporter.build_url_from_parts(
-                        project_bucket_path,
-                        asset_id,
-                        "content",  # FIXME : multilayer GEOSPATIAL project must have .tif extension
-                        str(j),
+                        project_bucket_path, asset_id, "content", f"{j!s}.tif"
                     )
                     to_upload.append((bucket_path, item.get("path"), i, j))
             else:

--- a/src/kili/services/asset_import/image.py
+++ b/src/kili/services/asset_import/image.py
@@ -5,6 +5,7 @@ from typing import List
 
 from kili.core.constants import mime_extensions_that_need_post_processing
 from kili.core.helpers import get_mime_type
+from kili.domain.project import InputType
 
 from .base import BaseAbstractAssetImporter, BatchParams, ContentBatchImporter
 from .constants import LARGE_IMAGE_THRESHOLD_SIZE
@@ -12,9 +13,9 @@ from .types import AssetLike
 
 
 class ImageDataImporter(BaseAbstractAssetImporter):
-    """Class for importing assets into an IMAGE project."""
+    """Class for importing assets into an IMAGE or GEOSPATIAL project."""
 
-    def import_assets(self, assets: List[AssetLike]):
+    def import_assets(self, assets: List[AssetLike], input_type: InputType):
         """Import IMAGE assets into Kili."""
         self._check_upload_is_allowed(assets)
         is_hosted = self.is_hosted_content(assets)
@@ -24,17 +25,25 @@ class ImageDataImporter(BaseAbstractAssetImporter):
         sync_assets, async_assets = self.split_asset_by_upload_type(assets, is_hosted)
         created_asset_ids: List[str] = []
         if len(sync_assets) > 0:
-            sync_batch_params = BatchParams(is_hosted=is_hosted, is_asynchronous=False)
+            sync_batch_params = BatchParams(
+                is_hosted=is_hosted, is_asynchronous=False, input_type=input_type
+            )
             batch_importer = ContentBatchImporter(
                 self.kili, self.project_params, sync_batch_params, self.pbar
             )
-            created_asset_ids += self.import_assets_by_batch(sync_assets, batch_importer)
+            created_asset_ids += self.import_assets_by_batch(
+                sync_assets, batch_importer, input_type=input_type
+            )
         if len(async_assets) > 0:
-            async_batch_params = BatchParams(is_hosted=is_hosted, is_asynchronous=True)
+            async_batch_params = BatchParams(
+                is_hosted=is_hosted, is_asynchronous=True, input_type=input_type
+            )
             batch_importer = ContentBatchImporter(
                 self.kili, self.project_params, async_batch_params, self.pbar
             )
-            created_asset_ids += self.import_assets_by_batch(async_assets, batch_importer)
+            created_asset_ids += self.import_assets_by_batch(
+                async_assets, batch_importer, input_type=input_type
+            )
         return created_asset_ids
 
     @staticmethod

--- a/src/kili/services/asset_import/llm.py
+++ b/src/kili/services/asset_import/llm.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import List, Optional, Tuple
 
 from kili.core.helpers import is_url
+from kili.domain.project import InputType
 
 from .base import (
     BaseAbstractAssetImporter,
@@ -71,7 +72,7 @@ class LLMDataImporter(BaseAbstractAssetImporter):
 
         return transformed_asset_content, changed_json_metadata
 
-    def import_assets(self, assets: List[AssetLike]):
+    def import_assets(self, assets: List[AssetLike], input_type: InputType):
         """Import LLM assets into Kili."""
         self._check_upload_is_allowed(assets)
         data_type = self.get_data_type(assets)

--- a/src/kili/services/asset_import/pdf.py
+++ b/src/kili/services/asset_import/pdf.py
@@ -2,6 +2,8 @@
 
 from typing import List
 
+from kili.domain.project import InputType
+
 from .base import BaseAbstractAssetImporter, BatchParams, ContentBatchImporter
 from .types import AssetLike
 
@@ -9,7 +11,7 @@ from .types import AssetLike
 class PdfDataImporter(BaseAbstractAssetImporter):
     """Class for importing data into a PDF project."""
 
-    def import_assets(self, assets: List[AssetLike]):
+    def import_assets(self, assets: List[AssetLike], input_type: InputType):
         """Import PDF assets into Kili."""
         self._check_upload_is_allowed(assets)
         is_hosted = self.is_hosted_content(assets)

--- a/src/kili/services/asset_import/text.py
+++ b/src/kili/services/asset_import/text.py
@@ -5,6 +5,7 @@ from enum import Enum
 from typing import List, Optional, Tuple
 
 from kili.core.helpers import is_url
+from kili.domain.project import InputType
 
 from .base import (
     BaseAbstractAssetImporter,
@@ -62,7 +63,7 @@ class TextDataImporter(BaseAbstractAssetImporter):
             return TextDataType.HOSTED_FILE
         return TextDataType.RAW_TEXT
 
-    def import_assets(self, assets: List[AssetLike]):
+    def import_assets(self, assets: List[AssetLike], input_type: InputType):
         """Import TEXT assets into Kili."""
         self._check_upload_is_allowed(assets)
         data_type = self.get_data_type(assets)

--- a/src/kili/services/asset_import/video.py
+++ b/src/kili/services/asset_import/video.py
@@ -5,7 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from itertools import repeat
 from json import JSONDecodeError
-from typing import List
+from typing import List, Optional
 
 from kili.core.helpers import get_mime_type, is_url
 from kili.domain.project import InputType
@@ -75,7 +75,9 @@ class VideoContentBatchImporter(ContentBatchImporter, VideoMixin):
         json_metadata = {**json_metadata, "processingParameters": processing_parameters}
         return AssetLike(**{**asset, "json_metadata": json_metadata})  # type: ignore
 
-    def import_batch(self, assets: List[AssetLike], verify: bool, input_type: InputType = None):
+    def import_batch(
+        self, assets: List[AssetLike], verify: bool, input_type: Optional[InputType] = None
+    ):
         """Import a batch of video assets from content into Kili."""
         assets = self.loop_on_batch(self.add_video_processing_parameters)(assets)
         return super().import_batch(assets, verify)
@@ -91,7 +93,9 @@ class FrameBatchImporter(JsonContentBatchImporter, VideoMixin):
         json_metadata = {**json_metadata, "processingParameters": processing_parameters}
         return AssetLike(**{**asset, "json_metadata": json_metadata})  # type: ignore
 
-    def import_batch(self, assets: List[AssetLike], verify: bool, input_type: InputType = None):
+    def import_batch(
+        self, assets: List[AssetLike], verify: bool, input_type: Optional[InputType] = None
+    ):
         """Import a batch of video assets from frames."""
         assets = self.add_ids(assets)
         if not self.is_hosted:

--- a/src/kili/services/asset_import/video.py
+++ b/src/kili/services/asset_import/video.py
@@ -8,6 +8,7 @@ from json import JSONDecodeError
 from typing import List
 
 from kili.core.helpers import get_mime_type, is_url
+from kili.domain.project import InputType
 from kili.services.asset_import.base import (
     BaseAbstractAssetImporter,
     BaseBatchImporter,
@@ -74,7 +75,7 @@ class VideoContentBatchImporter(ContentBatchImporter, VideoMixin):
         json_metadata = {**json_metadata, "processingParameters": processing_parameters}
         return AssetLike(**{**asset, "json_metadata": json_metadata})  # type: ignore
 
-    def import_batch(self, assets: List[AssetLike], verify: bool):
+    def import_batch(self, assets: List[AssetLike], verify: bool, input_type: InputType = None):
         """Import a batch of video assets from content into Kili."""
         assets = self.loop_on_batch(self.add_video_processing_parameters)(assets)
         return super().import_batch(assets, verify)
@@ -90,7 +91,7 @@ class FrameBatchImporter(JsonContentBatchImporter, VideoMixin):
         json_metadata = {**json_metadata, "processingParameters": processing_parameters}
         return AssetLike(**{**asset, "json_metadata": json_metadata})  # type: ignore
 
-    def import_batch(self, assets: List[AssetLike], verify: bool):
+    def import_batch(self, assets: List[AssetLike], verify: bool, input_type: InputType = None):
         """Import a batch of video assets from frames."""
         assets = self.add_ids(assets)
         if not self.is_hosted:
@@ -234,7 +235,7 @@ class VideoDataImporter(BaseAbstractAssetImporter):
                 return False
         return True
 
-    def import_assets(self, assets: List[AssetLike]):
+    def import_assets(self, assets: List[AssetLike], input_type: InputType):
         """Import video assets into Kili."""
         self._check_upload_is_allowed(assets)
         data_type = self.get_data_type(assets)

--- a/tests/integration/adapters/kili_api_gateway/test_paginated_graphql_query.py
+++ b/tests/integration/adapters/kili_api_gateway/test_paginated_graphql_query.py
@@ -156,8 +156,8 @@ def test_given_a_query_and_a_number_of_elements_to_query_i_have_a_progress_bar(
 
     # then
     captured = capsys.readouterr()
-    assert "0%|          | 0/250" in captured.err
-    assert "100%|██████████| 250/250" in captured.err
+    assert "0%" in captured.err and "0/250" in captured.err
+    assert "100%" in captured.err and "250/250" in captured.err
 
 
 def test_given_a_query_without_a_count_query_I_do_not_have_a_progress_bar(graphql_client, capsys):

--- a/tests/manual/geospatial_import_tests.py
+++ b/tests/manual/geospatial_import_tests.py
@@ -5,7 +5,7 @@ from kili.client import Kili
 
 LOCAL_KILI_API_KEY = "cm7nd7k63001gg90w28ot9vl7/881232fb4cce6e745f61612c5c5918d0"
 
-PROJECT_TYPES_TO_TEST = ["GEOSPATIAL"]
+PROJECT_TYPES_TO_TEST = ["IMAGE", "GEOSPATIAL"]
 
 IMAGE_PROJECT_TITLE = "Image Samples (from SDK)"
 GEOSPATIAL_PROJECT_TITLE = "Geospatial Samples (from SDK)"
@@ -95,7 +95,7 @@ GEOSPATIAL_FILES_MULTILAYER = ["3B_uint16_epsg4326_layer1.tif", "3B_uint16_epsg4
 def archive_previous_project():
     projects = kili.projects()
     for project in projects:
-        if project["inputType"] == "GEOSPATIAL" and project["title"] in [
+        if project["inputType"] in PROJECT_TYPES_TO_TEST and project["title"] in [
             IMAGE_PROJECT_TITLE,
             GEOSPATIAL_PROJECT_TITLE,
         ]:

--- a/tests/manual/geospatial_import_tests.py
+++ b/tests/manual/geospatial_import_tests.py
@@ -1,0 +1,197 @@
+import os
+import urllib.request
+
+from kili.client import Kili
+
+LOCAL_KILI_API_KEY = "cm7nd7k63001gg90w28ot9vl7/881232fb4cce6e745f61612c5c5918d0"
+
+PROJECT_TYPES_TO_TEST = ["GEOSPATIAL"]
+
+IMAGE_PROJECT_TITLE = "Image Samples (from SDK)"
+GEOSPATIAL_PROJECT_TITLE = "Geospatial Samples (from SDK)"
+
+JSON_INTERFACE = {
+    "jobs": {
+        "JOB_0": {
+            "mlTask": "CLASSIFICATION",
+            "required": 1,
+            "isChild": False,
+            "content": {
+                "categories": {
+                    "OBJECT_A": {"name": "Object A", "id": "category3"},
+                    "OBJECT_B": {"name": "Object B", "id": "category4"},
+                },
+                "input": "radio",
+            },
+            "isNew": False,
+            "instruction": "Classification",
+        },
+        "OBJECT_DETECTION_JOB": {
+            "content": {
+                "categories": {
+                    "B_BOX_1": {
+                        "children": [],
+                        "color": "#472CED",
+                        "name": "BBox1",
+                        "id": "category5",
+                    },
+                    "B_BOX_2": {
+                        "children": [],
+                        "name": "BBox2",
+                        "id": "category6",
+                        "color": "#5CE7B7",
+                    },
+                },
+                "input": "radio",
+            },
+            "instruction": "Bounding Box",
+            "mlTask": "OBJECT_DETECTION",
+            "required": 0,
+            "tools": ["rectangle"],
+            "isChild": False,
+            "isNew": False,
+        },
+        "OBJECT_DETECTION_JOB_0": {
+            "content": {
+                "categories": {
+                    "SEMANTIC_1": {
+                        "children": [],
+                        "color": "#D33BCE",
+                        "name": "Semantic1",
+                        "id": "category7",
+                    },
+                    "SEMANTIC_2": {
+                        "children": [],
+                        "name": "Semantic2",
+                        "id": "category8",
+                        "color": "#FB753C",
+                    },
+                },
+                "input": "radio",
+            },
+            "instruction": "Semantic",
+            "mlTask": "OBJECT_DETECTION",
+            "required": 0,
+            "tools": ["semantic"],
+            "isChild": False,
+            "isNew": False,
+        },
+    }
+}
+
+GEOSPATIAL_FILES = [
+    "1B_uint8_epsg4326.tif",
+    "1B_uint8_epsg21897.tif",
+    "1B_uint16_epsg4326.tif",
+    "3B_uint8_epsg4326.tif",
+    "3B_uint8_epsg32636.tif",
+    "3B_uint8_epsg32647.tif",
+    "10B_uint16_epsg4326.tif",
+    "23B_float32_epsg4326.tif",
+]
+GEOSPATIAL_FILES_MULTILAYER = ["3B_uint16_epsg4326_layer1.tif", "3B_uint16_epsg4326_layer2.tif"]
+
+
+def archive_previous_project():
+    projects = kili.projects()
+    for project in projects:
+        if project["inputType"] == "GEOSPATIAL" and project["title"] in [
+            IMAGE_PROJECT_TITLE,
+            GEOSPATIAL_PROJECT_TITLE,
+        ]:
+            kili.delete_project(project["id"])
+
+
+def download_geotiffs():
+    if not os.path.exists("geospatial"):
+        os.makedirs("geospatial")
+
+    base_url = "https://storage.googleapis.com/label-public-staging/geotiffs"
+
+    for file in GEOSPATIAL_FILES + GEOSPATIAL_FILES_MULTILAYER:
+        local_path = os.path.join("geospatial", file)
+        if not os.path.exists(local_path):
+            remote_url = f"{base_url}/{file}"
+            print(f"Downloading {file} from {remote_url}...")
+            urllib.request.urlretrieve(remote_url, local_path)
+
+
+kili = Kili(
+    api_key=LOCAL_KILI_API_KEY,
+    api_endpoint="http://localhost:4001/api/label/v2/graphql",
+    verify=False,
+)
+
+archive_previous_project()
+download_geotiffs()
+
+content_array = [os.path.join("geospatial", file) for file in GEOSPATIAL_FILES]
+external_id_array = GEOSPATIAL_FILES
+multi_layer_content_array = [
+    [
+        {
+            "path": os.path.join("geospatial", GEOSPATIAL_FILES_MULTILAYER[0]),
+            "name": "Layer 1",
+            "isBaseLayer": False,
+        },
+        {
+            "path": os.path.join("geospatial", GEOSPATIAL_FILES_MULTILAYER[1]),
+            "name": "Layer 2",
+            "isBaseLayer": False,
+        },
+    ]
+]
+json_metadata_array = [{"processingParameters": {"epsg": 3857}}]
+json_content_array = [
+    [
+        {
+            "name": "osm",
+            "tileLayerUrl": "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
+            "epsg": "EPSG3857",
+            "bounds": [
+                [11.17010498046875, 44.308941579503745],
+                [13.67478942871094, 46.542667432984864],
+            ],
+            "useClassicCoordinates": False,
+            "minZoom": 10,
+            "maxZoom": 18,
+            "isBaseLayer": True,
+        }
+    ]
+]
+
+if "GEOSPATIAL" in PROJECT_TYPES_TO_TEST:
+    geospatial_project_id = kili.create_project(
+        title=GEOSPATIAL_PROJECT_TITLE, input_type="GEOSPATIAL", json_interface=JSON_INTERFACE
+    )["id"]
+
+    kili.append_many_to_dataset(
+        project_id=geospatial_project_id,
+        content_array=content_array,
+        external_id_array=external_id_array,
+    )
+
+    kili.append_many_to_dataset(
+        project_id=geospatial_project_id,
+        multi_layer_content_array=multi_layer_content_array,
+        json_metadata_array=json_metadata_array,
+        json_content_array=json_content_array,
+    )
+
+if "IMAGE" in PROJECT_TYPES_TO_TEST:
+    image_project_id = kili.create_project(
+        title=IMAGE_PROJECT_TITLE, input_type="IMAGE", json_interface=JSON_INTERFACE
+    )["id"]
+
+    kili.append_many_to_dataset(
+        project_id=image_project_id,
+        content_array=content_array,
+        external_id_array=external_id_array,
+    )
+
+    kili.append_many_to_dataset(
+        project_id=image_project_id,
+        multi_layer_content_array=multi_layer_content_array,
+        json_metadata_array=json_metadata_array,
+        json_content_array=json_content_array,
+    )

--- a/tests/manual/geospatial_import_tests.py
+++ b/tests/manual/geospatial_import_tests.py
@@ -3,7 +3,7 @@ import urllib.request
 
 from kili.client import Kili
 
-LOCAL_KILI_API_KEY = "cm7nd7k63001gg90w28ot9vl7/881232fb4cce6e745f61612c5c5918d0"
+LOCAL_KILI_API_KEY = ""
 
 PROJECT_TYPES_TO_TEST = ["IMAGE", "GEOSPATIAL"]
 

--- a/tests/manual/geospatial_import_tests.py
+++ b/tests/manual/geospatial_import_tests.py
@@ -175,7 +175,7 @@ if "GEOSPATIAL" in PROJECT_TYPES_TO_TEST:
         project_id=geospatial_project_id,
         multi_layer_content_array=multi_layer_content_array,
         json_metadata_array=json_metadata_array,
-        json_content_array=json_content_array,
+        json_content_array=json_content_array,  # type: ignore
     )
 
 if "IMAGE" in PROJECT_TYPES_TO_TEST:
@@ -193,5 +193,5 @@ if "IMAGE" in PROJECT_TYPES_TO_TEST:
         project_id=image_project_id,
         multi_layer_content_array=multi_layer_content_array,
         json_metadata_array=json_metadata_array,
-        json_content_array=json_content_array,
+        json_content_array=json_content_array,  # type: ignore
     )


### PR DESCRIPTION
You can try to import geospatial assets using this [manual tests](https://github.com/kili-technology/kili-python-sdk/pull/1863/files#diff-85d208e5edf625ab844d2a18ff3265433b06932ed81ac0014f975b8f142c1647) (automatically download & import various geotiffs) or use this snippet :

```
from kili.client import Kili
from scripts.constants import LOCAL_KILI_API_KEY

kili = Kili(api_key=LOCAL_KILI_API_KEY, api_endpoint='http://localhost:4001/api/label/v2/graphql', verify=False)

projects = kili.projects()
for project in projects:
    if project['inputType'] == 'GEOSPATIAL':
        kili.delete_project(project['id'])

JSON_INTERFACE = {
    "jobs": {
        "JOB_0": {
            "mlTask": "CLASSIFICATION",
            "required": 1,
            "isChild": False,
            "content": {
                "categories": {"OBJECT_A": {"name": "Object A"}, "OBJECT_B": {"name": "Object B"}},
                "input": "radio",
            },
        }
    }
}

project_id = kili.create_project(
    title="Geospatial Project (created with SDK)",
    description="Project Description",
    input_type="GEOSPATIAL",
    json_interface=JSON_INTERFACE
)["id"]

url = './geospatial/airport.tif'

assets = kili.append_many_to_dataset(
    project_id=project_id,
    content_array=[url],
    external_id_array=["airport.tif"],
)
```