### PR TITLE
fix(LAB-3532): handle `external_ids` arg for `add_metadata` and `set_metadata`

### DIFF
--- a/src/kili/entrypoints/mutations/asset/__init__.py
+++ b/src/kili/entrypoints/mutations/asset/__init__.py
@@ -460,7 +460,7 @@ class MutationsAsset(BaseOperationEntrypointMixin):
 
         assets = self.kili_api_gateway.list_assets(
             AssetFilters(
-                project_id=ProjectId(project_id) if project_id else None,
+                project_id=ProjectId(project_id),
                 asset_id_in=cast(List[AssetId], resolved_asset_ids),
             ),
             ["id", "jsonMetadata"],
@@ -477,7 +477,7 @@ class MutationsAsset(BaseOperationEntrypointMixin):
             json_metadatas.append(current_metadata)
 
         return self.update_properties_in_assets(
-            asset_ids=resolved_asset_ids,
+            asset_ids=cast(List[str], resolved_asset_ids),
             json_metadatas=json_metadatas,
         )
 
@@ -533,7 +533,7 @@ class MutationsAsset(BaseOperationEntrypointMixin):
 
         assets = self.kili_api_gateway.list_assets(
             AssetFilters(
-                project_id=ProjectId(project_id) if project_id else None,
+                project_id=ProjectId(project_id),
                 asset_id_in=cast(List[AssetId], resolved_asset_ids),
             ),
             ["id", "jsonMetadata"],
@@ -555,7 +555,7 @@ class MutationsAsset(BaseOperationEntrypointMixin):
             json_metadatas.append(preserved_metadata)
 
         return self.update_properties_in_assets(
-            asset_ids=resolved_asset_ids,
+            asset_ids=cast(List[str], resolved_asset_ids),
             json_metadatas=json_metadatas,
         )
 

--- a/tests/integration/presentation/test_metadata.py
+++ b/tests/integration/presentation/test_metadata.py
@@ -261,7 +261,7 @@ def test_add_metadata_with_external_ids(mocker: pytest_mock.MockerFixture):
 
     project_id = "project1"
     external_ids = ["ext1", "ext2"]
-    new_metadata = [
+    new_metadata: List[Dict[str, Union[str, float, int]]] = [
         {"new_key1": "new_value1"},
         {"new_key2": "new_value2"},
     ]
@@ -273,7 +273,9 @@ def test_add_metadata_with_external_ids(mocker: pytest_mock.MockerFixture):
     resolve_mock.assert_called_once_with(None, external_ids, project_id)
 
     kili_api_gateway.list_assets.assert_called_once_with(
-        AssetFilters(project_id=ProjectId(project_id), asset_id_in=resolved_asset_ids),
+        AssetFilters(
+            project_id=ProjectId(project_id), asset_id_in=cast(List[AssetId], resolved_asset_ids)
+        ),
         ["id", "jsonMetadata"],
         QueryOptions(disable_tqdm=True),
     )
@@ -329,7 +331,7 @@ def test_set_metadata_with_external_ids(mocker: pytest_mock.MockerFixture):
 
     project_id = "project1"
     external_ids = ["ext1", "ext2"]
-    new_metadata = [
+    new_metadata: List[Dict[str, Union[str, float, int]]] = [
         {"new_key1": "new_value1"},
         {"new_key2": "new_value2"},
     ]
@@ -341,7 +343,9 @@ def test_set_metadata_with_external_ids(mocker: pytest_mock.MockerFixture):
     resolve_mock.assert_called_once_with(None, external_ids, project_id)
 
     kili_api_gateway.list_assets.assert_called_once_with(
-        AssetFilters(project_id=ProjectId(project_id), asset_id_in=resolved_asset_ids),
+        AssetFilters(
+            project_id=ProjectId(project_id), asset_id_in=cast(List[AssetId], resolved_asset_ids)
+        ),
         ["id", "jsonMetadata"],
         QueryOptions(disable_tqdm=True),
     )

--- a/tests/integration/presentation/test_metadata.py
+++ b/tests/integration/presentation/test_metadata.py
@@ -229,3 +229,131 @@ def test_multiple_assets_with_different_metadata_structures(mocker: pytest_mock.
 
     assert add_metadata_call_args["json_metadatas"] == expected_add_metadata
     assert set_metadata_call_args["json_metadatas"] == expected_set_metadata
+
+
+def test_add_metadata_with_external_ids(mocker: pytest_mock.MockerFixture):
+    """Test that add_metadata works correctly with external IDs."""
+    kili_api_gateway = mocker.Mock(spec=KiliAPIGateway)
+
+    resolve_mock = mocker.patch.object(MutationsAsset, "_resolve_asset_ids")
+    resolved_asset_ids = ["asset1", "asset2"]
+    resolve_mock.return_value = resolved_asset_ids
+
+    existing_assets = [
+        {
+            "id": "asset1",
+            "jsonMetadata": {"text": "Some text", "existing1": "value1"},
+        },
+        {
+            "id": "asset2",
+            "jsonMetadata": {"imageUrl": "http://example.com/image.jpg", "existing2": "value2"},
+        },
+    ]
+
+    kili_api_gateway.list_assets.return_value = existing_assets
+
+    update_mock = mocker.patch.object(MutationsAsset, "update_properties_in_assets")
+    update_mock.return_value = [{"id": "asset1"}, {"id": "asset2"}]
+
+    mutations_asset = MutationsAsset()
+    mutations_asset.kili_api_gateway = kili_api_gateway
+    mutations_asset.graphql_client = mocker.Mock()
+
+    project_id = "project1"
+    external_ids = ["ext1", "ext2"]
+    new_metadata = [
+        {"new_key1": "new_value1"},
+        {"new_key2": "new_value2"},
+    ]
+
+    result = mutations_asset.add_metadata(
+        json_metadata=new_metadata, external_ids=external_ids, project_id=project_id
+    )
+
+    resolve_mock.assert_called_once_with(None, external_ids, project_id)
+
+    kili_api_gateway.list_assets.assert_called_once_with(
+        AssetFilters(project_id=ProjectId(project_id), asset_id_in=resolved_asset_ids),
+        ["id", "jsonMetadata"],
+        QueryOptions(disable_tqdm=True),
+    )
+
+    update_mock.assert_called_once()
+    call_args = update_mock.call_args[1]
+    assert call_args["asset_ids"] == resolved_asset_ids
+
+    expected_metadata = [
+        {"text": "Some text", "existing1": "value1", "new_key1": "new_value1"},
+        {
+            "imageUrl": "http://example.com/image.jpg",
+            "existing2": "value2",
+            "new_key2": "new_value2",
+        },
+    ]
+
+    assert call_args["json_metadatas"] == expected_metadata
+    assert result == [{"id": "asset1"}, {"id": "asset2"}]
+
+
+def test_set_metadata_with_external_ids(mocker: pytest_mock.MockerFixture):
+    """Test that set_metadata works correctly with external IDs."""
+    kili_api_gateway = mocker.Mock(spec=KiliAPIGateway)
+
+    resolve_mock = mocker.patch.object(MutationsAsset, "_resolve_asset_ids")
+    resolved_asset_ids = ["asset1", "asset2"]
+    resolve_mock.return_value = resolved_asset_ids
+
+    existing_assets = [
+        {
+            "id": "asset1",
+            "jsonMetadata": {"text": "Some text", "existing1": "value1", "should_be_removed": True},
+        },
+        {
+            "id": "asset2",
+            "jsonMetadata": {
+                "imageUrl": "http://example.com/image.jpg",
+                "existing2": "value2",
+                "also_remove": "yes",
+            },
+        },
+    ]
+
+    kili_api_gateway.list_assets.return_value = existing_assets
+
+    update_mock = mocker.patch.object(MutationsAsset, "update_properties_in_assets")
+    update_mock.return_value = [{"id": "asset1"}, {"id": "asset2"}]
+
+    mutations_asset = MutationsAsset()
+    mutations_asset.kili_api_gateway = kili_api_gateway
+    mutations_asset.graphql_client = mocker.Mock()
+
+    project_id = "project1"
+    external_ids = ["ext1", "ext2"]
+    new_metadata = [
+        {"new_key1": "new_value1"},
+        {"new_key2": "new_value2"},
+    ]
+
+    result = mutations_asset.set_metadata(
+        json_metadata=new_metadata, external_ids=external_ids, project_id=project_id
+    )
+
+    resolve_mock.assert_called_once_with(None, external_ids, project_id)
+
+    kili_api_gateway.list_assets.assert_called_once_with(
+        AssetFilters(project_id=ProjectId(project_id), asset_id_in=resolved_asset_ids),
+        ["id", "jsonMetadata"],
+        QueryOptions(disable_tqdm=True),
+    )
+
+    update_mock.assert_called_once()
+    call_args = update_mock.call_args[1]
+    assert call_args["asset_ids"] == resolved_asset_ids
+
+    expected_metadata = [
+        {"text": "Some text", "new_key1": "new_value1"},
+        {"imageUrl": "http://example.com/image.jpg", "new_key2": "new_value2"},
+    ]
+
+    assert call_args["json_metadatas"] == expected_metadata
+    assert result == [{"id": "asset1"}, {"id": "asset2"}]


### PR DESCRIPTION
Previously, we could only add/set metadata using asset_id

This MR add ability to use external_ids

```
kili.add_metadata([{'foo': 'bar'}], external_ids=['hd_video.mp4'], project_id="cm9wi5b1b00e3x30w04mh6g5q")
```