### PR TITLE
fix(LAB-3807): remove retrieval of asset ids when creating issues

### DIFF
--- a/src/kili/adapters/kili_api_gateway/issue/types.py
+++ b/src/kili/adapters/kili_api_gateway/issue/types.py
@@ -10,5 +10,5 @@ class IssueToCreateKiliAPIGatewayInput:
 
     label_id: Optional[str]
     object_mid: Optional[str]
-    asset_id: str
+    asset_id: Optional[str]
     text: Optional[str]

--- a/src/kili/use_cases/issue/__init__.py
+++ b/src/kili/use_cases/issue/__init__.py
@@ -7,7 +7,6 @@ from kili.adapters.kili_api_gateway.issue.types import IssueToCreateKiliAPIGatew
 from kili.domain.issue import IssueFilters, IssueId, IssueStatus
 from kili.domain.project import ProjectId
 from kili.domain.types import ListOrTuple
-from kili.entrypoints.mutations.issue.helpers import get_labels_asset_ids_map
 from kili.use_cases.base import BaseUseCases
 from kili.use_cases.issue.types import IssueToCreateUseCaseInput
 
@@ -19,21 +18,20 @@ class IssueUseCases(BaseUseCases):
         self, project_id: ProjectId, issues: List[IssueToCreateUseCaseInput]
     ) -> List[IssueId]:
         """Create issues with issue type."""
-        label_id_array = [issue.label_id for issue in issues]
-        label_asset_ids_map = get_labels_asset_ids_map(
-            self._kili_api_gateway, project_id, label_id_array
-        )  # TODO: should be done in the backend
         gateway_issues = [
             IssueToCreateKiliAPIGatewayInput(
+                asset_id=None,
                 label_id=issue.label_id,
                 object_mid=issue.object_mid,
-                asset_id=label_asset_ids_map[issue.label_id],
                 text=issue.text,
             )
             for issue in issues
         ]
         return self._kili_api_gateway.create_issues(
-            type_="ISSUE", issues=gateway_issues, description="Creating issues"
+            project_id=project_id,
+            type_="ISSUE",
+            issues=gateway_issues,
+            description="Creating issues",
         )
 
     def count_issues(self, filters: IssueFilters) -> int:

--- a/src/kili/use_cases/question/question_use_case.py
+++ b/src/kili/use_cases/question/question_use_case.py
@@ -55,6 +55,9 @@ class QuestionUseCases(BaseUseCases):
         return [
             QuestionId(str(id_))
             for id_ in self._kili_api_gateway.create_issues(
-                type_="QUESTION", issues=gateway_issues, description="Creating questions"
+                project_id=project_id,
+                type_="QUESTION",
+                issues=gateway_issues,
+                description="Creating questions",
             )
         ]

--- a/tests/integration/use_cases/test_issue.py
+++ b/tests/integration/use_cases/test_issue.py
@@ -14,9 +14,6 @@ from kili.use_cases.issue.types import IssueToCreateUseCaseInput
 
 
 def test_create_one_issue(kili_api_gateway: KiliAPIGateway, mocker: pytest_mock.MockerFixture):
-    mocker.patch(
-        "kili.use_cases.issue.get_labels_asset_ids_map", return_value={"label_id": "asset_id"}
-    )
     kili_api_gateway.create_issues.return_value = [IssueId("created_issue_id")]
 
     # given one issue to create

--- a/tests/integration/use_cases/test_question.py
+++ b/tests/integration/use_cases/test_question.py
@@ -38,6 +38,7 @@ def test_given_text_and_asset_ids_when_calling_create_questions_it_creates_quest
     # Then
     assert len(question_ids) == 2
     kili_api_gateway.create_issues.assert_called_once_with(
+        project_id=project_id,
         type_="QUESTION",
         issues=[
             IssueToCreateKiliAPIGatewayInput(
@@ -94,6 +95,7 @@ def test_given_text_and_external_ids_when_calling_create_questions_it_creates_qu
     # Then
     assert len(question_ids) == 2
     kili_api_gateway.create_issues.assert_called_once_with(
+        project_id=project_id,
         type_="QUESTION",
         issues=[
             IssueToCreateKiliAPIGatewayInput(


### PR DESCRIPTION
It uses the replicas to get asset ids from labels, which is not working when we have replica lag.

