### PR TITLE
feat(LAB-4527): I can add/remove labelers and reviewers on a Workflow V3 group/step

### DIFF
--- a/src/kili/adapters/kili_api_gateway/project_workflow/common.py
+++ b/src/kili/adapters/kili_api_gateway/project_workflow/common.py
@@ -1,6 +1,7 @@
 """Project Workflow gateway common."""
 
 import warnings
+from typing import Optional
 
 
 def get_assignees_to_add_ids(existing_members: list[dict], assignees: list[str]) -> list:
@@ -23,3 +24,47 @@ def get_assignees_to_add_ids(existing_members: list[dict], assignees: list[str])
             + ", ".join(assignees_not_added)
         )
     return assignees_to_add
+
+
+def find_step_by_name(project: dict, step_name: str, group_name: Optional[str]) -> dict:
+    """Find a workflow step by name, optionally scoped to a step group.
+
+    When group_name is provided, the lookup is restricted to the named group and only supported
+    on workflow V3 projects. When group_name is None, the step name must be unique across all
+    groups, otherwise the caller is asked to provide a group_name.
+    """
+    steps = project.get("steps") or []
+
+    if group_name is not None:
+        if project.get("workflowVersion") != "V3":
+            raise ValueError("group_name is only supported on workflow V3 projects")
+        group = next(
+            (
+                step_group
+                for step_group in project.get("stepGroups") or []
+                if step_group.get("name") == group_name
+            ),
+            None,
+        )
+        if group is None:
+            raise ValueError(f"Group '{group_name}' not found in project workflow")
+        target_step = next(
+            (
+                step
+                for step in steps
+                if step.get("name") == step_name and step.get("stepGroupId") == group.get("id")
+            ),
+            None,
+        )
+        if target_step is None:
+            raise ValueError(f"Step '{step_name}' not found in group '{group_name}'")
+        return target_step
+
+    matching_steps = [step for step in steps if step.get("name") == step_name]
+    if not matching_steps:
+        raise ValueError(f"Step '{step_name}' not found in project workflow")
+    if len(matching_steps) > 1:
+        raise ValueError(
+            f"Multiple steps named '{step_name}' exist across groups; please provide group_name"
+        )
+    return matching_steps[0]

--- a/src/kili/adapters/kili_api_gateway/project_workflow/operations_mixin.py
+++ b/src/kili/adapters/kili_api_gateway/project_workflow/operations_mixin.py
@@ -1,6 +1,7 @@
 """Mixin extending Kili API Gateway class with Projects related operations."""
 
 import warnings
+from typing import Optional
 
 from kili.adapters.kili_api_gateway.base import BaseOperationMixin
 from kili.adapters.kili_api_gateway.helpers.queries import (
@@ -12,7 +13,7 @@ from kili.domain.project import ProjectId
 from kili.domain.types import ListOrTuple
 from kili.exceptions import NotFound
 
-from .common import get_assignees_to_add_ids
+from .common import find_step_by_name, get_assignees_to_add_ids
 from .mappers import (
     add_review_step_input_mapper,
     delete_step_input_mapper,
@@ -81,6 +82,41 @@ class ProjectWorkflowOperationMixin(BaseOperationMixin):
 
         return steps
 
+    def get_project_workflow_context(
+        self, project_id: str, include_assignee_emails: bool = False
+    ) -> dict:
+        """Get the workflow version, steps and step groups of a project in a single query."""
+        fields = [
+            "workflowVersion",
+            "steps.id",
+            "steps.name",
+            "steps.type",
+            "steps.stepGroupId",
+            "steps.assignees.id",
+            "stepGroups.id",
+            "stepGroups.name",
+        ]
+        if include_assignee_emails:
+            fields.append("steps.assignees.email")
+
+        fragment = fragment_builder(fields)
+        query = get_steps_query(fragment)
+        variables = {"where": {"id": project_id}, "first": 1, "skip": 0}
+        result = self.graphql_client.execute(query, variables)
+        project = result["data"]
+
+        if len(project) == 0:
+            raise NotFound(f"project ID: {project_id}. The project does not exist.")
+
+        steps = project[0].get("steps")
+
+        if len(steps) == 0:
+            raise NotFound(
+                f"project ID: {project_id}. The workflow v2 is not activated on this project."
+            )
+
+        return project[0]
+
     def count_activated_project_users(self, project_id: str) -> int:
         """Count project users with ACTIVATED status."""
         where = ProjectUserWhere(project_id=project_id, status="ACTIVATED", deleted=False)
@@ -98,9 +134,80 @@ class ProjectWorkflowOperationMixin(BaseOperationMixin):
         )
 
     def add_reviewers_to_step(
-        self, project_id: str, step_name: str, emails: list[str]
+        self, project_id: str, step_name: str, emails: list[str], group_name: Optional[str] = None
     ) -> list[str]:
         """Add reviewers to a specific step."""
+        assignees_to_add, assignees_added = self._resolve_assignees_to_add(
+            project_id,
+            emails,
+            exclude_labelers=True,
+            not_added_warning_prefix="These emails were not added (not found or can not review): ",
+        )
+        context = self.get_project_workflow_context(project_id)
+        target_step = find_step_by_name(context, step_name, group_name)
+        if target_step.get("type") == "DEFAULT":
+            raise ValueError("The step must be a review step, can't add reviewers to a label step")
+        self._apply_added_assignees(project_id, target_step, assignees_to_add)
+        return assignees_added
+
+    def remove_reviewers_from_step(
+        self, project_id: str, step_name: str, emails: list[str], group_name: Optional[str] = None
+    ) -> list[str]:
+        """Remove reviewers from a specific step."""
+        context = self.get_project_workflow_context(project_id, include_assignee_emails=True)
+        target_step = find_step_by_name(context, step_name, group_name)
+        if target_step.get("type") == "DEFAULT":
+            raise ValueError(
+                "The step must be a review step, can't remove reviewers from a label step"
+            )
+        return self._remove_assignees_from_step(project_id, target_step, emails)
+
+    def add_labelers_to_step(
+        self, project_id: str, step_name: str, emails: list[str], group_name: Optional[str] = None
+    ) -> list[str]:
+        """Add labelers to a specific labeling step of a workflow V3 project."""
+        context = self.get_project_workflow_context(project_id)
+        if context.get("workflowVersion") != "V3":
+            raise ValueError("Assigning labelers to a step requires a workflow V3 project")
+        target_step = find_step_by_name(context, step_name, group_name)
+        if target_step.get("type") != "DEFAULT":
+            raise ValueError(
+                "The step must be a labeling step, can't add labelers to a review step"
+            )
+        assignees_to_add, assignees_added = self._resolve_assignees_to_add(
+            project_id,
+            emails,
+            exclude_labelers=False,
+            not_added_warning_prefix="These emails were not added (not project members): ",
+        )
+        self._apply_added_assignees(project_id, target_step, assignees_to_add)
+        return assignees_added
+
+    def remove_labelers_from_step(
+        self, project_id: str, step_name: str, emails: list[str], group_name: Optional[str] = None
+    ) -> list[str]:
+        """Remove labelers from a specific labeling step of a workflow V3 project."""
+        context = self.get_project_workflow_context(project_id, include_assignee_emails=True)
+        if context.get("workflowVersion") != "V3":
+            raise ValueError("Assigning labelers to a step requires a workflow V3 project")
+        target_step = find_step_by_name(context, step_name, group_name)
+        if target_step.get("type") != "DEFAULT":
+            raise ValueError(
+                "The step must be a labeling step, can't remove labelers from a review step"
+            )
+        return self._remove_assignees_from_step(project_id, target_step, emails)
+
+    def _resolve_assignees_to_add(
+        self,
+        project_id: str,
+        emails: list[str],
+        exclude_labelers: bool,
+        not_added_warning_prefix: str,
+    ) -> tuple[list[str], list[str]]:
+        """Resolve emails to activated member ids to add, warning about emails that can't be added.
+
+        Returns a tuple (assignees_to_add_ids, assignees_added_emails).
+        """
         existing_members = ProjectUserQuery(self.graphql_client, self.http_client)(
             where=ProjectUserWhere(project_id=project_id, status="ACTIVATED", deleted=False),
             fields=["role", "user.email", "user.id", "activated"],
@@ -112,59 +219,32 @@ class ProjectWorkflowOperationMixin(BaseOperationMixin):
         assignees_not_added = []
         for email in emails:
             member = members_by_email.get(email)
-
-            if member and member.get("role") != "LABELER":
-                user_id = member["user"]["id"]
-                assignees_to_add.append(user_id)
+            if member and (not exclude_labelers or member.get("role") != "LABELER"):
+                assignees_to_add.append(member["user"]["id"])
                 assignees_added.append(email)
             else:
                 assignees_not_added.append(email)
         if assignees_not_added:
-            warnings.warn(
-                "These emails were not added (not found or can not review): "
-                + ", ".join(assignees_not_added)
-            )
-        steps = self.get_steps(
-            project_id, fields=["steps.id", "steps.name", "steps.type", "steps.assignees.id"]
-        )
-        target_step = next((s for s in steps if s.get("name") == step_name), None)
-        if not target_step:
-            raise ValueError(f"Step '{step_name}' not found in project workflow")
-        if target_step.get("type") == "DEFAULT":
-            raise ValueError("The step must be a review step, can't add reviewers to a label step")
+            warnings.warn(not_added_warning_prefix + ", ".join(assignees_not_added))
+        return assignees_to_add, assignees_added
+
+    def _apply_added_assignees(
+        self, project_id: str, target_step: dict, assignees_to_add: list[str]
+    ) -> None:
+        """Merge the new assignees with the step's current assignees and update the workflow."""
         current_ids = [a["id"] for a in target_step.get("assignees", [])]
-
         merged_ids = list(dict.fromkeys(current_ids + assignees_to_add))
-
         self.update_project_workflow(
             project_id=ProjectId(project_id),
             project_workflow_data=ProjectWorkflowDataKiliAPIGatewayInput(
                 None, None, [{"id": target_step["id"], "assignees": merged_ids}], None
             ),
         )
-        return assignees_added
 
-    def remove_reviewers_from_step(
-        self, project_id: str, step_name: str, emails: list[str]
+    def _remove_assignees_from_step(
+        self, project_id: str, target_step: dict, emails: list[str]
     ) -> list[str]:
-        """Remove reviewers from a specific step."""
-        steps = self.get_steps(
-            project_id,
-            fields=[
-                "steps.id",
-                "steps.name",
-                "steps.type",
-                "steps.assignees.id",
-                "steps.assignees.email",
-            ],
-        )
-        target_step = next((s for s in steps if s.get("name") == step_name), None)
-        if not target_step:
-            raise ValueError(f"Step '{step_name}' not found in project workflow")
-        if target_step.get("type") == "DEFAULT":
-            raise ValueError(
-                "The step must be a review step, can't remove reviewers from a label step"
-            )
+        """Remove the given emails from the step's assignees and update the workflow."""
         assignees = target_step.get("assignees", [])
         email_to_id = {a["email"]: a["id"] for a in assignees}
         removed_emails = []
@@ -182,6 +262,11 @@ class ProjectWorkflowOperationMixin(BaseOperationMixin):
             new_assignees_ids = [
                 a["id"] for a in assignees if a.get("id") and a["id"] not in ids_to_remove
             ]
+            if not new_assignees_ids:
+                raise ValueError(
+                    "Cannot remove all assignees from a step; a step must keep at least one"
+                    " assignee"
+                )
 
             self.update_project_workflow(
                 project_id=ProjectId(project_id),

--- a/src/kili/domain_api/projects.py
+++ b/src/kili/domain_api/projects.py
@@ -284,6 +284,7 @@ class WorkflowNamespace:
         project_id: str,
         step_name: str,
         emails: List[str],
+        group_name: Optional[str] = None,
     ) -> List[str]:
         """Add reviewers to a specific step.
 
@@ -291,12 +292,14 @@ class WorkflowNamespace:
             project_id: Id of the project.
             step_name: Name of the step.
             emails: List of emails to add.
+            group_name: Name of the workflow V3 group containing the step.
+                Required when several groups have a step with the same name.
 
         Returns:
             A list with emails added to the step.
         """
         return self._client.add_reviewers_to_step(
-            project_id=project_id, step_name=step_name, emails=emails
+            project_id=project_id, step_name=step_name, emails=emails, group_name=group_name
         )
 
     @typechecked
@@ -305,6 +308,7 @@ class WorkflowNamespace:
         project_id: str,
         step_name: str,
         emails: List[str],
+        group_name: Optional[str] = None,
     ) -> List[str]:
         """Remove reviewers from a specific step.
 
@@ -312,12 +316,69 @@ class WorkflowNamespace:
             project_id: Id of the project.
             step_name: Name of the step.
             emails: List of emails to remove.
+            group_name: Name of the workflow V3 group containing the step.
+                Required when several groups have a step with the same name.
 
         Returns:
             A list with emails removed from the step.
         """
         return self._client.remove_reviewers_from_step(
-            project_id=project_id, step_name=step_name, emails=emails
+            project_id=project_id, step_name=step_name, emails=emails, group_name=group_name
+        )
+
+    @typechecked
+    def add_labelers(
+        self,
+        project_id: str,
+        step_name: str,
+        emails: List[str],
+        group_name: Optional[str] = None,
+    ) -> List[str]:
+        """Add labelers to a specific labeling step.
+
+        Only workflow V3 projects support assigning labelers to a step, and the target step must
+        be a labeling step.
+
+        Args:
+            project_id: Id of the project.
+            step_name: Name of the labeling step.
+            emails: List of emails to add.
+            group_name: Name of the workflow V3 group containing the step.
+                Required when several groups have a step with the same name.
+
+        Returns:
+            A list with emails added to the step.
+        """
+        return self._client.add_labelers_to_step(
+            project_id=project_id, step_name=step_name, emails=emails, group_name=group_name
+        )
+
+    @typechecked
+    def remove_labelers(
+        self,
+        project_id: str,
+        step_name: str,
+        emails: List[str],
+        group_name: Optional[str] = None,
+    ) -> List[str]:
+        """Remove labelers from a specific labeling step.
+
+        Only workflow V3 projects support removing labelers from a step, and the target step must
+        be a labeling step. Removing a labeler also clears their asset-step assignments and step
+        queue for that step.
+
+        Args:
+            project_id: Id of the project.
+            step_name: Name of the labeling step.
+            emails: List of emails to remove.
+            group_name: Name of the workflow V3 group containing the step.
+                Required when several groups have a step with the same name.
+
+        Returns:
+            A list with emails removed from the step.
+        """
+        return self._client.remove_labelers_from_step(
+            project_id=project_id, step_name=step_name, emails=emails, group_name=group_name
         )
 
     @typechecked

--- a/src/kili/presentation/client/project_workflow.py
+++ b/src/kili/presentation/client/project_workflow.py
@@ -74,7 +74,11 @@ class ProjectWorkflowClientMethods(BaseClientMethods):
 
     @typechecked
     def add_reviewers_to_step(
-        self, project_id: str, step_name: str, emails: list[str]
+        self,
+        project_id: str,
+        step_name: str,
+        emails: list[str],
+        group_name: Optional[str] = None,
     ) -> list[str]:
         """Add reviewers to a specific step.
 
@@ -82,17 +86,23 @@ class ProjectWorkflowClientMethods(BaseClientMethods):
             project_id: Id of the project.
             step_name: Name of the step.
             emails: List of emails to add.
+            group_name: Name of the workflow V3 group containing the step.
+                Required when several groups have a step with the same name.
 
         Returns:
             A list with the added emails.
         """
         return ProjectWorkflowUseCases(self.kili_api_gateway).add_reviewers_to_step(
-            project_id=project_id, step_name=step_name, emails=emails
+            project_id=project_id, step_name=step_name, emails=emails, group_name=group_name
         )
 
     @typechecked
     def remove_reviewers_from_step(
-        self, project_id: str, step_name: str, emails: list[str]
+        self,
+        project_id: str,
+        step_name: str,
+        emails: list[str],
+        group_name: Optional[str] = None,
     ) -> list[str]:
         """Remove reviewers from a specific step.
 
@@ -100,12 +110,69 @@ class ProjectWorkflowClientMethods(BaseClientMethods):
             project_id: Id of the project.
             step_name: Name of the step.
             emails: List of emails to remove.
+            group_name: Name of the workflow V3 group containing the step.
+                Required when several groups have a step with the same name.
 
         Returns:
             A list with the removed emails.
         """
         return ProjectWorkflowUseCases(self.kili_api_gateway).remove_reviewers_from_step(
-            project_id=project_id, step_name=step_name, emails=emails
+            project_id=project_id, step_name=step_name, emails=emails, group_name=group_name
+        )
+
+    @typechecked
+    def add_labelers_to_step(
+        self,
+        project_id: str,
+        step_name: str,
+        emails: list[str],
+        group_name: Optional[str] = None,
+    ) -> list[str]:
+        """Add labelers to a specific labeling step.
+
+        Only workflow V3 projects support assigning labelers to a step, and the target step must
+        be a labeling step.
+
+        Args:
+            project_id: Id of the project.
+            step_name: Name of the labeling step.
+            emails: List of emails to add.
+            group_name: Name of the workflow V3 group containing the step.
+                Required when several groups have a step with the same name.
+
+        Returns:
+            A list with the added emails.
+        """
+        return ProjectWorkflowUseCases(self.kili_api_gateway).add_labelers_to_step(
+            project_id=project_id, step_name=step_name, emails=emails, group_name=group_name
+        )
+
+    @typechecked
+    def remove_labelers_from_step(
+        self,
+        project_id: str,
+        step_name: str,
+        emails: list[str],
+        group_name: Optional[str] = None,
+    ) -> list[str]:
+        """Remove labelers from a specific labeling step.
+
+        Only workflow V3 projects support removing labelers from a step, and the target step must
+        be a labeling step. Removing a labeler also clears their asset-step assignments and step
+        queue for that step.
+
+        Args:
+            project_id: Id of the project.
+            step_name: Name of the labeling step.
+            emails: List of emails to remove.
+            group_name: Name of the workflow V3 group containing the step.
+                Required when several groups have a step with the same name.
+
+        Returns:
+            A list with the removed emails.
+        """
+        return ProjectWorkflowUseCases(self.kili_api_gateway).remove_labelers_from_step(
+            project_id=project_id, step_name=step_name, emails=emails, group_name=group_name
         )
 
     @typechecked

--- a/src/kili/use_cases/project_workflow/__init__.py
+++ b/src/kili/use_cases/project_workflow/__init__.py
@@ -59,16 +59,36 @@ class ProjectWorkflowUseCases(BaseUseCases):
         return self._kili_api_gateway.get_steps(project_id, fields)
 
     def add_reviewers_to_step(
-        self, project_id: str, step_name: str, emails: list[str]
+        self, project_id: str, step_name: str, emails: list[str], group_name: Optional[str] = None
     ) -> list[str]:
         """Add reviewers to a specific step."""
-        return self._kili_api_gateway.add_reviewers_to_step(project_id, step_name, emails)
+        return self._kili_api_gateway.add_reviewers_to_step(
+            project_id, step_name, emails, group_name
+        )
 
     def remove_reviewers_from_step(
-        self, project_id: str, step_name: str, emails: list[str]
+        self, project_id: str, step_name: str, emails: list[str], group_name: Optional[str] = None
     ) -> list[str]:
         """Remove reviewers from a specific step."""
-        return self._kili_api_gateway.remove_reviewers_from_step(project_id, step_name, emails)
+        return self._kili_api_gateway.remove_reviewers_from_step(
+            project_id, step_name, emails, group_name
+        )
+
+    def add_labelers_to_step(
+        self, project_id: str, step_name: str, emails: list[str], group_name: Optional[str] = None
+    ) -> list[str]:
+        """Add labelers to a specific step."""
+        return self._kili_api_gateway.add_labelers_to_step(
+            project_id, step_name, emails, group_name
+        )
+
+    def remove_labelers_from_step(
+        self, project_id: str, step_name: str, emails: list[str], group_name: Optional[str] = None
+    ) -> list[str]:
+        """Remove labelers from a specific step."""
+        return self._kili_api_gateway.remove_labelers_from_step(
+            project_id, step_name, emails, group_name
+        )
 
     def copy_workflow_from_project(
         self,

--- a/tests/integration/presentation/test_project_workflow.py
+++ b/tests/integration/presentation/test_project_workflow.py
@@ -1,3 +1,4 @@
+import pytest
 import pytest_mock
 
 from kili.adapters.kili_api_gateway.kili_api_gateway import KiliAPIGateway
@@ -6,6 +7,39 @@ from kili.adapters.kili_api_gateway.project_workflow.operations import (
 )
 from kili.presentation.client.project_workflow import ProjectWorkflowClientMethods
 from kili.use_cases.project_workflow import ProjectWorkflowUseCases
+
+_UPDATE_FRAGMENT = " enforceStepSeparation steps{id}"
+
+
+def _client(mocker: pytest_mock.MockerFixture) -> ProjectWorkflowClientMethods:
+    kili = ProjectWorkflowClientMethods()
+    kili.kili_api_gateway = KiliAPIGateway(
+        graphql_client=mocker.MagicMock(), http_client=mocker.MagicMock()
+    )
+    return kili
+
+
+def _member(email: str, user_id: str, role: str) -> dict:
+    return {"role": role, "user": {"id": user_id, "email": email}, "activated": True}
+
+
+def _project_users_results(members: list[dict]) -> list[dict]:
+    return [{"data": len(members)}, {"data": members}]
+
+
+def _context_result(workflow_version: str, steps: list[dict], step_groups: list[dict]) -> dict:
+    return {
+        "data": [{"workflowVersion": workflow_version, "steps": steps, "stepGroups": step_groups}]
+    }
+
+
+_MUTATION_RESULT = {"data": {"id": "proj"}}
+
+
+def _last_update_variables(kili: ProjectWorkflowClientMethods) -> dict:
+    last_call = kili.kili_api_gateway.graphql_client.execute.call_args_list[-1]
+    assert last_call.args[0] == get_update_project_workflow_mutation(_UPDATE_FRAGMENT)
+    return last_call.args[1]["input"]
 
 
 def test_when_updating_project_workflow_then_it_returns_updated_project_workflow(
@@ -59,3 +93,335 @@ def test_when_getting_steps_then_it_returns_steps(
     # Then
 
     assert steps == [{"id": "step_id", "name": "step_name", "type": "step_type"}]
+
+
+def test_add_reviewers_to_step_on_v2_project(mocker: pytest_mock.MockerFixture):
+    kili = _client(mocker)
+    members = [
+        _member("rev@kili.com", "u-rev", "REVIEWER"),
+        _member("lab@kili.com", "u-lab", "LABELER"),
+    ]
+    steps = [
+        {
+            "id": "step-review",
+            "name": "Review",
+            "type": "REVIEW",
+            "stepGroupId": None,
+            "assignees": [{"id": "u-existing"}],
+        }
+    ]
+    kili.kili_api_gateway.graphql_client.execute.side_effect = [
+        *_project_users_results(members),
+        _context_result("V2", steps, []),
+        _MUTATION_RESULT,
+    ]
+
+    added = kili.add_reviewers_to_step("proj", "Review", ["rev@kili.com"])
+
+    assert added == ["rev@kili.com"]
+    variables = _last_update_variables(kili)
+    assert variables["projectId"] == "proj"
+    assert variables["steps"]["updates"] == [
+        {"id": "step-review", "assignees": ["u-existing", "u-rev"]}
+    ]
+
+
+def test_add_reviewers_to_step_skips_labeler_role_emails(mocker: pytest_mock.MockerFixture):
+    kili = _client(mocker)
+    members = [
+        _member("rev@kili.com", "u-rev", "REVIEWER"),
+        _member("lab@kili.com", "u-lab", "LABELER"),
+    ]
+    steps = [
+        {
+            "id": "step-review",
+            "name": "Review",
+            "type": "REVIEW",
+            "stepGroupId": None,
+            "assignees": [],
+        }
+    ]
+    kili.kili_api_gateway.graphql_client.execute.side_effect = [
+        *_project_users_results(members),
+        _context_result("V2", steps, []),
+        _MUTATION_RESULT,
+    ]
+
+    with pytest.warns(UserWarning, match="not found or can not review"):
+        added = kili.add_reviewers_to_step("proj", "Review", ["rev@kili.com", "lab@kili.com"])
+
+    assert added == ["rev@kili.com"]
+
+
+def test_add_reviewers_to_step_on_labeling_step_raises(mocker: pytest_mock.MockerFixture):
+    kili = _client(mocker)
+    members = [_member("rev@kili.com", "u-rev", "REVIEWER")]
+    steps = [
+        {
+            "id": "step-label",
+            "name": "Labeling",
+            "type": "DEFAULT",
+            "stepGroupId": None,
+            "assignees": [],
+        }
+    ]
+    kili.kili_api_gateway.graphql_client.execute.side_effect = [
+        *_project_users_results(members),
+        _context_result("V2", steps, []),
+    ]
+
+    with pytest.raises(ValueError, match="must be a review step"):
+        kili.add_reviewers_to_step("proj", "Labeling", ["rev@kili.com"])
+
+
+def test_remove_reviewers_from_step_on_v2_project(mocker: pytest_mock.MockerFixture):
+    kili = _client(mocker)
+    steps = [
+        {
+            "id": "step-review",
+            "name": "Review",
+            "type": "REVIEW",
+            "stepGroupId": None,
+            "assignees": [{"id": "u1", "email": "a@kili.com"}, {"id": "u2", "email": "b@kili.com"}],
+        }
+    ]
+    kili.kili_api_gateway.graphql_client.execute.side_effect = [
+        _context_result("V2", steps, []),
+        _MUTATION_RESULT,
+    ]
+
+    removed = kili.remove_reviewers_from_step("proj", "Review", ["a@kili.com"])
+
+    assert removed == ["a@kili.com"]
+    variables = _last_update_variables(kili)
+    assert variables["steps"]["updates"] == [{"id": "step-review", "assignees": ["u2"]}]
+
+
+def test_remove_reviewers_leaving_zero_assignees_raises(mocker: pytest_mock.MockerFixture):
+    kili = _client(mocker)
+    steps = [
+        {
+            "id": "step-review",
+            "name": "Review",
+            "type": "REVIEW",
+            "stepGroupId": None,
+            "assignees": [{"id": "u1", "email": "a@kili.com"}],
+        }
+    ]
+    kili.kili_api_gateway.graphql_client.execute.side_effect = [_context_result("V2", steps, [])]
+
+    with pytest.raises(ValueError, match="at least one"):
+        kili.remove_reviewers_from_step("proj", "Review", ["a@kili.com"])
+
+
+def test_add_reviewers_to_step_v3_uses_group_name_to_pick_step(mocker: pytest_mock.MockerFixture):
+    kili = _client(mocker)
+    members = [_member("rev@kili.com", "u-rev", "REVIEWER")]
+    steps = [
+        {
+            "id": "step-g1-review",
+            "name": "Review",
+            "type": "REVIEW",
+            "stepGroupId": "grp-1",
+            "assignees": [],
+        },
+        {
+            "id": "step-g2-review",
+            "name": "Review",
+            "type": "REVIEW",
+            "stepGroupId": "grp-2",
+            "assignees": [],
+        },
+    ]
+    step_groups = [{"id": "grp-1", "name": "Group 1"}, {"id": "grp-2", "name": "Group 2"}]
+    kili.kili_api_gateway.graphql_client.execute.side_effect = [
+        *_project_users_results(members),
+        _context_result("V3", steps, step_groups),
+        _MUTATION_RESULT,
+    ]
+
+    added = kili.add_reviewers_to_step("proj", "Review", ["rev@kili.com"], group_name="Group 2")
+
+    assert added == ["rev@kili.com"]
+    variables = _last_update_variables(kili)
+    assert variables["steps"]["updates"] == [{"id": "step-g2-review", "assignees": ["u-rev"]}]
+
+
+def test_add_reviewers_to_step_v3_ambiguous_step_name_raises(mocker: pytest_mock.MockerFixture):
+    kili = _client(mocker)
+    members = [_member("rev@kili.com", "u-rev", "REVIEWER")]
+    steps = [
+        {
+            "id": "step-g1-review",
+            "name": "Review",
+            "type": "REVIEW",
+            "stepGroupId": "grp-1",
+            "assignees": [],
+        },
+        {
+            "id": "step-g2-review",
+            "name": "Review",
+            "type": "REVIEW",
+            "stepGroupId": "grp-2",
+            "assignees": [],
+        },
+    ]
+    step_groups = [{"id": "grp-1", "name": "Group 1"}, {"id": "grp-2", "name": "Group 2"}]
+    kili.kili_api_gateway.graphql_client.execute.side_effect = [
+        *_project_users_results(members),
+        _context_result("V3", steps, step_groups),
+    ]
+
+    with pytest.raises(ValueError, match="Multiple steps named 'Review'"):
+        kili.add_reviewers_to_step("proj", "Review", ["rev@kili.com"])
+
+
+def test_add_reviewers_to_step_group_name_not_found_raises(mocker: pytest_mock.MockerFixture):
+    kili = _client(mocker)
+    members = [_member("rev@kili.com", "u-rev", "REVIEWER")]
+    steps = [
+        {
+            "id": "step-g1-review",
+            "name": "Review",
+            "type": "REVIEW",
+            "stepGroupId": "grp-1",
+            "assignees": [],
+        }
+    ]
+    step_groups = [{"id": "grp-1", "name": "Group 1"}]
+    kili.kili_api_gateway.graphql_client.execute.side_effect = [
+        *_project_users_results(members),
+        _context_result("V3", steps, step_groups),
+    ]
+
+    with pytest.raises(ValueError, match="Group 'Missing' not found"):
+        kili.add_reviewers_to_step("proj", "Review", ["rev@kili.com"], group_name="Missing")
+
+
+def test_add_reviewers_to_step_group_name_on_v2_raises(mocker: pytest_mock.MockerFixture):
+    kili = _client(mocker)
+    members = [_member("rev@kili.com", "u-rev", "REVIEWER")]
+    steps = [
+        {
+            "id": "step-review",
+            "name": "Review",
+            "type": "REVIEW",
+            "stepGroupId": None,
+            "assignees": [],
+        }
+    ]
+    kili.kili_api_gateway.graphql_client.execute.side_effect = [
+        *_project_users_results(members),
+        _context_result("V2", steps, []),
+    ]
+
+    with pytest.raises(ValueError, match="group_name is only supported on workflow V3"):
+        kili.add_reviewers_to_step("proj", "Review", ["rev@kili.com"], group_name="Group 1")
+
+
+def test_add_labelers_to_step_v3_default_step(mocker: pytest_mock.MockerFixture):
+    kili = _client(mocker)
+    members = [_member("lab@kili.com", "u-lab", "LABELER")]
+    steps = [
+        {
+            "id": "step-label",
+            "name": "Labeling",
+            "type": "DEFAULT",
+            "stepGroupId": "grp-1",
+            "assignees": [{"id": "u-existing"}],
+        }
+    ]
+    step_groups = [{"id": "grp-1", "name": "Group 1"}]
+    kili.kili_api_gateway.graphql_client.execute.side_effect = [
+        _context_result("V3", steps, step_groups),
+        *_project_users_results(members),
+        _MUTATION_RESULT,
+    ]
+
+    added = kili.add_labelers_to_step("proj", "Labeling", ["lab@kili.com"], group_name="Group 1")
+
+    assert added == ["lab@kili.com"]
+    variables = _last_update_variables(kili)
+    assert variables["steps"]["updates"] == [
+        {"id": "step-label", "assignees": ["u-existing", "u-lab"]}
+    ]
+
+
+def test_add_labelers_to_step_on_review_step_raises(mocker: pytest_mock.MockerFixture):
+    kili = _client(mocker)
+    steps = [
+        {
+            "id": "step-review",
+            "name": "Review",
+            "type": "REVIEW",
+            "stepGroupId": "grp-1",
+            "assignees": [],
+        }
+    ]
+    step_groups = [{"id": "grp-1", "name": "Group 1"}]
+    kili.kili_api_gateway.graphql_client.execute.side_effect = [
+        _context_result("V3", steps, step_groups),
+    ]
+
+    with pytest.raises(ValueError, match="must be a labeling step"):
+        kili.add_labelers_to_step("proj", "Review", ["lab@kili.com"], group_name="Group 1")
+
+
+def test_add_labelers_to_step_on_v2_project_raises(mocker: pytest_mock.MockerFixture):
+    kili = _client(mocker)
+    steps = [
+        {
+            "id": "step-label",
+            "name": "Labeling",
+            "type": "DEFAULT",
+            "stepGroupId": None,
+            "assignees": [],
+        }
+    ]
+    kili.kili_api_gateway.graphql_client.execute.side_effect = [_context_result("V2", steps, [])]
+
+    with pytest.raises(ValueError, match="requires a workflow V3 project"):
+        kili.add_labelers_to_step("proj", "Labeling", ["lab@kili.com"])
+
+
+def test_remove_labelers_from_step_v3_default_step(mocker: pytest_mock.MockerFixture):
+    kili = _client(mocker)
+    steps = [
+        {
+            "id": "step-label",
+            "name": "Labeling",
+            "type": "DEFAULT",
+            "stepGroupId": "grp-1",
+            "assignees": [{"id": "u1", "email": "a@kili.com"}, {"id": "u2", "email": "b@kili.com"}],
+        }
+    ]
+    step_groups = [{"id": "grp-1", "name": "Group 1"}]
+    kili.kili_api_gateway.graphql_client.execute.side_effect = [
+        _context_result("V3", steps, step_groups),
+        _MUTATION_RESULT,
+    ]
+
+    removed = kili.remove_labelers_from_step(
+        "proj", "Labeling", ["a@kili.com"], group_name="Group 1"
+    )
+
+    assert removed == ["a@kili.com"]
+    variables = _last_update_variables(kili)
+    assert variables["steps"]["updates"] == [{"id": "step-label", "assignees": ["u2"]}]
+
+
+def test_remove_labelers_from_step_on_v2_project_raises(mocker: pytest_mock.MockerFixture):
+    kili = _client(mocker)
+    steps = [
+        {
+            "id": "step-label",
+            "name": "Labeling",
+            "type": "DEFAULT",
+            "stepGroupId": None,
+            "assignees": [{"id": "u1", "email": "a@kili.com"}],
+        }
+    ]
+    kili.kili_api_gateway.graphql_client.execute.side_effect = [_context_result("V2", steps, [])]
+
+    with pytest.raises(ValueError, match="requires a workflow V3 project"):
+        kili.remove_labelers_from_step("proj", "Labeling", ["a@kili.com"])

--- a/tests/unit/adapters/kili_api_gateway/project_workflow/test_common.py
+++ b/tests/unit/adapters/kili_api_gateway/project_workflow/test_common.py
@@ -1,0 +1,72 @@
+"""Tests for the project workflow gateway common helpers."""
+
+import pytest
+
+from kili.adapters.kili_api_gateway.project_workflow.common import find_step_by_name
+
+
+def _v3_project() -> dict:
+    return {
+        "workflowVersion": "V3",
+        "steps": [
+            {"id": "s-g1-label", "name": "Labeling", "type": "DEFAULT", "stepGroupId": "grp-1"},
+            {"id": "s-g1-review", "name": "Review", "type": "REVIEW", "stepGroupId": "grp-1"},
+            {"id": "s-g2-label", "name": "Labeling", "type": "DEFAULT", "stepGroupId": "grp-2"},
+            {"id": "s-g2-review", "name": "Review", "type": "REVIEW", "stepGroupId": "grp-2"},
+        ],
+        "stepGroups": [
+            {"id": "grp-1", "name": "Group 1"},
+            {"id": "grp-2", "name": "Group 2"},
+        ],
+    }
+
+
+def _v2_project() -> dict:
+    return {
+        "workflowVersion": "V2",
+        "steps": [
+            {"id": "s-label", "name": "Labeling", "type": "DEFAULT", "stepGroupId": None},
+            {"id": "s-review", "name": "Review", "type": "REVIEW", "stepGroupId": None},
+        ],
+        "stepGroups": [],
+    }
+
+
+def test_find_step_by_name_without_group_returns_unique_match():
+    step = find_step_by_name(_v2_project(), "Review", None)
+
+    assert step["id"] == "s-review"
+
+
+def test_find_step_by_name_without_group_missing_step_raises():
+    with pytest.raises(ValueError, match="Step 'Missing' not found in project workflow"):
+        find_step_by_name(_v2_project(), "Missing", None)
+
+
+def test_find_step_by_name_without_group_ambiguous_raises():
+    with pytest.raises(ValueError, match="Multiple steps named 'Review'"):
+        find_step_by_name(_v3_project(), "Review", None)
+
+
+def test_find_step_by_name_with_group_scopes_to_group():
+    step = find_step_by_name(_v3_project(), "Review", "Group 2")
+
+    assert step["id"] == "s-g2-review"
+
+
+def test_find_step_by_name_with_group_on_v2_raises():
+    with pytest.raises(ValueError, match="group_name is only supported on workflow V3 projects"):
+        find_step_by_name(_v2_project(), "Review", "Group 1")
+
+
+def test_find_step_by_name_with_unknown_group_raises():
+    with pytest.raises(ValueError, match="Group 'Missing' not found in project workflow"):
+        find_step_by_name(_v3_project(), "Review", "Missing")
+
+
+def test_find_step_by_name_with_step_not_in_group_raises():
+    project = _v3_project()
+    project["stepGroups"].append({"id": "grp-3", "name": "Group 3"})
+
+    with pytest.raises(ValueError, match="Step 'Review' not found in group 'Group 3'"):
+        find_step_by_name(project, "Review", "Group 3")


### PR DESCRIPTION
Linear ticket: [LAB-4527](https://linear.app/kili-technology/issue/LAB-4527/sdk-i-can-addremove-labelers-and-reviewers-on-a-workflow-v3-groupstep) · Plan: [Linear document](https://linear.app/kili-technology/document/lab-4527-sdk-i-can-addremove-labelers-and-reviewers-on-a-workflow-v3-a3773809ed61)

**Purpose**: Let SDK users add/remove labelers and reviewers on a Workflow V3 group/step by extending the existing `add_reviewers_to_step`/`remove_reviewers_from_step` methods with `group_name` targeting and adding their labeler counterparts.

**Context**: In Workflow V3 (multi-group), steps live inside step groups, step names are only unique per group, and labelers are explicitly assigned to each group's labeling (DEFAULT) step — something V2 never had. Today only the UI can do this. No backend change is needed: the `editProjectWorkflowSettings` mutation (which the SDK already calls under the hood) fully supports V3 — it updates any step's `assignees` by step ID and lifts the "no assignees on DEFAULT steps" restriction for V3 projects. All work is in the Python SDK, across its four layers (presentation client → use cases → API gateway → domain-API namespace).

**Approach**:
- [x] Gateway helper `get_project_workflow_context` fetching `workflowVersion`, `steps` (with `stepGroupId`), and `stepGroups` in one `projects` query, plus shared `find_step_by_name` resolution handling `group_name`
- [x] `add_reviewers_to_step` / `remove_reviewers_from_step` extended with optional trailing `group_name` through all four layers (positional call sites stay compatible)
- [x] New `add_labelers_to_step` / `remove_labelers_from_step` (V3-only, DEFAULT-step targeting, same layering and `group_name` support)
- [x] Domain layer `WorkflowNamespace` (`kili.projects.workflow`): `group_name` on `add_reviewers`/`remove_reviewers`, new `add_labelers`/`remove_labelers`
- [x] 14 new integration tests (mocked GraphQL client through the real gateway) + 7 unit tests for `find_step_by_name`: V2 back-compat, V3 `group_name` targeting, ambiguity/not-found/V2-misuse errors, labeler-on-REVIEW-step error, zero-assignee-removal pre-check
- [x] No changes in the kili monorepo

**Risks & open questions**:
- Ambiguous `step_name` across V3 groups without `group_name` raises a ValueError asking for `group_name` (never silently picks one).
- Removing a step's last assignee is pre-checked SDK-side with a clear ValueError (backend would reject with an opaque error).
- Labeler removal has real workflow side effects backend-side (clears the user's asset-step assignments and step queues) — flagged in the docstring.
- The backend path for V3 DEFAULT-step assignee updates is exercised daily by the UI but has no dedicated backend test; a manual end-to-end check against a V3 staging project is recommended before release (not performed in this PR — no staging credentials).

**Verification**: pylint 10.00/10 · pyright 0 errors on changed files (1 pre-existing error in untouched `src/kili/utils/labels/image.py`) · pre-commit hooks all pass · targeted pytest: 43 passed (project_workflow unit + integration + use cases) and domain_api suite 83 passed. Full suite/coverage gate left to CI.
