### PR TITLE
feat(LAB-4555): probe the backend before using the new async import m…

### DIFF
--- a/src/kili/core/graphql/operations/asset/mutations.py
+++ b/src/kili/core/graphql/operations/asset/mutations.py
@@ -14,16 +14,16 @@ mutation appendManyAssets(
 }
 """
 
-GQL_APPEND_MANY_FRAMES_TO_DATASET = """
-mutation(
-    $data: AppendManyFramesToDatasetAsynchronouslyData!,
+GQL_APPEND_MANY_ASSETS_ASYNCHRONOUSLY = """
+mutation appendManyAssetsAsynchronously(
+    $data: AppendManyAssetsAsynchronouslyData!,
     $where: ProjectWhere!
   ) {
-  data: appendManyFramesToDatasetAsynchronously(
+  data: appendManyAssetsAsynchronously(
     data: $data,
     where: $where
   ) {
-    id
+      id
   }
 }
 """

--- a/src/kili/services/asset_import/base.py
+++ b/src/kili/services/asset_import/base.py
@@ -27,7 +27,7 @@ from tenacity.wait import wait_exponential
 from kili.adapters.kili_api_gateway.helpers.queries import QueryOptions
 from kili.core.graphql.operations.asset.mutations import (
     GQL_APPEND_MANY_ASSETS,
-    GQL_APPEND_MANY_FRAMES_TO_DATASET,
+    GQL_APPEND_MANY_ASSETS_ASYNCHRONOUSLY,
 )
 from kili.core.helpers import T, format_result, get_mime_type, is_url
 from kili.core.utils.pagination import batcher
@@ -243,8 +243,10 @@ class BaseBatchImporter:  # pylint: disable=too-many-instance-attributes
 
     def _async_import_to_kili(self, assets: list[KiliResolverAsset]):
         """Import assets with asynchronous resolver."""
-        if self.input_type in ["IMAGE", "GEOSPATIAL"]:
+        if self.input_type == "GEOSPATIAL":
             upload_type = "GEO_SATELLITE"
+        elif self.input_type == "IMAGE":
+            upload_type = "TILED_IMAGE"
         elif self.input_type in ("VIDEO", "VIDEO_LEGACY"):
             upload_type = "NATIVE_VIDEO" if self.are_native_videos(assets) else "FRAME_VIDEO"
         else:
@@ -270,7 +272,7 @@ class BaseBatchImporter:  # pylint: disable=too-many-instance-attributes
             },
             "where": {"id": self.project_id},
         }
-        result = self.kili.graphql_client.execute(GQL_APPEND_MANY_FRAMES_TO_DATASET, payload)
+        result = self.kili.graphql_client.execute(GQL_APPEND_MANY_ASSETS_ASYNCHRONOUSLY, payload)
         return format_result("data", result, None, self.kili.http_client)
 
     def _sync_import_to_kili(self, assets: list[KiliResolverAsset]):

--- a/tests/unit/services/asset_import/base.py
+++ b/tests/unit/services/asset_import/base.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, call
 from kili.adapters.http_client import HttpClient
 from kili.core.graphql.operations.asset.mutations import (
     GQL_APPEND_MANY_ASSETS,
-    GQL_APPEND_MANY_FRAMES_TO_DATASET,
+    GQL_APPEND_MANY_ASSETS_ASYNCHRONOUSLY,
 )
 from kili.domain.project import ProjectId
 from kili.services.asset_import import import_assets
@@ -62,10 +62,15 @@ class ImportTestCase(TestCase):
         )
 
     def get_expected_async_call(
-        self, content_array, external_id_array, id_array, json_metadata_array, upload_type
+        self,
+        content_array,
+        external_id_array,
+        id_array,
+        json_metadata_array,
+        upload_type,
     ):
         return (
-            GQL_APPEND_MANY_FRAMES_TO_DATASET,
+            GQL_APPEND_MANY_ASSETS_ASYNCHRONOUSLY,
             {
                 "data": {
                     "contentArray": content_array,
@@ -88,7 +93,7 @@ class ImportTestCase(TestCase):
         upload_type,
     ):
         return (
-            GQL_APPEND_MANY_FRAMES_TO_DATASET,
+            GQL_APPEND_MANY_ASSETS_ASYNCHRONOUSLY,
             {
                 "data": {
                     "multiLayerContentArray": multi_layer_content_array,

--- a/tests/unit/services/asset_import/test_import_image.py
+++ b/tests/unit/services/asset_import/test_import_image.py
@@ -55,7 +55,7 @@ class ImageTestCase(ImportTestCase):
             ["local jp2 image"],
             ["unique_id"],
             ["{}"],
-            "GEO_SATELLITE",
+            "TILED_IMAGE",
         )
         self.kili.graphql_client.execute.assert_called_with(*expected_parameters)
 
@@ -70,7 +70,7 @@ class ImageTestCase(ImportTestCase):
             ["local ntf image"],
             ["unique_id"],
             ["{}"],
-            "GEO_SATELLITE",
+            "TILED_IMAGE",
         )
         self.kili.graphql_client.execute.assert_called_with(*expected_parameters)
 
@@ -85,7 +85,7 @@ class ImageTestCase(ImportTestCase):
             ["local tiff image"],
             ["unique_id"],
             ["{}"],
-            "GEO_SATELLITE",
+            "TILED_IMAGE",
         )
         self.kili.graphql_client.execute.assert_called_with(*expected_parameters)
 
@@ -117,7 +117,7 @@ class ImageTestCase(ImportTestCase):
             ["local tiff image"],
             ["unique_id"],
             ["{}"],
-            "GEO_SATELLITE",
+            "TILED_IMAGE",
         )
         self.kili.graphql_client.execute.assert_called_with(*expected_parameters)
 
@@ -145,7 +145,7 @@ class ImageTestCase(ImportTestCase):
             ["local tiff image"],
             ["unique_id"],
             ["{}"],
-            "GEO_SATELLITE",
+            "TILED_IMAGE",
         )
         calls = [call(*expected_parameters_sync), call(*expected_parameters_async)]
         self.kili.graphql_client.execute.assert_has_calls(calls, any_order=True)
@@ -173,3 +173,28 @@ class ImageTestCase(ImportTestCase):
         assets = [{"content": path_image, "external_id": "local image"}]
         with pytest.raises(UploadFromLocalDataForbiddenError):
             import_assets(self.kili, self.project_id, assets)
+
+
+@patch("kili.utils.bucket.request_signed_urls", mocked_request_signed_urls)
+@patch("kili.utils.bucket.upload_data_via_rest", mocked_upload_data_via_rest)
+@patch("kili.utils.bucket.generate_unique_id", mocked_unique_id)
+class AsyncUploadTypeTestCase(ImportTestCase):
+    """Tests which uploadType the async import sends.
+
+    `GEOSPATIAL` keeps `GEO_SATELLITE`; every other async import is a tiled image.
+    """
+
+    def test_upload_to_geospatial_project_still_uses_geo_satellite(self, *_):
+        self.kili.kili_api_gateway.get_project.return_value = {"inputType": "GEOSPATIAL"}
+        url = "https://storage.googleapis.com/label-public-staging/geotiffs/bogota.tif"
+        path_image = self.downloader(url)
+        assets = [{"content": path_image, "external_id": "local tiff image"}]
+        import_assets(self.kili, self.project_id, assets)
+        expected_parameters = self.get_expected_async_call(
+            ["https://signed_url?id=id"],
+            ["local tiff image"],
+            ["unique_id"],
+            ["{}"],
+            "GEO_SATELLITE",
+        )
+        self.kili.graphql_client.execute.assert_called_with(*expected_parameters)


### PR DESCRIPTION
…utation

`appendManyFramesToDatasetAsynchronously` is named after video frames but is the single entry point for video, geospatial imagery and large tiled images, and every non-video async import was tagged `GEO_SATELLITE` even when nothing about the asset was geospatial.

The SDK now sends `appendManyAssetsAsynchronously` and, for IMAGE projects, `uploadType: TILED_IMAGE`. Because the SDK is a published package pointed at backends of unknown age — and `GraphQLClient` validates queries client-side against the introspected schema, so an unknown field or enum value is a hard failure — each of the two is guarded by its own schema probe. All four combinations of mutation name x enum value are valid, so no deploy ordering is imposed on kili or import.

GEOSPATIAL projects keep sending `GEO_SATELLITE`, and the legacy mutation is kept byte-for-byte as the fallback.

