### PR TITLE
feat(LAB-4614): return a clear error when isUsedForConsensus is refused

### DIFF
--- a/docs/sdk/tutorials/set_up_workflows.md
+++ b/docs/sdk/tutorials/set_up_workflows.md
@@ -90,6 +90,21 @@ kili.update_properties_in_project(
 
 You can manually select specific project assets to be used for computing consensus KPIs.
 
+The method to use depends on the workflow version of your project. On multi-review
+projects, use `update_asset_consensus`, one call per asset:
+
+
+```python
+for external_id in ["1.jpg", "2.jpg", "3.jpg"]:
+    kili.update_asset_consensus(
+        project_id=project_id,
+        external_id=external_id,
+        is_consensus=True,
+    )
+```
+
+On projects still using workflow version 1, `update_asset_consensus` is not available.
+Use `update_properties_in_assets` with `is_used_for_consensus_array` instead:
 
 ```python
 kili.update_properties_in_assets(
@@ -99,14 +114,8 @@ kili.update_properties_in_assets(
 )
 ```
 
-
-
-
-    [{'id': 'clnwvhvo00000gsvzinsato00'},
-     {'id': 'clnwvhvo00001gsvzsiqcx5dc'},
-     {'id': 'clnwvhvo00002gsvzzbjtyuif'}]
-
-
+Using `is_used_for_consensus_array` on a multi-review project raises
+`DeprecatedArgumentError`.
 
 For more information on consensus, refer to our [documentation](https://docs.kili-technology.com/docs/consensus-overview).
 

--- a/recipes/set_up_workflows.ipynb
+++ b/recipes/set_up_workflows.ipynb
@@ -269,33 +269,44 @@
    "source": [
     "### Setting consensus for specific assets to compute consensus KPIs\n",
     "\n",
-    "You can manually select specific project assets to be used for computing consensus KPIs."
+    "You can manually select specific project assets to be used for computing consensus KPIs.\n",
+    "\n",
+    "The method to use depends on the workflow version of your project. On multi-review\n",
+    "projects, use `update_asset_consensus`, one call per asset:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[{'id': 'clnwvhvo00000gsvzinsato00'},\n",
-       " {'id': 'clnwvhvo00001gsvzsiqcx5dc'},\n",
-       " {'id': 'clnwvhvo00002gsvzzbjtyuif'}]"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
+    "for external_id in [\"1.jpg\", \"2.jpg\", \"3.jpg\"]:\n",
+    "    kili.update_asset_consensus(\n",
+    "        project_id=project_id,\n",
+    "        external_id=external_id,\n",
+    "        is_consensus=True,\n",
+    "    )"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "On projects still using workflow version 1, `update_asset_consensus` is not available.\n",
+    "Use `update_properties_in_assets` with `is_used_for_consensus_array` instead:\n",
+    "\n",
+    "```python\n",
     "kili.update_properties_in_assets(\n",
     "    project_id=project_id,\n",
     "    external_ids=[\"1.jpg\", \"2.jpg\", \"3.jpg\"],\n",
     "    is_used_for_consensus_array=[True] * 3,\n",
-    ")"
+    ")\n",
+    "```\n",
+    "\n",
+    "Using `is_used_for_consensus_array` on a multi-review project raises\n",
+    "`DeprecatedArgumentError`."
    ]
   },
   {

--- a/src/kili/domain_api/assets.py
+++ b/src/kili/domain_api/assets.py
@@ -2369,6 +2369,9 @@ class AssetsNamespace(DomainNamespace):  # pylint: disable=too-many-public-metho
     ) -> bool:
         """Activate or deactivate consensus on an asset.
 
+        This method is not compatible with projects using workflow version 1. On those projects,
+        use `kili.update_properties_in_assets()` with `is_used_for_consensus_array` instead.
+
         Args:
             project_id: The project ID.
             is_consensus: Whether to activate (True) or deactivate (False) consensus on the asset.

--- a/src/kili/entrypoints/mutations/asset/__init__.py
+++ b/src/kili/entrypoints/mutations/asset/__init__.py
@@ -27,11 +27,35 @@ from kili.entrypoints.mutations.asset.queries import (
     GQL_UPDATE_PROPERTIES_IN_ASSETS,
 )
 from kili.entrypoints.mutations.exceptions import MutationError
-from kili.exceptions import MissingArgumentError
+from kili.exceptions import DeprecatedArgumentError, GraphQLError, MissingArgumentError
 from kili.services.asset_import import import_assets
 from kili.services.asset_import_csv import get_text_assets_from_csv
 from kili.utils.assets import PageResolution
 from kili.utils.logcontext import for_all_methods, log_call
+
+# The backend rejects `isUsedForConsensus` on multi-review projects (workflow version 2 and
+# above). Its error message is the only place carrying this key: `extensions.code` is the generic
+# `OPERATION_RESOLUTION_FAILURE` shared by nearly every domain error, so the bracketed token is
+# the only usable discriminator.
+IS_USED_FOR_CONSENSUS_DEPRECATED_KEY = "[isUsedForConsensusDeprecated]"
+IS_USED_FOR_CONSENSUS_DEPRECATED_MESSAGE = (
+    "`isUsedForConsensus` is deprecated in `update_properties_in_assets`."
+    " Use `update_asset_consensus` instead to manage consensus for this asset."
+)
+
+
+def _has_error_key(error: GraphQLError, key: str) -> bool:
+    """Tell whether any GraphQL error raised by the backend carries the given key.
+
+    Every element is scanned because `GraphQLError` only ever renders the first one, and the
+    backend may report several errors for a single batch.
+    """
+    errors = error.error if isinstance(error.error, list) else [error.error]
+    for item in errors:
+        message = item.get("message", "") if isinstance(item, dict) else str(item)
+        if key in message:
+            return True
+    return False
 
 
 @for_all_methods(log_call, exclude=["__init__"])
@@ -317,6 +341,8 @@ class MutationsAsset(BaseOperationEntrypointMixin):
                     to each frame of the video.
             status_array: DEPRECATED and does not have any effect.
             is_used_for_consensus_array: Whether to use the asset to compute consensus kpis or not.
+                Not supported on multi-review projects, where it raises
+                `DeprecatedArgumentError`. Use `kili.update_asset_consensus()` for those projects.
             is_honeypot_array: Whether to use the asset for honeypot.
             project_id: The project ID. Only required if `external_ids` argument is provided.
             resolution_array: The resolution of each asset (for image and video assets).
@@ -329,6 +355,13 @@ class MutationsAsset(BaseOperationEntrypointMixin):
 
         Returns:
             A list of dictionaries with the asset ids.
+
+        Raises:
+            DeprecatedArgumentError: If `is_used_for_consensus_array` is used on a multi-review
+                project. Use `kili.update_asset_consensus()` for those projects.
+            MissingArgumentError: If both `asset_ids` and `external_ids` are provided, or if
+                neither of them is.
+            GraphQLError: If the backend refuses the update for any other reason.
 
         Examples:
             >>> kili.update_properties_in_assets(
@@ -417,12 +450,17 @@ class MutationsAsset(BaseOperationEntrypointMixin):
                 "dataArray": data_array,
             }
 
-        results = mutate_from_paginated_call(
-            self,
-            properties_to_batch,
-            generate_variables,
-            GQL_UPDATE_PROPERTIES_IN_ASSETS,
-        )
+        try:
+            results = mutate_from_paginated_call(
+                self,
+                properties_to_batch,
+                generate_variables,
+                GQL_UPDATE_PROPERTIES_IN_ASSETS,
+            )
+        except GraphQLError as err:
+            if _has_error_key(err, IS_USED_FOR_CONSENSUS_DEPRECATED_KEY):
+                raise DeprecatedArgumentError(IS_USED_FOR_CONSENSUS_DEPRECATED_MESSAGE) from err
+            raise
         formated_results = [self.format_result("data", result, None) for result in results]
         return [item for batch_list in formated_results for item in batch_list]
 

--- a/src/kili/exceptions.py
+++ b/src/kili/exceptions.py
@@ -65,3 +65,7 @@ class MissingArgumentError(ValueError):
 
 class IncompatibleArgumentsError(ValueError):
     """Raised when the user gave at least two incompatible arguments."""
+
+
+class DeprecatedArgumentError(ValueError):
+    """Raised when the user gave an argument that is no longer supported."""

--- a/src/kili/presentation/client/asset.py
+++ b/src/kili/presentation/client/asset.py
@@ -1,5 +1,6 @@
 """Client presentation methods for assets."""
 
+# pylint: disable=too-many-lines
 import warnings
 from collections.abc import Generator, Iterable
 from typing import (
@@ -948,6 +949,9 @@ class AssetClientMethods(BaseClientMethods):
         external_id: Optional[str] = None,
     ) -> bool:
         """Activate or deactivate consensus on an asset.
+
+        This method is not compatible with projects using workflow version 1. On those projects,
+        use `kili.update_properties_in_assets()` with `is_used_for_consensus_array` instead.
 
         Args:
             project_id: The project ID.

--- a/tests/integration/entrypoints/client/mutations/test_assets.py
+++ b/tests/integration/entrypoints/client/mutations/test_assets.py
@@ -4,6 +4,7 @@ import pytest
 import pytest_mock
 
 from kili.entrypoints.mutations.asset import MutationsAsset, PageResolution
+from kili.exceptions import DeprecatedArgumentError, GraphQLError
 
 
 @pytest.mark.parametrize(
@@ -79,3 +80,83 @@ def test_given_asset_resolution_when_updating_resolution_then_it_works(
         "whereArray": [{"id": "asset_id_1"}],
         "dataArray": [{"resolution": {"width": 100, "height": 200}}],
     }
+
+
+def _backend_error(message: str) -> GraphQLError:
+    """Build the error the graphql client raises when the backend refuses the mutation."""
+    return GraphQLError(
+        error=[
+            {
+                "message": message,
+                "extensions": {
+                    "code": "OPERATION_RESOLUTION_FAILURE",
+                    "context": {"projectID": "project_id"},
+                },
+            }
+        ]
+    )
+
+
+def test_given_multi_review_project_when_i_use_is_used_for_consensus_then_i_get_a_clear_error(
+    mocker: pytest_mock.MockerFixture,
+):
+    # Given
+    kili = MutationsAsset()
+    kili.graphql_client = mocker.MagicMock()
+    kili.http_client = mocker.MagicMock()
+    kili.kili_api_gateway = mocker.MagicMock()
+    kili.graphql_client.execute.side_effect = _backend_error(
+        "[isUsedForConsensusDeprecated] `isUsedForConsensus` is deprecated in"
+        " `update_properties_in_assets`. Use `update_asset_consensus` instead to manage consensus"
+        " for this asset."
+    )
+
+    # When
+    with pytest.raises(DeprecatedArgumentError) as exc_info:
+        kili.update_properties_in_assets(
+            asset_ids=["asset_id_1"], is_used_for_consensus_array=[True]
+        )
+
+    # Then
+    assert str(exc_info.value) == (
+        "`isUsedForConsensus` is deprecated in `update_properties_in_assets`."
+        " Use `update_asset_consensus` instead to manage consensus for this asset."
+    )
+    assert isinstance(exc_info.value.__cause__, GraphQLError)
+    assert "[isUsedForConsensusDeprecated]" in str(exc_info.value.__cause__)
+
+
+def test_given_workflow_v1_project_when_i_use_is_used_for_consensus_then_the_field_is_sent(
+    mocker: pytest_mock.MockerFixture,
+):
+    # Given
+    kili = MutationsAsset()
+    kili.graphql_client = mocker.MagicMock()
+    kili.http_client = mocker.MagicMock()
+    kili.kili_api_gateway = mocker.MagicMock()
+
+    # When
+    kili.update_properties_in_assets(
+        asset_ids=["asset_id_1", "asset_id_2"], is_used_for_consensus_array=[True, False]
+    )
+
+    # Then
+    assert kili.graphql_client.execute.call_args[0][1] == {
+        "whereArray": [{"id": "asset_id_1"}, {"id": "asset_id_2"}],
+        "dataArray": [{"isUsedForConsensus": True}, {"isUsedForConsensus": False}],
+    }
+
+
+def test_given_an_unrelated_backend_error_when_i_update_properties_then_it_is_not_converted(
+    mocker: pytest_mock.MockerFixture,
+):
+    # Given
+    kili = MutationsAsset()
+    kili.graphql_client = mocker.MagicMock()
+    kili.http_client = mocker.MagicMock()
+    kili.kili_api_gateway = mocker.MagicMock()
+    kili.graphql_client.execute.side_effect = _backend_error("[somethingElse] Another failure")
+
+    # When / Then
+    with pytest.raises(GraphQLError):
+        kili.update_properties_in_assets(asset_ids=["asset_id_1"], priorities=[1])


### PR DESCRIPTION
**Purpose**: Translate the backend's new deprecation error into a typed SDK exception, so the user sees an actionable message instead of a `TransportQueryError` wrapping a JS stack trace.

**Paired MR**: `kili` [!14392](https://gitlab.com/kili-technology/kili/-/merge_requests/14392). Ships in either order — against a pre-deploy backend the token is simply absent and the user sees today's error. Graceful degradation.

**Plan document**: https://linear.app/kili-technology/document/lab-4614-aau-i-get-the-right-error-message-when-using-kiliupdate-ce9688058bc8

---

### Approach: pass through, do NOT reject client-side

Five reasons, all verified rather than assumed:

1. `project_id` is **optional** on `update_properties_in_assets` — a client-side check would need up to two extra round trips on every call using the argument.
2. `asset_ids` can span **multiple projects**, which may mix workflow v1 and v2. A single client-side verdict cannot express that; the backend evaluates per project.
3. A client-side check races migration — workflow version is backend state and can flip between check and mutation.
4. **Pass-through fails fast**: the tenacity predicate is `retry_all(...)` whose final conjunct matches none of this message, so there is **no retry** and `stop_after_delay(3*60)` never engages. One round trip, immediate raise.
5. **Zero regression for workflow v1** — the call goes through byte-identical to today.

### ⚠️ The most important thing in this diff is what it does NOT change

`src/kili/entrypoints/mutations/asset/helpers.py` is **untouched** — verified explicitly: `git diff origin/main -- helpers.py` is **empty**. `"isUsedForConsensus": is_used_for_consensus_array` is still at line 51 and still forwarded.

An earlier draft of this change stripped that parameter and its mapping. **That would have silently disabled consensus for every workflow-v1 user, with no error at all** — the field is still valid and still honoured on v1. The regression guard is a test asserting `isUsedForConsensus` **is present** in the `dataArray` sent on the v1 happy path.

### Acceptance criterion — verified end to end, not inferred

Ran the real path with the literal backend string. The user sees exactly:

> `isUsedForConsensus` is deprecated in `update_properties_in_assets`. Use `update_asset_consensus` instead to manage consensus for this asset.

Byte-identical to the AC. `__cause__` renders `GraphQL error at index 0: [isUsedForConsensusDeprecated] …` — the **"at index 0"** proves the test exercises the real `mutate_from_paginated_call` re-wrap rather than a synthetic error. The exception is a `ValueError` subclass, so existing `except ValueError` handlers keep working.

### Contract compliance

Matches on the literal substring `[isUsedForConsensusDeprecated]`, scanning **every element** of the errors array — necessary because `GraphQLError.__init__` only ever reads `error[0]`. `extensions.code` is ignored entirely (it is the generic `OPERATION_RESOLUTION_FAILURE`). The prose after the token is **not** matched, so backend copy edits cannot break the SDK. Both `true` and `false` are covered.

**Scoping note:** the guard fires on `workflowVersion >= 2` — **v2 and v3** (v3 is "multi-step labeling", also multi-review). The acceptance message reads as an unconditional deprecation but is not one: the parameter still works on v1, and `update_asset_consensus` explicitly rejects v1. **Release notes should say "on multi-review projects (workflow v2+)".**

### Documentation fixes

The backend confirmed **new projects default to workflow v2** on every path the repo controls. So a reader following the **published** `set_up_workflows` tutorial today creates a v2 project and hits this exact error. The executable cell is **swapped** to `update_asset_consensus` rather than merely annotated, while stating that the correct setter depends on the project's workflow version — an on-prem instance with `FLAG_MULTI_STEP_REVIEW=false` still gets v1. The `.md` is regenerated by the repo hook, not hand-edited.

`update_asset_consensus` and `kili.assets.update_consensus` now document their **workflow-v1 incompatibility**, which neither mentioned before — a second documentation gap this ticket exposed.

### Post-review fixes (agent self-review)

- **[REQUIRED]** pylint 10.00 → 9.93: adding a `Raises:` section activated `missing-raises-doc` → documented `MissingArgumentError` and `GraphQLError` too.
- **[REQUIRED]** `presentation/client/asset.py` went 999 → 1002 lines, tripping `too-many-lines`. **Confirmed a regression rather than pre-existing** by running pylint against the pristine `origin/main` copy (10.00/10) → fixed with the established `# pylint: disable=too-many-lines` convention, already used by 6 modules including sibling `client/label.py`.
- **[REQUIRED]** The `Raises:` line for `MissingArgumentError` was **factually wrong** — written as "if both are provided", but it is also raised when *neither* is → corrected.
- **[REQUIRED]** The `_has_error_key` generator expression sat **exactly on the 100-char boundary** where the local ruff 0.15.14 and the repo-pinned 0.1.15 could disagree — CI would break whichever way it was written → rewritten as an explicit loop so no formatter has a choice.
- **[SUGGESTION, considered and REJECTED]** Gating the conversion on `is_used_for_consensus_array is not None` as well as the token — rejected because the backend only emits the token when the field is in the payload, so it guards an unreachable state.

**Test honesty:** tests 2 and 3 pass against pre-change code by design — they are regression guards, not new-behaviour tests. **Test 1 is the only one that fails without the fix**, and it does fail without it.

### Verification

Baseline captured from a pristine tree **before the first edit**: 748 passed / pyright 0 / pylint 10.00. After: **751 passed — exactly +3, no regressions**. pylint 10.00 restored, pyright 0, ruff set-comparison shows zero new findings. Full pre-commit suite passed at commit time including the repo-pinned ruff 0.1.15.

### ⚠️ Not run

- **`tests/e2e/`** — needs a live Kili instance and API key. CI runs unit+integration only, which is exactly what was run. No e2e test references `is_used_for_consensus_array`, but that is not proof.
- Repo-wide `ruff check` reports 4119 findings on the implementing host — purely the 0.15.14 vs pinned 0.1.15 version gap, **present on pristine `origin/main` too**.

🤖 Planned and implemented by Claude Code.