### PR TITLE
test(LAB-4547): pin the setAssetConsensus contract and document its r…

### DIFF
--- a/src/kili/domain_api/assets.py
+++ b/src/kili/domain_api/assets.py
@@ -2380,6 +2380,13 @@ class AssetsNamespace(DomainNamespace):  # pylint: disable=too-many-public-metho
 
         Raises:
             ValueError: If neither asset_id nor external_id is provided.
+            GraphQLError: If a server-side precondition is not met. The server accepts the
+                call only on workflow V2/V3 projects, while the asset sits on a labeling
+                (DEFAULT) step whose status is still TO_DO, when consensus is enabled on that
+                step, and when the caller is an admin or a team manager. Note that the TO_DO
+                window closes as soon as any labeler starts working on the asset (their first
+                autosave, not their submission), so the real precondition is that no labeler
+                has opened and started the asset yet.
 
         Examples:
             >>> # Activate consensus on an asset using asset_id

--- a/src/kili/entrypoints/mutations/asset/__init__.py
+++ b/src/kili/entrypoints/mutations/asset/__init__.py
@@ -317,6 +317,8 @@ class MutationsAsset(BaseOperationEntrypointMixin):
                     to each frame of the video.
             status_array: DEPRECATED and does not have any effect.
             is_used_for_consensus_array: Whether to use the asset to compute consensus kpis or not.
+                Only supported on legacy workflow V1 projects; on workflow V2/V3 projects use
+                `kili.assets.update_consensus()` instead.
             is_honeypot_array: Whether to use the asset for honeypot.
             project_id: The project ID. Only required if `external_ids` argument is provided.
             resolution_array: The resolution of each asset (for image and video assets).

--- a/src/kili/presentation/client/asset.py
+++ b/src/kili/presentation/client/asset.py
@@ -1,5 +1,6 @@
 """Client presentation methods for assets."""
 
+# pylint: disable=too-many-lines
 import warnings
 from collections.abc import Generator, Iterable
 from typing import (
@@ -960,6 +961,13 @@ class AssetClientMethods(BaseClientMethods):
 
         Raises:
             ValueError: If neither asset_id nor external_id is provided.
+            GraphQLError: If a server-side precondition is not met. The server accepts the
+                call only on workflow V2/V3 projects, while the asset sits on a labeling
+                (DEFAULT) step whose status is still TO_DO, when consensus is enabled on that
+                step, and when the caller is an admin or a team manager. Note that the TO_DO
+                window closes as soon as any labeler starts working on the asset (their first
+                autosave, not their submission), so the real precondition is that no labeler
+                has opened and started the asset yet.
 
         Examples:
             >>> # Activate consensus on an asset using asset_id

--- a/tests/integration/adapters/kili_api_gateway/test_asset.py
+++ b/tests/integration/adapters/kili_api_gateway/test_asset.py
@@ -1,9 +1,12 @@
 from copy import deepcopy
 
+import pytest
+
 from kili.adapters.kili_api_gateway.asset.operations_mixin import AssetOperationMixin
 from kili.adapters.kili_api_gateway.helpers.queries import QueryOptions
 from kili.domain.asset import AssetFilters
 from kili.domain.project import ProjectId
+from kili.exceptions import GraphQLError
 
 
 def test_given_video_project_only_latest_label_json_response_requested_annotations_not_fetched_for_labels(
@@ -134,3 +137,82 @@ def test_given_a_query_returning_serialized_json_it_parses_json_fields(graphql_c
         "labels": [{"jsonResponse": {}}],
         "latestLabel": {"jsonResponse": {}},
     }
+
+
+def _asset_operations(graphql_client, http_client) -> AssetOperationMixin:
+    asset_operations = AssetOperationMixin()
+    asset_operations.graphql_client = graphql_client
+    asset_operations.http_client = http_client
+    return asset_operations
+
+
+def test_update_asset_consensus_sends_the_set_asset_consensus_mutation_with_an_asset_id(
+    graphql_client, http_client
+):
+    """Pins the backend contract of update_asset_consensus: mutation name, alias and payload."""
+    captured = {}
+
+    def mock_graphql_execute(query, variables=None, **_kwargs) -> dict:
+        captured["query"] = query
+        captured["variables"] = variables
+        return {"data": True}
+
+    graphql_client.execute.side_effect = mock_graphql_execute
+
+    result = _asset_operations(graphql_client, http_client).update_asset_consensus(
+        project_id="project_id", is_consensus=True, asset_id="asset_id"
+    )
+
+    assert result is True
+    assert "mutation setAssetConsensus" in captured["query"]
+    assert "data: setAssetConsensus" in captured["query"]
+    assert captured["variables"] == {
+        "projectId": "project_id",
+        "isConsensus": True,
+        "assetId": "asset_id",
+    }
+
+
+def test_update_asset_consensus_sends_the_external_id_only_when_given(graphql_client, http_client):
+    captured = {}
+
+    def mock_graphql_execute(query, variables=None, **_kwargs) -> dict:
+        captured["variables"] = variables
+        return {"data": False}
+
+    graphql_client.execute.side_effect = mock_graphql_execute
+
+    result = _asset_operations(graphql_client, http_client).update_asset_consensus(
+        project_id="project_id", is_consensus=False, external_id="external_id"
+    )
+
+    assert result is False
+    assert captured["variables"] == {
+        "projectId": "project_id",
+        "isConsensus": False,
+        "externalId": "external_id",
+    }
+
+
+def test_update_asset_consensus_requires_an_asset_id_or_an_external_id(graphql_client, http_client):
+    with pytest.raises(ValueError, match="asset_id or external_id"):
+        _asset_operations(graphql_client, http_client).update_asset_consensus(
+            project_id="project_id", is_consensus=True
+        )
+
+    graphql_client.execute.assert_not_called()
+
+
+def test_update_asset_consensus_propagates_a_graphql_error_without_retrying(
+    graphql_client, http_client
+):
+    graphql_client.execute.side_effect = GraphQLError(
+        error="Cannot set consensus on the current step if its status is not TO DO"
+    )
+
+    with pytest.raises(GraphQLError):
+        _asset_operations(graphql_client, http_client).update_asset_consensus(
+            project_id="project_id", is_consensus=True, asset_id="asset_id"
+        )
+
+    assert graphql_client.execute.call_count == 1


### PR DESCRIPTION
## Why

`update_asset_consensus` (and the legacy `set_consensus`) fail with a `GraphQLError` whenever the server refuses the call, and the conditions under which it refuses were nowhere in the docs. The most surprising one is a timing rule users cannot guess: the call only works while nobody has started the asset yet.

LAB-4547 makes that window close earlier in practice, so it is worth writing down now, together with tests pinning what the SDK actually sends.

## What

Documentation and tests only. No new or changed API — `update_asset_consensus` is unchanged since LAB-4021.

- **Docstrings** now list the server-side preconditions: workflow V2/V3 projects only, the asset on a labeling (DEFAULT) step whose status is still `TO_DO`, consensus enabled on that step, and the caller an admin or a team manager. They also spell out the timing: the `TO_DO` window closes as soon as a labeler *starts* the asset — their first autosave, not their submission — so in practice the call only succeeds before anyone has opened it. The legacy `set_consensus` docstring points at `update_asset_consensus` for workflow V2/V3.
- **Contract tests** pin the mutation the SDK sends: its name, alias and payload when the asset is addressed by id, that the external id is sent only when given, that one of the two is required, and that a `GraphQLError` from the server propagates without being retried.

## Important context

Independent of the backend stack: it documents behavior the server already has and asserts a contract the backend does not change. Shipping alongside kili !14415.

## Validation

`tests/integration/adapters/kili_api_gateway/test_asset.py` — 6 passed (4 of them new here).
